### PR TITLE
Remove real type as template parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,6 +485,15 @@ if (PLSSVM_ENABLE_ASSERTS)
     target_compile_definitions(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC PLSSVM_ENABLE_ASSERTS)
 endif ()
 
+## use float as real_type if requested
+option(PLSSVM_USE_FLOAT_AS_REAL_TYPE "Use float as real_type instead of double." OFF)
+if (PLSSVM_USE_FLOAT_AS_REAL_TYPE)
+    message(STATUS "Using float as real_type.")
+    target_compile_definitions(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC PLSSVM_FLOAT_AS_REAL_TYPE)
+else ()
+    message(STATUS "Using double as real_type (default).")
+endif ()
+
 ## set specific thread block sizes if requested
 if (DEFINED ENV{PLSSVM_THREAD_BLOCK_SIZE})
     set(PLSSVM_THREAD_BLOCK_SIZE $ENV{PLSSVM_THREAD_BLOCK_SIZE} CACHE STRING "The used thread block size." FORCE)

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ If `PLSSVM_ENABLE_LANGUAGE_BINDINGS` is set to `ON`, the following option can al
 
 If `PLSSVM_ENABLE_PYTHON_BINDINGS` is set to `ON`, the following options can also be set:
 
-- `PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE` (default: `double`): the default `real_type` used if the generic `plssvm.Model` and `plssvm.DataSet` Python classes are used
 - `PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE` (default: `std::string`): the default `label_type` used if the generic `plssvm.Model` and `plssvm.DataSet` Python classes are used
 
 If the SYCL backend is available additional options can be set.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The `[optional_options]` can be one or multiple of:
 **Attention:** at least one backend must be enabled and available!
 
 - `PLSSVM_ENABLE_ASSERTS=ON|OFF` (default: `OFF`): enables custom assertions regardless whether the `DEBUG` macro is defined or not
+- `PLSSVM_USE_FLOAT_AS_REAL_TYPE=ON|OFF` (default: `OFF`): use `float` as real_type instead of `double`
 - `PLSSVM_THREAD_BLOCK_SIZE` (default: `16`): set a specific thread block size used in the GPU kernels (for fine-tuning optimizations)
 - `PLSSVM_INTERNAL_BLOCK_SIZE` (default: `6`: set a specific internal block size used in the GPU kernels (for fine-tuning optimizations)
 - `PLSSVM_OPENMP_BLOCK_SIZE` (default: `64`): set a specific block size used in the OpenMP kernels
@@ -348,7 +349,6 @@ Usage:
       --performance_tracking arg
                                 the output YAML file where the performance tracking results are written to; if not provided, the results are dumped to stderr
       --use_strings_as_labels   use strings as labels instead of plane numbers
-      --use_float_as_real_type  use floats as real types instead of doubles
       --verbosity               choose the level of verbosity: full|timing|libsvm|quiet (default: full)
   -q, --quiet                   quiet mode (no outputs regardless the provided verbosity level!)
   -h, --help                    print this helper message
@@ -415,7 +415,6 @@ Usage:
       --performance_tracking arg
                                 the output YAML file where the performance tracking results are written to; if not provided, the results are dumped to stderr
       --use_strings_as_labels   use strings as labels instead of plane numbers
-      --use_float_as_real_type  use floats as real types instead of doubles
       --verbosity               choose the level of verbosity: full|timing|libsvm|quiet (default: full)
   -q, --quiet                   quiet mode (no outputs regardless the provided verbosity level!)
   -h, --help                    print this helper message
@@ -454,7 +453,6 @@ Usage:
       --performance_tracking arg
                                 the output YAML file where the performance tracking results are written to; if not provided, the results are dumped to stderr
       --use_strings_as_labels   use strings as labels instead of plane numbers
-      --use_float_as_real_type  use floats as real types instead of doubles
       --verbosity               choose the level of verbosity: full|timing|libsvm|quiet (default: full)
   -q, --quiet                   quiet mode (no outputs regardless the provided verbosity level!)
   -h, --help                    print this helper message
@@ -491,14 +489,13 @@ A simple C++ program (`main.cpp`) using this library could look like:
 
 int main() {
     try {
-      
         // create a new C-SVM parameter set, explicitly overriding the default kernel function
         const plssvm::parameter params{ plssvm::kernel_type = plssvm::kernel_function_type::polynomial };
 
         // create two data sets: one with the training data scaled to [-1, 1] 
         // and one with the test data scaled like the training data
-        const plssvm::data_set<double> train_data{ "train_file.libsvm", { -1.0, 1.0 } };
-        const plssvm::data_set<double> test_data{ "test_file.libsvm", train_data.scaling_factors()->get() };
+        const plssvm::data_set train_data{ "train_file.libsvm", { -1.0, 1.0 } };
+        const plssvm::data_set test_data{ "test_file.libsvm", train_data.scaling_factors()->get() };
 
         // create C-SVM using the default backend and the previously defined parameter
         const auto svm = plssvm::make_csvm(params);
@@ -518,7 +515,6 @@ int main() {
 
         // write model file to disk
         model.save("model_file.libsvm");
-        
     } catch (const plssvm::exception &e) {
         std::cerr << e.what_with_loc() << std::endl;
     } catch (const std::exception &e) {

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -80,15 +80,6 @@ endif ()
 set(PLSSVM_PYTHON_BINDINGS_LIBRARY_NAME plssvm)
 pybind11_add_module(${PLSSVM_PYTHON_BINDINGS_LIBRARY_NAME} ${PLSSVM_PYTHON_BINDINGS_SOURCES})
 
-# set default real type
-set(PLSSVM_PYTHON_BINDINGS_POSSIBLE_REAL_TYPE "float;double")
-set(PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE "double" CACHE STRING "The preferred type of the data points for the Python bindings.")
-set_property(CACHE PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE PROPERTY STRINGS ${PLSSVM_PYTHON_BINDINGS_POSSIBLE_REAL_TYPE})
-if (NOT "${PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE}" IN_LIST PLSSVM_PYTHON_BINDINGS_POSSIBLE_REAL_TYPE)
-    message(FATAL_ERROR "The provided real_type \"${PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE}\" is not one of the allowed values: \"${PLSSVM_PYTHON_BINDINGS_POSSIBLE_REAL_TYPE}\"")
-endif ()
-message(STATUS "The preferred real_type for the Python bindings is \"${PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE}\".")
-
 # set default label type
 set(PLSSVM_PYTHON_BINDINGS_POSSIBLE_LABEL_TYPE "bool;char;signed char;unsigned char;short;unsigned short;int;unsigned int;long;unsigned long;long long;unsigned long long;float;double;long double;std::string")
 set(PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE "std::string" CACHE STRING "The preferred type of the labels for the Python bindings.")
@@ -99,7 +90,6 @@ endif ()
 message(STATUS "The preferred label_type for the Python bindings is \"${PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE}\".")
 
 # add necessary compile definitions for the default real_type and label_type
-target_compile_definitions(${PLSSVM_PYTHON_BINDINGS_LIBRARY_NAME} PRIVATE PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE=${PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE})
 target_compile_definitions(${PLSSVM_PYTHON_BINDINGS_LIBRARY_NAME} PRIVATE PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE=${PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE})
 if (PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE STREQUAL "std::string")
     target_compile_definitions(${PLSSVM_PYTHON_BINDINGS_LIBRARY_NAME} PRIVATE PLSSVM_PYTHON_BINDINGS_LABEL_TYPE_IS_STRING)

--- a/bindings/Python/data_set.cpp
+++ b/bindings/Python/data_set.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "plssvm/data_set.hpp"
-#include "plssvm/detail/type_list.hpp"  // plssvm::detail::real_type_label_type_combination_list
+
+#include "plssvm/constants.hpp"         // plssvm::real_type
+#include "plssvm/detail/type_list.hpp"  // plssvm::detail::label_type_list
 
 #include "utility.hpp"                  // check_kwargs_for_correctness, assemble_unique_class_name,
                                         // pyarray_to_vector, pyarray_to_string_vector, pylist_to_string_vector, pyarray_to_matrix
@@ -29,10 +31,8 @@ namespace py = pybind11;
 
 template <typename data_set_type>
 typename data_set_type::scaling create_scaling_object(const py::kwargs &args) {
-    using real_type = typename data_set_type::real_type;
-
     if (args.contains("scaling")) {
-        typename data_set_type::scaling scaling{ real_type{ -1.0 }, real_type{ 1.0 } };
+        typename data_set_type::scaling scaling{ plssvm::real_type{ -1.0 }, plssvm::real_type{ 1.0 } };
 
         // try to directly convert it to a plssvm::data_set_type::scaling object
         try {
@@ -41,7 +41,7 @@ typename data_set_type::scaling create_scaling_object(const py::kwargs &args) {
             // can't cast to plssvm::data_set_type::scaling
             // -> try a std::array<real_type, 2> instead!
             try {
-                const auto interval = args["scaling"].cast<std::array<real_type, 2>>();
+                const auto interval = args["scaling"].cast<std::array<plssvm::real_type, 2>>();
                 scaling = typename data_set_type::scaling{ interval[0], interval[1] };
             } catch (...) {
                 // rethrow exception if this also did not succeed
@@ -54,19 +54,19 @@ typename data_set_type::scaling create_scaling_object(const py::kwargs &args) {
     }
 }
 
-template <typename real_type, typename label_type>
-void instantiate_data_set_bindings(py::module_ &m, plssvm::detail::real_type_label_type_combination<real_type, label_type>) {
-    using data_set_type = plssvm::data_set<real_type, label_type>;
+template <typename label_type>
+void instantiate_data_set_bindings(py::module_ &m, label_type) {
+    using data_set_type = plssvm::data_set<label_type>;
     using size_type = typename data_set_type::size_type;
 
     // create the Python type names based on the provided real_type and label_type
-    const std::string class_name_scaling_factors = assemble_unique_class_name<real_type, label_type>("DataSetScalingFactors");
-    const std::string class_name_scaling = assemble_unique_class_name<real_type, label_type>("DataSetScaling");
-    const std::string class_name = assemble_unique_class_name<real_type, label_type>("DataSet");
+    const std::string class_name_scaling_factors = assemble_unique_class_name<label_type>("DataSetScalingFactors");
+    const std::string class_name_scaling = assemble_unique_class_name<label_type>("DataSetScaling");
+    const std::string class_name = assemble_unique_class_name<label_type>("DataSet");
 
     // bind the plssvm::data_set::scaling internal "factors" struct
     py::class_<typename data_set_type::scaling::factors>(m, class_name_scaling_factors.c_str())
-        .def(py::init<size_type, real_type, real_type>(), "create a new scaling factor", py::arg("feature"), py::arg("lower"), py::arg("upper"))
+        .def(py::init<size_type, plssvm::real_type, plssvm::real_type>(), "create a new scaling factor", py::arg("feature"), py::arg("lower"), py::arg("upper"))
         .def_readonly("feature", &data_set_type::scaling::factors::feature, "the feature index for which the factors are valid")
         .def_readonly("lower", &data_set_type::scaling::factors::lower, "the lower scaling factor")
         .def_readonly("upper", &data_set_type::scaling::factors::upper, "the upper scaling factor")
@@ -80,8 +80,8 @@ void instantiate_data_set_bindings(py::module_ &m, plssvm::detail::real_type_lab
 
     // bind the plssvm::data_set internal "scaling" struct
     py::class_<typename data_set_type::scaling>(m, class_name_scaling.c_str())
-        .def(py::init<real_type, real_type>(), "create new scaling factors for the range [lower, upper]", py::arg("lower"), py::arg("upper"))
-        .def(py::init([](const std::array<real_type, 2> interval) {
+        .def(py::init<plssvm::real_type, plssvm::real_type>(), "create new scaling factors for the range [lower, upper]", py::arg("lower"), py::arg("upper"))
+        .def(py::init([](const std::array<plssvm::real_type, 2> interval) {
                  return typename data_set_type::scaling{ interval[0], interval[1] };
              }),
              "create new scaling factors for the range [lower, upper]")
@@ -121,7 +121,7 @@ void instantiate_data_set_bindings(py::module_ &m, plssvm::detail::real_type_lab
                     }),
                     "create a new data set from the provided file and additional optional parameters");
     // bind constructor taking only data points without labels
-    py_data_set.def(py::init([](py::array_t<real_type> data, py::kwargs args) {
+    py_data_set.def(py::init([](py::array_t<plssvm::real_type> data, py::kwargs args) {
                         // check keyword arguments
                         check_kwargs_for_correctness(args, { "scaling" });
 
@@ -134,7 +134,7 @@ void instantiate_data_set_bindings(py::module_ &m, plssvm::detail::real_type_lab
                     "create a new data set without labels given additional optional parameters");
 
     if constexpr (!std::is_same_v<label_type, std::string>) {
-        py_data_set.def(py::init([](py::array_t<real_type> data, py::array_t<label_type> labels, py::kwargs args) {
+        py_data_set.def(py::init([](py::array_t<plssvm::real_type> data, py::array_t<label_type> labels, py::kwargs args) {
                             // check keyword arguments
                             check_kwargs_for_correctness(args, { "scaling" });
 
@@ -147,7 +147,7 @@ void instantiate_data_set_bindings(py::module_ &m, plssvm::detail::real_type_lab
                         "create a new data set with labels from a numpy array given additional optional parameters");
     } else {
         // if the requested label_type is std::string, accept numpy arrays with real_type and convert them to a std::string internally
-        py_data_set.def(py::init([](py::array_t<real_type> data, py::array_t<real_type> labels, py::kwargs args) {
+        py_data_set.def(py::init([](py::array_t<plssvm::real_type> data, py::array_t<plssvm::real_type> labels, py::kwargs args) {
                             // check keyword arguments
                             check_kwargs_for_correctness(args, { "scaling" });
 
@@ -159,7 +159,7 @@ void instantiate_data_set_bindings(py::module_ &m, plssvm::detail::real_type_lab
                         }),
                         "create a new data set with labels from a numpy array given additional optional parameters");
         // if the requested label_type is std::string, accept a python list (which can contain py::str) and convert them to a std::string internally
-        py_data_set.def(py::init([](py::array_t<real_type> data, const py::list &labels, py::kwargs args) {
+        py_data_set.def(py::init([](py::array_t<plssvm::real_type> data, const py::list &labels, py::kwargs args) {
                             // check keyword arguments
                             check_kwargs_for_correctness(args, { "scaling" });
 
@@ -251,10 +251,10 @@ void instantiate_data_set_bindings(py::module_ &m) {
 
 void init_data_set(py::module_ &m) {
     // bind all data_set classes
-    instantiate_data_set_bindings<plssvm::detail::real_type_label_type_combination_list>(m);
+    instantiate_data_set_bindings<plssvm::detail::label_type_list>(m);
 
     // create aliases
-    m.attr("DataSetScalingFactors") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE, PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("DataSetScalingFactors").c_str());
-    m.attr("DataSetScaling") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE, PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("DataSetScaling").c_str());
-    m.attr("DataSet") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE, PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("DataSet").c_str());
+    m.attr("DataSetScalingFactors") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("DataSetScalingFactors").c_str());
+    m.attr("DataSetScaling") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("DataSetScaling").c_str());
+    m.attr("DataSet") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("DataSet").c_str());
 }

--- a/bindings/Python/kernel_function_types.cpp
+++ b/bindings/Python/kernel_function_types.cpp
@@ -7,6 +7,8 @@
  */
 
 #include "plssvm/kernel_function_types.hpp"
+
+#include "plssvm/constants.hpp"  // plssvm::real_type
 #include "plssvm/parameter.hpp"  // plssvm::parameter
 
 #include "pybind11/pybind11.h"   // py::module_, py::enum_, py::arg, py::pos_only
@@ -29,10 +31,10 @@ void init_kernel_function_types(py::module_ &m) {
 
     const plssvm::parameter default_params{};
 
-    m.def("linear_kernel_function", &plssvm::kernel_function<plssvm::kernel_function_type::linear, double>, "apply the linear kernel function to two vectors");
+    m.def("linear_kernel_function", &plssvm::kernel_function<plssvm::kernel_function_type::linear>, "apply the linear kernel function to two vectors");
     m.def(
-        "polynomial_kernel_function", [](const std::vector<double> &x, const std::vector<double> &y, const int degree, const std::optional<double> gamma, const double coef0) {
-            return plssvm::kernel_function<plssvm::kernel_function_type::polynomial>(x, y, degree, gamma.has_value() ? gamma.value() : 1.0 / static_cast<double>(x.size()), coef0);
+        "polynomial_kernel_function", [](const std::vector<plssvm::real_type> &x, const std::vector<plssvm::real_type> &y, const int degree, const std::optional<plssvm::real_type> gamma, const plssvm::real_type coef0) {
+            return plssvm::kernel_function<plssvm::kernel_function_type::polynomial>(x, y, degree, gamma.has_value() ? gamma.value() : plssvm::real_type{ 1.0 } / static_cast<plssvm::real_type>(x.size()), coef0);
         },
         "apply the polynomial kernel function to two vectors",
         py::arg("x"),
@@ -42,8 +44,8 @@ void init_kernel_function_types(py::module_ &m) {
         py::arg("gamma") = std::nullopt,
         py::arg("coef0") = default_params.coef0.value());
     m.def(
-        "rbf_kernel_function", [](const std::vector<double> &x, const std::vector<double> &y, const std::optional<double> gamma) {
-            return plssvm::kernel_function<plssvm::kernel_function_type::rbf>(x, y, gamma.has_value() ? gamma.value() : 1.0 / static_cast<double>(x.size()));
+        "rbf_kernel_function", [](const std::vector<plssvm::real_type> &x, const std::vector<plssvm::real_type> &y, const std::optional<plssvm::real_type> gamma) {
+            return plssvm::kernel_function<plssvm::kernel_function_type::rbf>(x, y, gamma.has_value() ? gamma.value() : plssvm::real_type{ 1.0 } / static_cast<plssvm::real_type>(x.size()));
         },
         "apply the radial basis function kernel function to two vectors",
         py::arg("x"),
@@ -52,10 +54,10 @@ void init_kernel_function_types(py::module_ &m) {
         py::arg("gamma") = std::nullopt);
 
     m.def(
-        "kernel_function", [](const std::vector<double> &x, const std::vector<double> &y, plssvm::parameter params) {
+        "kernel_function", [](const std::vector<plssvm::real_type> &x, const std::vector<plssvm::real_type> &y, plssvm::parameter params) {
             // set default gamma value
             if (params.gamma.is_default()) {
-                params.gamma = 1.0 / static_cast<double>(x.size());
+                params.gamma = plssvm::real_type{ 1.0 } / static_cast<plssvm::real_type>(x.size());
             }
             return plssvm::kernel_function(x, y, params);
         },

--- a/bindings/Python/model.cpp
+++ b/bindings/Python/model.cpp
@@ -7,7 +7,9 @@
  */
 
 #include "plssvm/model.hpp"
-#include "plssvm/detail/type_list.hpp"  // plssvm::detail::real_type_label_type_combination_list
+
+#include "plssvm/constants.hpp"         // plssvm::real_type
+#include "plssvm/detail/type_list.hpp"  // plssvm::detail::label_type_list
 
 #include "utility.hpp"                  // assemble_unique_class_name, vector_to_pyarray, matrix_to_pyarray
 
@@ -23,11 +25,11 @@
 
 namespace py = pybind11;
 
-template <typename real_type, typename label_type>
-void instantiate_model_bindings(py::module_ &m, plssvm::detail::real_type_label_type_combination<real_type, label_type>) {
-    using model_type = plssvm::model<real_type, label_type>;
+template <typename label_type>
+void instantiate_model_bindings(py::module_ &m, label_type) {
+    using model_type = plssvm::model<label_type>;
 
-    const std::string class_name = assemble_unique_class_name<real_type, label_type>("Model");
+    const std::string class_name = assemble_unique_class_name<label_type>("Model");
 
     py::class_<model_type>(m, class_name.c_str())
         .def(py::init<const std::string &>(), "load a previously learned model from a file")
@@ -62,7 +64,7 @@ void instantiate_model_bindings(py::module_ &m, plssvm::detail::real_type_label_
         .def(
             "weights", []([[maybe_unused]] const model_type &self) {
                 py::list ret{};
-                for (const plssvm::aos_matrix<typename model_type::real_type> &matr : self.weights()) {
+                for (const plssvm::aos_matrix<plssvm::real_type> &matr : self.weights()) {
                     ret.append(matrix_to_pyarray(matr));
                 }
                 return ret;
@@ -92,8 +94,8 @@ void instantiate_model_bindings(py::module_ &m) {
 
 void init_model(py::module_ &m) {
     // bind all model classes
-    instantiate_model_bindings<plssvm::detail::real_type_label_type_combination_list>(m);
+    instantiate_model_bindings<plssvm::detail::label_type_list>(m);
 
     // create alias
-    m.attr("Model") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE, PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("Model").c_str());
+    m.attr("Model") = m.attr(assemble_unique_class_name<PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE>("Model").c_str());
 }

--- a/bindings/Python/sklearn.cpp
+++ b/bindings/Python/sklearn.cpp
@@ -8,6 +8,8 @@
 
 #include "plssvm/core.hpp"
 
+#include "plssvm/constants.hpp"  // plssvm::real_type
+
 #include "utility.hpp"           // check_kwargs_for_correctness, assemble_unique_class_name, pyarray_to_vector, pyarray_to_matrix
 
 #include "fmt/core.h"            // fmt::format
@@ -34,10 +36,10 @@ namespace py = pybind11;
 // dummy
 struct svc {
     // the types
-    using real_type = PLSSVM_PYTHON_BINDINGS_PREFERRED_REAL_TYPE;
+    using real_type = plssvm::real_type;
     using label_type = PLSSVM_PYTHON_BINDINGS_PREFERRED_LABEL_TYPE;
-    using data_set_type = plssvm::data_set<real_type, label_type>;
-    using model_type = plssvm::model<real_type, label_type>;
+    using data_set_type = plssvm::data_set<label_type>;
+    using model_type = plssvm::model<label_type>;
 
     std::optional<real_type> epsilon{};
     std::optional<long long> max_iter{};

--- a/bindings/Python/utility.hpp
+++ b/bindings/Python/utility.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BINDINGS_PYTHON_UTILITY_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"       // plssvm::real_type
 #include "plssvm/detail/utility.hpp"  // plssvm::detail::contains
 #include "plssvm/matrix.hpp"          // plssvm::matrix, plssvm::layout_type
 #include "plssvm/parameter.hpp"       // plssvm::parameter
@@ -251,14 +252,13 @@ PLSSVM_CREATE_NUMPY_NAME_MAPPING(std::string, "string")
 
 /**
  * @brief Append the type information to the base @p class_name.
- * @tparam real_type the type of the data points to convert to its Numpy name
  * @tparam label_type the type of the labels to convert to its Numpy name
  * @param class_name the base class name (the type names are appended to it)
  * @return the unique class name
  */
-template <typename real_type, typename label_type>
+template <typename label_type>
 [[nodiscard]] inline std::string assemble_unique_class_name(const std::string_view class_name) {
-    return fmt::format("{}_{}_{}", class_name, detail::numpy_name_mapping<real_type>(), detail::numpy_name_mapping<label_type>());
+    return fmt::format("{}_{}_{}", class_name, detail::numpy_name_mapping<plssvm::real_type>(), detail::numpy_name_mapping<label_type>());
 }
 
 #endif  // PLSSVM_BINDINGS_PYTHON_UTILITY_HPP_

--- a/docs/plssvm-predict.1.in
+++ b/docs/plssvm-predict.1.in
@@ -29,10 +29,6 @@ choose the target platform: @PLSSVM_PLATFORM_NAME_LIST@ (default: automatic)
 must be specified if the labels should be interpreted as strings instead of integers
 
 .TP
-.B --use_float_as_real_type arg
-must be specified if float should be used instead of double as floating point type
-
-.TP
 .B --verbosity arg
 choose the level of verbosity: full|timing|libsvm|quiet (default: full)
 

--- a/docs/plssvm-scale.1.in
+++ b/docs/plssvm-scale.1.in
@@ -39,10 +39,6 @@ the file name from which previous scaling factors should be loaded
 must be specified if the labels should be interpreted as strings instead of integers
 
 .TP
-.B --use_float_as_real_type arg
-must be specified if float should be used instead of double as floating point type
-
-.TP
 .B --verbosity arg
 choose the level of verbosity: full|timing|libsvm|quiet (default: full)
 

--- a/docs/plssvm-train.1.in
+++ b/docs/plssvm-train.1.in
@@ -60,10 +60,6 @@ choose the target platform: @PLSSVM_PLATFORM_NAME_LIST@ (default: automatic)
 must be specified if the labels should be interpreted as strings instead of integers
 
 .TP
-.B --use_float_as_real_type arg
-must be specified if float should be used instead of double as floating point type
-
-.TP
 .B --verbosity arg
 choose the level of verbosity: full|timing|libsvm|quiet (default: full)
 

--- a/docs/resources/examples/csvm_examples.cpp
+++ b/docs/resources/examples/csvm_examples.cpp
@@ -15,9 +15,9 @@
 
 int main() {
     // create a train data set from a file with int labels
-    const plssvm::data_set<double> train_data_with_label{ "path/to/train/file.libsvm" };
+    const plssvm::data_set train_data_with_label{ "path/to/train/file.libsvm" };
     // create a test data set from a file without labels
-    const plssvm::data_set<double> test_data{ "path/to/test/file.libsvm" };
+    const plssvm::data_set test_data{ "path/to/test/file.libsvm" };
 
     // create a support vector machine
     auto svm = plssvm::make_csvm();

--- a/docs/resources/examples/data_set_examples.cpp
+++ b/docs/resources/examples/data_set_examples.cpp
@@ -16,9 +16,9 @@
 int main() {
 
     // create a data set from a file with int labels
-    plssvm::data_set<double> data1{ "path/to/train/file.libsvm" };
+    plssvm::data_set data1{ "path/to/train/file.libsvm" };
     // create a data set from a file with std::string labels
-    plssvm::data_set<double, std::string> data2{ "path/to/train/file_string_labels.libsvm" };
+    plssvm::data_set std::string> data2{ "path/to/train/file_string_labels.libsvm" };
 
     // create a data set from a std::vector with labels
     std::vector<std::vector<double>> data_vector{ { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 } };
@@ -29,9 +29,9 @@ int main() {
     auto different_labels = data3.classes().value();  // will return an optional vector containing { 0, 1 }
 
     // create a train data set and scale it to the range [-1, 1]
-    plssvm::data_set<double> train_data{ "path/to/train/file.libsvm", { -1.0, 1.0 } };
+    plssvm::data_set train_data{ "path/to/train/file.libsvm", { -1.0, 1.0 } };
     // scale a test data set and scale it according to the train data set
-    plssvm::data_set<double> test_data{ "path/to/test/file.libsvm", train_data.scaling_factors()->get() };
+    plssvm::data_set test_data{ "path/to/test/file.libsvm", train_data.scaling_factors()->get() };
 
     return 0;
 }

--- a/docs/resources/examples/model_examples.cpp
+++ b/docs/resources/examples/model_examples.cpp
@@ -12,7 +12,7 @@
 
 int main() {
     // create a data set from a file
-    const plssvm::data_set<double> data{ "path/to/train/file.libsvm" };
+    const plssvm::data_set data{ "path/to/train/file.libsvm" };
 
     // create a support vector machine
     const auto svm = plssvm::make_csvm();

--- a/examples/cpp/main.cpp
+++ b/examples/cpp/main.cpp
@@ -11,8 +11,8 @@ int main() {
 
         // create two data sets: one with the training data scaled to [-1, 1]
         // and one with the test data scaled like the training data
-        const plssvm::data_set<double> train_data{ "train_file.libsvm", { -1.0, 1.0 } };
-        const plssvm::data_set<double> test_data{ "test_file.libsvm", train_data.scaling_factors()->get() };
+        const plssvm::data_set train_data{ "train_file.libsvm", { -1.0, 1.0 } };
+        const plssvm::data_set test_data{ "test_file.libsvm", train_data.scaling_factors()->get() };
 
         // create C-SVM using the default backend and the previously defined parameter
         const auto svm = plssvm::make_csvm(params);

--- a/include/plssvm/backends/CUDA/cg_explicit/blas.cuh
+++ b/include/plssvm/backends/CUDA/cg_explicit/blas.cuh
@@ -13,11 +13,10 @@
 #define PLSSVM_BACKENDS_CUDA_CG_EXPLICIT_BLAS_CUH_
 #pragma once
 
-#include "plssvm/constants.hpp"  // plssvm::kernel_index_type
+#include "plssvm/constants.hpp"  // plssvm::real_type, plssvm::kernel_index_type
 
 namespace plssvm::cuda {
 
-template <typename real_type>
 __global__ void device_kernel_gemm(const kernel_index_type m, const kernel_index_type n, const kernel_index_type k, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C);
 
 }  // namespace plssvm::cuda

--- a/include/plssvm/backends/CUDA/cg_explicit/kernel_matrix_assembly.cuh
+++ b/include/plssvm/backends/CUDA/cg_explicit/kernel_matrix_assembly.cuh
@@ -13,17 +13,14 @@
 #define PLSSVM_BACKENDS_CUDA_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLE_CUH_
 #pragma once
 
-#include "plssvm/constants.hpp"  // plssvm::kernel_index_type
+#include "plssvm/constants.hpp"  // plssvm::real_type, plssvm::kernel_index_type
 
 namespace plssvm::cuda {
 
-template <typename real_type>
 __global__ void device_kernel_assembly_linear(const real_type *q, real_type *ret, const real_type *data_d, const real_type QA_cost, const real_type cost, const kernel_index_type num_rows, const kernel_index_type num_features);
 
-template <typename real_type>
 __global__ void device_kernel_assembly_polynomial(const real_type *q, real_type *ret, const real_type *data_d, const real_type QA_cost, const real_type cost, const kernel_index_type num_rows, const kernel_index_type num_features, const int degree, const real_type gamma, const real_type coef0);
 
-template <typename real_type>
 __global__ void device_kernel_assembly_rbf(const real_type *q, real_type *ret, const real_type *data_d, const real_type QA_cost, const real_type cost, const kernel_index_type num_rows, const kernel_index_type num_features, const real_type gamma);
 
 }  // namespace plssvm::cuda

--- a/include/plssvm/backends/CUDA/csvm.hpp
+++ b/include/plssvm/backends/CUDA/csvm.hpp
@@ -17,7 +17,7 @@
 #include "plssvm/backends/gpu_csvm.hpp"                // plssvm::detail::gpu_csvm
 #include "plssvm/constants.hpp"                        // plssvm::real_type
 #include "plssvm/detail/simple_any.hpp"                // plssvm::detail::simple_any
-#include "plssvm/parameter.hpp"                        // plssvm::parameter, plssvm::detail::parameter
+#include "plssvm/parameter.hpp"                        // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                 // plssvm::target_platform
 
 #include <cstddef>                                     // std::size_t
@@ -134,7 +134,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int> {
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type & data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(const parameter &params, const device_ptr_type & data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_gemm_kernel_explicit
      */
@@ -143,7 +143,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int> {
     //***************************************************//
     //                   predict, score                  //
     //***************************************************//
-    device_ptr_type run_predict_kernel(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type &w_d, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const final;
+    device_ptr_type run_predict_kernel(const parameter &params, const device_ptr_type &w_d, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const final;
     device_ptr_type run_w_kernel(const device_ptr_type &alpha_d, const device_ptr_type &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const final;
 
   private:

--- a/include/plssvm/backends/CUDA/csvm.hpp
+++ b/include/plssvm/backends/CUDA/csvm.hpp
@@ -15,6 +15,7 @@
 
 #include "plssvm/backends/CUDA/detail/device_ptr.cuh"  // plssvm::cuda::detail::device_ptr
 #include "plssvm/backends/gpu_csvm.hpp"                // plssvm::detail::gpu_csvm
+#include "plssvm/constants.hpp"                        // plssvm::real_type
 #include "plssvm/detail/simple_any.hpp"                // plssvm::detail::simple_any
 #include "plssvm/parameter.hpp"                        // plssvm::parameter, plssvm::detail::parameter
 #include "plssvm/target_platforms.hpp"                 // plssvm::target_platform
@@ -125,7 +126,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int> {
     /**
      * @copydoc plssvm::csvm::get_device_memory
      */
-    unsigned long long get_device_memory() const final;
+    [[nodiscard]] unsigned long long get_device_memory() const final;
 
     //***************************************************//
     //                        fit                        //
@@ -133,43 +134,17 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int> {
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type<float> run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<float> &params, const device_ptr_type<float> & data_d, const device_ptr_type<float> &q_red_d, float QA_cost) const final { return this->run_assemble_kernel_matrix_explicit_impl(params, data_d, q_red_d, QA_cost); }
-    /**
-     * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
-     */
-    [[nodiscard]] device_ptr_type<double> run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<double> &params, const device_ptr_type<double> &data_d, const device_ptr_type<double> &q_red_d, double QA_cost) const final { return this->run_assemble_kernel_matrix_explicit_impl(params, data_d, q_red_d, QA_cost); }
-    /**
-     * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
-     */
-    template <typename real_type>
-    [[nodiscard]] device_ptr_type<real_type> run_assemble_kernel_matrix_explicit_impl(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type<real_type> &data_d, const device_ptr_type<real_type> &q_red_d, real_type QA_cost) const;
-
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type & data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_gemm_kernel_explicit
      */
-    void run_gemm_kernel_explicit(std::size_t m, std::size_t n, std::size_t k, float alpha, const device_ptr_type<float> &A_d, const device_ptr_type<float> &B_d, const float beta, device_ptr_type<float> &C_d) const final { this->run_gemm_kernel_explicit_impl(m, n, k, alpha, A_d, B_d, beta, C_d); }
-    /**
-     * @copydoc plssvm::detail::gpu_csvm::run_gemm_kernel_explicit
-     */
-    void run_gemm_kernel_explicit(std::size_t m, std::size_t n, std::size_t k, double alpha, const device_ptr_type<double> &A_d, const device_ptr_type<double> &B_d, const double beta, device_ptr_type<double> &C_d) const final { this->run_gemm_kernel_explicit_impl(m, n, k, alpha, A_d, B_d, beta, C_d); }
-    /**
-     * @copydoc plssvm::detail::gpu_csvm::run_gemm_kernel_explicit
-     */
-    template <typename real_type>
-    void run_gemm_kernel_explicit_impl(std::size_t m, std::size_t n, std::size_t k, real_type alpha, const device_ptr_type<real_type> &A_d, const device_ptr_type<real_type> &B_d, const real_type beta, device_ptr_type<real_type> &C_d) const;
+    void run_gemm_kernel_explicit(std::size_t m, std::size_t n, std::size_t k, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const final;
 
     //***************************************************//
     //                   predict, score                  //
     //***************************************************//
-    device_ptr_type<float> run_predict_kernel(const ::plssvm::detail::parameter<float> &params, const device_ptr_type<float> &w_d, const device_ptr_type<float> &alpha_d, const device_ptr_type<float> &rho_d, const device_ptr_type<float> &sv_d, const device_ptr_type<float> &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const final { return this->run_predict_kernel_impl(params, w_d, alpha_d, rho_d, sv_d, predict_points_d, num_classes, num_sv, num_predict_points, num_features); }
-    device_ptr_type<double> run_predict_kernel(const ::plssvm::detail::parameter<double> &params, const device_ptr_type<double> &w_d, const device_ptr_type<double> &alpha_d, const device_ptr_type<double> &rho_d, const device_ptr_type<double> &sv_d, const device_ptr_type<double> &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const final { return this->run_predict_kernel_impl(params, w_d, alpha_d, rho_d, sv_d, predict_points_d, num_classes, num_sv, num_predict_points, num_features); }
-    template <typename real_type>
-    device_ptr_type<real_type> run_predict_kernel_impl(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type<real_type> &w_d, const device_ptr_type<real_type> &alpha_d, const device_ptr_type<real_type> &rho_d, const device_ptr_type<real_type> &sv_d, const device_ptr_type<real_type> &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const;
-
-    device_ptr_type<float> run_w_kernel(const device_ptr_type<float> &alpha_d, const device_ptr_type<float> &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const final { return this->run_w_kernel_impl(alpha_d, sv_d, num_classes, num_sv, num_features); }
-    device_ptr_type<double> run_w_kernel(const device_ptr_type<double> &alpha_d, const device_ptr_type<double> &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const final { return this->run_w_kernel_impl(alpha_d, sv_d, num_classes, num_sv, num_features); }
-    template <typename real_type>
-    device_ptr_type<real_type> run_w_kernel_impl(const device_ptr_type<real_type> &alpha_d, const device_ptr_type<real_type> &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const;
+    device_ptr_type run_predict_kernel(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type &w_d, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const final;
+    device_ptr_type run_w_kernel(const device_ptr_type &alpha_d, const device_ptr_type &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const final;
 
   private:
     /**

--- a/include/plssvm/backends/CUDA/predict_kernel.cuh
+++ b/include/plssvm/backends/CUDA/predict_kernel.cuh
@@ -13,20 +13,16 @@
 #define PLSSVM_BACKENDS_CUDA_PREDICT_KERNEL_HPP_
 #pragma once
 
-#include "plssvm/constants.hpp"  // plssvm::kernel_index_type
+#include "plssvm/constants.hpp"  // plssvm::real_type, plssvm::kernel_index_type
 
 namespace plssvm::cuda {
 
-template <typename real_type>
 __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const kernel_index_type num_classes, const kernel_index_type num_sv, const kernel_index_type num_features);
 
-template <typename real_type>
 __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const kernel_index_type num_classes, const kernel_index_type num_predict_points, const kernel_index_type num_features);
 
-template <typename real_type>
 __global__ void device_kernel_predict_polynomial(real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const kernel_index_type num_classes, const kernel_index_type num_sv, const kernel_index_type num_predict_points, const kernel_index_type num_features, const int degree, const real_type gamma, const real_type coef0);
 
-template <typename real_type>
 __global__ void device_kernel_predict_rbf(real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const kernel_index_type num_classes, const kernel_index_type num_sv, const kernel_index_type num_predict_points, const kernel_index_type num_features, const real_type gamma);
 
 

--- a/include/plssvm/backends/OpenMP/cg_explicit/kernel_matrix_assembly.hpp
+++ b/include/plssvm/backends/OpenMP/cg_explicit/kernel_matrix_assembly.hpp
@@ -13,7 +13,8 @@
 #define PLSSVM_BACKENDS_OPENMP_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLY_HPP_
 #pragma once
 
-#include "plssvm/matrix.hpp"  // plssvm::aos_matrix
+#include "plssvm/constants.hpp"  // plssvm::real_type
+#include "plssvm/matrix.hpp"     // plssvm::aos_matrix
 
 #include <vector>  // std::vector
 
@@ -21,19 +22,16 @@ namespace plssvm::openmp {
 
 /**
  * @brief Assemble the kernel matrix using the linear kernel function.
- * @tparam real_type the type of the data
  * @param[in] q the `q` vector
  * @param[out] ret the resulting kernel matrix
  * @param[in] data the data matrix
  * @param[in] QA_cost he bottom right matrix entry multiplied by cost
  * @param[in] cost 1 / the cost parameter in the C-SVM
  */
-template <typename real_type>
 void linear_kernel_matrix_assembly(const std::vector<real_type> &q, ::plssvm::aos_matrix<real_type> &ret, const ::plssvm::aos_matrix<real_type> &data, real_type QA_cost, real_type cost);
 
 /**
  * @brief Assemble the kernel matrix using the polynomial kernel function.
- * @tparam real_type the type of the data
  * @param[in] q the `q` vector
  * @param[out] ret the resulting kernel matrix
  * @param[in] data the data matrix
@@ -43,12 +41,10 @@ void linear_kernel_matrix_assembly(const std::vector<real_type> &q, ::plssvm::ao
  * @param[in] gamma the gamma parameter used in the polynomial kernel function
  * @param[in] coef0 the coef0 parameter used in the polynomial kernel function
  */
-template <typename real_type>
 void polynomial_kernel_matrix_assembly(const std::vector<real_type> &q, ::plssvm::aos_matrix<real_type> &ret, const ::plssvm::aos_matrix<real_type> &data, real_type QA_cost, real_type cost, int degree, real_type gamma, real_type coef0);
 
 /**
  * @brief Assemble the kernel matrix using the radial basis function kernel function.
- * @tparam real_type the type of the data
  * @param[in] q the `q` vector
  * @param[out] ret the resulting kernel matrix
  * @param[in] data the data matrix
@@ -56,9 +52,8 @@ void polynomial_kernel_matrix_assembly(const std::vector<real_type> &q, ::plssvm
  * @param[in] cost 1 / the cost parameter in the C-SVM
  * @param[in] gamma the gamma parameter used in the rbf kernel function
  */
-template <typename real_type>
 void rbf_kernel_matrix_assembly(const std::vector<real_type> &q, ::plssvm::aos_matrix<real_type> &ret, const ::plssvm::aos_matrix<real_type> &data, real_type QA_cost, real_type cost, real_type gamma);
 
 }  // namespace plssvm::openmp
 
-#endif  // PLSSVM_BACKENDS_OPENMP_KERNEL_MATRIX_ASSEMBLY_HPP_
+#endif  // PLSSVM_BACKENDS_OPENMP_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLY_HPP_

--- a/include/plssvm/backends/OpenMP/csvm.hpp
+++ b/include/plssvm/backends/OpenMP/csvm.hpp
@@ -18,7 +18,7 @@
 #include "plssvm/detail/simple_any.hpp"   // plssvm::detail::simple_any
 #include "plssvm/detail/type_traits.hpp"  // PLSSVM_REQUIRES
 #include "plssvm/matrix.hpp"              // plssvm::aos_matrix
-#include "plssvm/parameter.hpp"           // plssvm::parameter, plssvm::detail::{parameter, has_only_parameter_named_args_v}
+#include "plssvm/parameter.hpp"           // plssvm::parameter, plssvm::detail::has_only_parameter_named_args_v
 #include "plssvm/target_platforms.hpp"    // plssvm::target_platform
 
 
@@ -119,7 +119,7 @@ class csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::assemble_kernel_matrix
      */
-    [[nodiscard]] detail::simple_any assemble_kernel_matrix(const solver_type solver, const detail::parameter<real_type> &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const final;
+    [[nodiscard]] detail::simple_any assemble_kernel_matrix(const solver_type solver, const parameter &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const final;
     /**
      * @copydoc plssvm::csvm::blas_gemm
      */
@@ -131,7 +131,7 @@ class csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::predict_values
      */
-    [[nodiscard]] aos_matrix<real_type> predict_values(const detail::parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const final;
+    [[nodiscard]] aos_matrix<real_type> predict_values(const parameter &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const final;
 
     private:
     /**

--- a/include/plssvm/backends/OpenMP/csvm.hpp
+++ b/include/plssvm/backends/OpenMP/csvm.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BACKENDS_OPENMP_CSVM_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"           // plssvm::real_type
 #include "plssvm/csvm.hpp"                // plssvm::csvm
 #include "plssvm/detail/simple_any.hpp"   // plssvm::detail::simple_any
 #include "plssvm/detail/type_traits.hpp"  // PLSSVM_REQUIRES
@@ -105,7 +106,7 @@ class csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::get_device_memory
      */
-    unsigned long long get_device_memory() const final;
+    [[nodiscard]] unsigned long long get_device_memory() const final;
 
     //***************************************************//
     //                        fit                        //
@@ -113,44 +114,16 @@ class csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::setup_data_on_devices
      */
-    [[nodiscard]] detail::simple_any setup_data_on_devices(const solver_type solver, const aos_matrix<float> &A) const final { return this->setup_data_on_devices_impl(solver, A); }
-    /**
-     * @copydoc plssvm::csvm::setup_data_on_devices
-     */
-    [[nodiscard]] detail::simple_any setup_data_on_devices(const solver_type solver, const aos_matrix<double> &A) const final { return this->setup_data_on_devices_impl(solver, A); }
-    /**
-     * @copydoc plssvm::csvm::setup_data_on_devices
-     */
-    template <typename real_type>
-    [[nodiscard]] detail::simple_any setup_data_on_devices_impl(solver_type solver, const aos_matrix<real_type> &A) const;
+    [[nodiscard]] detail::simple_any setup_data_on_devices(const solver_type solver, const aos_matrix<real_type> &A) const final;
 
     /**
      * @copydoc plssvm::csvm::assemble_kernel_matrix
      */
-    [[nodiscard]] detail::simple_any assemble_kernel_matrix(const solver_type solver, const detail::parameter<float> &params, const detail::simple_any &data, const std::vector<float> &q_red, const float QA_cost) const final { return this->assemble_kernel_matrix_impl(solver, params, data, q_red, QA_cost); }
-    /**
-     * @copydoc plssvm::csvm::assemble_kernel_matrix
-     */
-    [[nodiscard]] detail::simple_any assemble_kernel_matrix(const solver_type solver, const detail::parameter<double> &params, const detail::simple_any &data, const std::vector<double> &q_red, const double QA_cost) const final { return this->assemble_kernel_matrix_impl(solver, params, data, q_red, QA_cost); }
-    /**
-     * @copydoc plssvm::csvm::assemble_kernel_matrix
-     */
-    template <typename real_type>
-    [[nodiscard]] detail::simple_any assemble_kernel_matrix_impl(solver_type solver, const detail::parameter<real_type> &params, const detail::simple_any &data, const std::vector<real_type> &q_red, real_type QA_cost) const;
-
+    [[nodiscard]] detail::simple_any assemble_kernel_matrix(const solver_type solver, const detail::parameter<real_type> &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const final;
     /**
      * @copydoc plssvm::csvm::blas_gemm
      */
-    void blas_gemm(const solver_type solver, const float alpha, const detail::simple_any &A, const aos_matrix<float> &B, const float beta, aos_matrix<float> &C) const final { this->blas_gemm_impl(solver, alpha, A, B, beta, C); }
-    /**
-     * @copydoc plssvm::csvm::blas_gemm
-     */
-    void blas_gemm(const solver_type solver, const double alpha, const detail::simple_any &A, const aos_matrix<double> &B, const double beta, aos_matrix<double> &C) const final { this->blas_gemm_impl(solver, alpha, A, B, beta, C); }
-    /**
-     * @copydoc plssvm::csvm::blas_gemm
-     */
-    template <typename real_type>
-    void blas_gemm_impl(solver_type solver, real_type alpha, const detail::simple_any &A, const aos_matrix<real_type> &B, real_type beta, aos_matrix<real_type> &C) const;
+    void blas_gemm(const solver_type solver, const real_type alpha, const detail::simple_any &A, const aos_matrix<real_type> &B, const real_type beta, aos_matrix<real_type> &C) const final;
 
     //***************************************************//
     //                   predict, score                  //
@@ -158,16 +131,7 @@ class csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::predict_values
      */
-    [[nodiscard]] aos_matrix<float> predict_values(const detail::parameter<float> &params, const aos_matrix<float> &support_vectors, const aos_matrix<float> &alpha, const std::vector<float> &rho, aos_matrix<float> &w, const aos_matrix<float> &predict_points) const override { return this->predict_values_impl(params, support_vectors, alpha, rho, w, predict_points); }
-    /**
-     * @copydoc plssvm::csvm::predict_values
-     */
-    [[nodiscard]] aos_matrix<double> predict_values(const detail::parameter<double> &params, const aos_matrix<double> &support_vectors, const aos_matrix<double> &alpha, const std::vector<double> &rho, aos_matrix<double> &w, const aos_matrix<double> &predict_points) const override { return this->predict_values_impl(params, support_vectors, alpha, rho, w, predict_points); }
-    /**
-     * @copydoc plssvm::csvm::predict_values
-     */
-    template <typename real_type>
-    [[nodiscard]] aos_matrix<real_type> predict_values_impl(const detail::parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const;
+    [[nodiscard]] aos_matrix<real_type> predict_values(const detail::parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const final;
 
     private:
     /**

--- a/include/plssvm/backends/gpu_csvm.hpp
+++ b/include/plssvm/backends/gpu_csvm.hpp
@@ -13,7 +13,7 @@
 #define PLSSVM_BACKENDS_GPU_CSVM_HPP_
 #pragma once
 
-#include "plssvm/constants.hpp"                   // plssvm::{THREAD_BLOCK_SIZE, INTERNAL_BLOCK_SIZE}
+#include "plssvm/constants.hpp"                   // plssvm::real_type, plssvm::{THREAD_BLOCK_SIZE, INTERNAL_BLOCK_SIZE}
 #include "plssvm/csvm.hpp"                        // plssvm::csvm
 #include "plssvm/detail/execution_range.hpp"      // plssvm::detail::execution_range
 #include "plssvm/detail/logger.hpp"               // plssvm::detail::log, plssvm::verbosity_level
@@ -46,7 +46,6 @@ template <template <typename> typename device_ptr_t, typename queue_t>
 class gpu_csvm : public ::plssvm::csvm {
   public:
     /// The type of the device pointer (dependent on the used backend).
-    template <typename real_type>
     using device_ptr_type = device_ptr_t<real_type>;
     /// The type of the device queue (dependent on the used backend).
     using queue_type = queue_t;
@@ -109,8 +108,7 @@ class gpu_csvm : public ::plssvm::csvm {
      * @param[in,out] buffer_d the data to gather
      * @param[in,out] buffer the reduced data
      */
-    template <typename real_type>
-    void device_reduction(std::vector<device_ptr_type<real_type>> &buffer_d, std::vector<real_type> &buffer) const;
+    void device_reduction(std::vector<device_ptr_type> &buffer_d, std::vector<real_type> &buffer) const;
 
     //***************************************************//
     //                        fit                        //
@@ -118,44 +116,16 @@ class gpu_csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::setup_data_on_devices
      */
-    [[nodiscard]] ::plssvm::detail::simple_any setup_data_on_devices(const solver_type solver, const aos_matrix<float> &A) const final { return this->setup_data_on_devices_impl(solver, A); }
-    /**
-     * @copydoc plssvm::csvm::setup_data_on_devices
-     */
-    [[nodiscard]] ::plssvm::detail::simple_any setup_data_on_devices(const solver_type solver, const aos_matrix<double> &A) const final { return this->setup_data_on_devices_impl(solver, A); }
-    /**
-     * @copydoc plssvm::csvm::setup_data_on_devices
-     */
-    template <typename real_type>
-    [[nodiscard]] ::plssvm::detail::simple_any setup_data_on_devices_impl(solver_type solver, const aos_matrix<real_type> &A) const;
+    [[nodiscard]] ::plssvm::detail::simple_any setup_data_on_devices(const solver_type solver, const aos_matrix<real_type> &A) const final;
 
     /**
      * @copydoc plssvm::csvm::assemble_kernel_matrix_explicit_impl
      */
-    [[nodiscard]] ::plssvm::detail::simple_any assemble_kernel_matrix(const solver_type solver, const ::plssvm::detail::parameter<float> &params, const ::plssvm::detail::simple_any & data, const std::vector<float> &q_red, const float QA_cost) const final { return this->assemble_kernel_matrix_impl(solver, params, data, q_red, QA_cost); }
-    /**
-     * @copydoc plssvm::csvm::assemble_kernel_matrix_explicit_impl
-     */
-    [[nodiscard]] ::plssvm::detail::simple_any assemble_kernel_matrix(const solver_type solver, const ::plssvm::detail::parameter<double> &params, const ::plssvm::detail::simple_any &data, const std::vector<double> &q_red, const double QA_cost) const final { return this->assemble_kernel_matrix_impl(solver, params, data, q_red, QA_cost); }
-    /**
-     * @copydoc plssvm::csvm::assemble_kernel_matrix_explicit_impl
-     */
-    template <typename real_type>
-    [[nodiscard]] ::plssvm::detail::simple_any assemble_kernel_matrix_impl(solver_type solver, const ::plssvm::detail::parameter<real_type> &params, const ::plssvm::detail::simple_any &data, const std::vector<real_type> &q_red, real_type QA_cost) const;
-
+    [[nodiscard]] ::plssvm::detail::simple_any assemble_kernel_matrix(const solver_type solver, const ::plssvm::detail::parameter<real_type> &params, const ::plssvm::detail::simple_any & data, const std::vector<real_type> &q_red, const real_type QA_cost) const final;
     /**
      * @copydoc plssvm::csvm::kernel_matrix_matmul_explicit
      */
-    void blas_gemm(const solver_type solver, const float alpha, const ::plssvm::detail::simple_any &A, const aos_matrix<float> &B, const float beta, aos_matrix<float> &C) const final { this->blas_gemm_impl(solver, alpha, A, B, beta, C); }
-    /**
-     * @copydoc plssvm::csvm::kernel_matrix_matmul_explicit
-     */
-    void blas_gemm(const solver_type solver, const double alpha, const ::plssvm::detail::simple_any &A, const aos_matrix<double> &B, const double beta, aos_matrix<double> &C) const final { this->blas_gemm_impl(solver, alpha, A, B, beta, C); }
-    /**
-     * @copydoc plssvm::csvm::kernel_matrix_matmul_explicit
-     */
-    template <typename real_type>
-    void blas_gemm_impl(solver_type solver, real_type alpha, const ::plssvm::detail::simple_any &A, const aos_matrix<real_type> &B, real_type beta, aos_matrix<real_type> &C) const;
+    void blas_gemm(const solver_type solver, const real_type alpha, const ::plssvm::detail::simple_any &A, const aos_matrix<real_type> &B, const real_type beta, aos_matrix<real_type> &C) const final;
 
     //***************************************************//
     //                   predict, score                  //
@@ -163,20 +133,10 @@ class gpu_csvm : public ::plssvm::csvm {
     /**
      * @copydoc plssvm::csvm::predict_values
      */
-    [[nodiscard]] aos_matrix<float> predict_values(const parameter<float> &params, const aos_matrix<float> &support_vectors, const aos_matrix<float> &alpha, const std::vector<float> &rho, aos_matrix<float> &w, const aos_matrix<float> &predict_points) const final { return this->predict_values_impl(params, support_vectors, alpha, rho, w, predict_points); }
-    /**
-     * @copydoc plssvm::csvm::predict_values
-     */
-    [[nodiscard]] aos_matrix<double> predict_values(const parameter<double> &params, const aos_matrix<double> &support_vectors, const aos_matrix<double> &alpha, const std::vector<double> &rho, aos_matrix<double> &w, const aos_matrix<double> &predict_points) const final { return this->predict_values_impl(params, support_vectors, alpha, rho, w, predict_points); }
-    /**
-     * @copydoc plssvm::csvm::predict_values
-     */
-    template <typename real_type>
-    [[nodiscard]] aos_matrix<real_type> predict_values_impl(const parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const;
+    [[nodiscard]] aos_matrix<real_type> predict_values(const parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const final;
 
     /**
      * @brief Precalculate the `w` vector to speedup up the prediction using the linear kernel function.
-     * @tparam real_type the type of the data points (either `float` or `double`)
      * @param[in] data_d the data points used in the dimensional reduction located on the device(s)
      * @param[in] data_last_d the last data point of the data set located on the device(s)
      * @param[in] alpha_d the previously learned weights located on the device(s)
@@ -184,8 +144,7 @@ class gpu_csvm : public ::plssvm::csvm {
      * @param[in] feature_ranges the range of features a specific device is responsible for
      * @return the `w` vector (`[[nodiscard]]`)
      */
-    template <typename real_type>
-    [[nodiscard]] std::vector<real_type> calculate_w(const std::vector<device_ptr_type<real_type>> &data_d, const std::vector<device_ptr_type<real_type>> &data_last_d, const std::vector<device_ptr_type<real_type>> &alpha_d, std::size_t num_data_points, const std::vector<std::size_t> &feature_ranges) const;
+    [[nodiscard]] std::vector<real_type> calculate_w(const std::vector<device_ptr_type> &data_d, const std::vector<device_ptr_type> &data_last_d, const std::vector<device_ptr_type> &alpha_d, std::size_t num_data_points, const std::vector<std::size_t> &feature_ranges) const;
 
     /**
      * @brief Select the correct kernel based on the value of @p kernel_ and run it on the device denoted by @p device.
@@ -201,8 +160,7 @@ class gpu_csvm : public ::plssvm::csvm {
      * @param[in] dept the number of data points after the dimensional reduction
      * @param[in] boundary_size the size of the padding boundary
      */
-    template <typename real_type>
-    void run_device_kernel(std::size_t device, const parameter<real_type> &params, const device_ptr_type<real_type> &q_d, device_ptr_type<real_type> &r_d, const device_ptr_type<real_type> &x_d, const device_ptr_type<real_type> &data_d, const std::vector<std::size_t> &feature_ranges, real_type QA_cost, real_type add, std::size_t dept, std::size_t boundary_size) const;
+    void run_device_kernel(std::size_t device, const parameter<real_type> &params, const device_ptr_type &q_d, device_ptr_type &r_d, const device_ptr_type &x_d, const device_ptr_type &data_d, const std::vector<std::size_t> &feature_ranges, real_type QA_cost, real_type add, std::size_t dept, std::size_t boundary_size) const;
 
     //*************************************************************************************************************************************//
     //                                         pure virtual, must be implemented by all subclasses                                         //
@@ -218,20 +176,16 @@ class gpu_csvm : public ::plssvm::csvm {
     //***************************************************//
     //                        fit                        //
     //***************************************************//
-    virtual device_ptr_type<float> run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<float> &params, const device_ptr_type<float> & data_d, const device_ptr_type<float> &q_red_d, float QA_cost) const = 0;
-    virtual device_ptr_type<double> run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<double> &params, const device_ptr_type<double> &data_d, const device_ptr_type<double> &q_red_d, double QA_cost) const = 0;
+    virtual device_ptr_type run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type & data_d, const device_ptr_type &q_red_d, real_type QA_cost) const = 0;
 
-    virtual void run_gemm_kernel_explicit(std::size_t m, std::size_t n, std::size_t k, float alpha, const device_ptr_type<float> &A, const device_ptr_type<float> &B, float beta, device_ptr_type<float> &C) const = 0;
-    virtual void run_gemm_kernel_explicit(std::size_t m, std::size_t n, std::size_t k, double alpha, const device_ptr_type<double> &A, const device_ptr_type<double> &B, double beta, device_ptr_type<double> &C) const = 0;
+    virtual void run_gemm_kernel_explicit(std::size_t m, std::size_t n, std::size_t k, real_type alpha, const device_ptr_type &A, const device_ptr_type &B, real_type beta, device_ptr_type &C) const = 0;
 
     //***************************************************//
     //                   predict, score                  //
     //***************************************************//
-    virtual device_ptr_type<float> run_predict_kernel(const parameter<float> &params, const device_ptr_type<float> &w, const device_ptr_type<float> &alpha_d, const device_ptr_type<float> &rho_d, const device_ptr_type<float> &sv_d, const device_ptr_type<float> &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const = 0;
-    virtual device_ptr_type<double> run_predict_kernel(const parameter<double> &params, const device_ptr_type<double> &w, const device_ptr_type<double> &alpha_d, const device_ptr_type<double> &rho_d, const device_ptr_type<double> &sv_d, const device_ptr_type<double> &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const = 0;
+    virtual device_ptr_type run_predict_kernel(const parameter<real_type> &params, const device_ptr_type &w, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const = 0;
 
-    virtual device_ptr_type<float> run_w_kernel(const device_ptr_type<float> &alpha_d, const device_ptr_type<float> &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const = 0;
-    virtual device_ptr_type<double> run_w_kernel(const device_ptr_type<double> &alpha_d, const device_ptr_type<double> &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const = 0;
+    virtual device_ptr_type run_w_kernel(const device_ptr_type &alpha_d, const device_ptr_type &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const = 0;
 
 
     /// The available/used backend devices.
@@ -257,10 +211,9 @@ std::size_t gpu_csvm<device_ptr_t, queue_t>::select_num_used_devices(const kerne
 }
 
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-void gpu_csvm<device_ptr_t, queue_t>::device_reduction(std::vector<device_ptr_type<real_type>> &buffer_d, std::vector<real_type> &buffer) const {
+void gpu_csvm<device_ptr_t, queue_t>::device_reduction(std::vector<device_ptr_type> &buffer_d, std::vector<real_type> &buffer) const {
     PLSSVM_ASSERT(!buffer_d.empty(), "The buffer_d array may not be empty!");
-    PLSSVM_ASSERT(std::all_of(buffer_d.cbegin(), buffer_d.cend(), [](const device_ptr_type<real_type> &ptr) { return !ptr.empty(); }), "Each device_ptr in buffer_d must at least contain one data point!");
+    PLSSVM_ASSERT(std::all_of(buffer_d.cbegin(), buffer_d.cend(), [](const device_ptr_type &ptr) { return !ptr.empty(); }), "Each device_ptr in buffer_d must at least contain one data point!");
     PLSSVM_ASSERT(!buffer.empty(), "The buffer array may not be empty!");
 
     using namespace plssvm::operators;
@@ -270,7 +223,7 @@ void gpu_csvm<device_ptr_t, queue_t>::device_reduction(std::vector<device_ptr_ty
 
     if (buffer_d.size() > 1) {
         std::vector<real_type> ret(buffer.size());
-        for (typename std::vector<device_ptr_type<real_type>>::size_type device = 1; device < buffer_d.size(); ++device) {
+        for (typename std::vector<device_ptr_type>::size_type device = 1; device < buffer_d.size(); ++device) {
             device_synchronize(devices_[device]);
             buffer_d[device].copy_to_host(ret, 0, ret.size());
 
@@ -278,7 +231,7 @@ void gpu_csvm<device_ptr_t, queue_t>::device_reduction(std::vector<device_ptr_ty
         }
 
         #pragma omp parallel for default(none) shared(buffer_d, buffer)
-        for (typename std::vector<device_ptr_type<real_type>>::size_type device = 0; device < buffer_d.size(); ++device) {
+        for (typename std::vector<device_ptr_type>::size_type device = 0; device < buffer_d.size(); ++device) {
             buffer_d[device].copy_to_device(buffer, 0, buffer.size());
         }
     }
@@ -288,14 +241,13 @@ void gpu_csvm<device_ptr_t, queue_t>::device_reduction(std::vector<device_ptr_ty
 //                        fit                        //
 //***************************************************//
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-::plssvm::detail::simple_any gpu_csvm<device_ptr_t, queue_t>::setup_data_on_devices_impl(const solver_type solver, const aos_matrix<real_type> &A) const {
+::plssvm::detail::simple_any gpu_csvm<device_ptr_t, queue_t>::setup_data_on_devices(const solver_type solver, const aos_matrix<real_type> &A) const {
     PLSSVM_ASSERT(!A.empty(), "The matrix to setup on the devices may not be empty!");
     PLSSVM_ASSERT(solver != solver_type::automatic, "An explicit solver type must be provided instead of solver_type::automatic!");
 
     if (solver == solver_type::cg_explicit) {
         // initialize the data on the device
-        device_ptr_type<real_type> data_d{ A.shape() };  // TODO: don't copy last data point to device?
+        device_ptr_type data_d{ A.shape() };  // TODO: don't copy last data point to device?
         data_d.copy_to_device(A.data());
 
         return ::plssvm::detail::simple_any{ std::move(data_d) };
@@ -306,14 +258,13 @@ template <typename real_type>
 }
 
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-::plssvm::detail::simple_any gpu_csvm<device_ptr_t, queue_t>::assemble_kernel_matrix_impl(const solver_type solver, const ::plssvm::detail::parameter<real_type> &params, const ::plssvm::detail::simple_any &data, const std::vector<real_type> &q_red, real_type QA_cost) const {
+::plssvm::detail::simple_any gpu_csvm<device_ptr_t, queue_t>::assemble_kernel_matrix(const solver_type solver, const ::plssvm::detail::parameter<real_type> &params, const ::plssvm::detail::simple_any &data, const std::vector<real_type> &q_red, real_type QA_cost) const {
     PLSSVM_ASSERT(!q_red.empty(), "The q_red vector may not be empty!");
     PLSSVM_ASSERT(solver != solver_type::automatic, "An explicit solver type must be provided instead of solver_type::automatic!");
 
     if (solver == solver_type::cg_explicit) {
         // get the pointer to the data that already is on the device
-        const device_ptr_type<real_type> &data_d = data.get<device_ptr_type<real_type>>();
+        const device_ptr_type &data_d = data.get<device_ptr_type>();
         const std::size_t num_rows_reduced = data_d.size(0) - 1;
         const std::size_t num_features = data_d.size(1);
 
@@ -324,9 +275,9 @@ template <typename real_type>
                       data_d.size(), (num_rows_reduced + 1) * num_features);
 
         // allocate memory for the values currently not on the device
-        device_ptr_type<real_type> q_red_d{ q_red.size() };
+        device_ptr_type q_red_d{ q_red.size() };
         q_red_d.copy_to_device(q_red);
-        device_ptr_type<real_type> kernel_matrix = this->run_assemble_kernel_matrix_explicit(params, data_d, q_red_d, QA_cost);
+        device_ptr_type kernel_matrix = this->run_assemble_kernel_matrix_explicit(params, data_d, q_red_d, QA_cost);
 
         PLSSVM_ASSERT(num_rows_reduced * num_rows_reduced == kernel_matrix.size(),
                       "The kernel matrix must be a quadratic matrix with num_rows_reduced^2 ({}) entries, but is {}!",
@@ -340,28 +291,27 @@ template <typename real_type>
 }
 
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-void gpu_csvm<device_ptr_t, queue_t>::blas_gemm_impl(const solver_type solver, const real_type alpha, const ::plssvm::detail::simple_any &A, const aos_matrix<real_type> &B, const real_type beta, aos_matrix<real_type> &C) const {
+void gpu_csvm<device_ptr_t, queue_t>::blas_gemm(const solver_type solver, const real_type alpha, const ::plssvm::detail::simple_any &A, const aos_matrix<real_type> &B, const real_type beta, aos_matrix<real_type> &C) const {
     PLSSVM_ASSERT(!B.empty(), "The B matrix may not be empty!");
     PLSSVM_ASSERT(!C.empty(), "The C matrix may not be empty!");
     PLSSVM_ASSERT(solver != solver_type::automatic, "An explicit solver type must be provided instead of solver_type::automatic!");
 
     if (solver == solver_type::cg_explicit) {
-        const device_ptr_type<real_type> &A_d = A.get<device_ptr_type<real_type>>();
+        const device_ptr_type &A_d = A.get<device_ptr_type>();
         PLSSVM_ASSERT(!A_d.empty(), "The A matrix may not be empty!");
 
         const std::size_t num_rhs = B.num_rows();
         const std::size_t num_rows = B.num_cols();
 
         // allocate memory on the device
-        static device_ptr_type<real_type> B_d{ B.shape() };
+        static device_ptr_type B_d{ B.shape() };
         if (B_d.size() != B.num_entries()) {
-            B_d = device_ptr_type<real_type>{ B.shape() };
+            B_d = device_ptr_type{ B.shape() };
         }
         B_d.copy_to_device(B.data());
-        static device_ptr_type<real_type> C_d{ C.shape() };
+        static device_ptr_type C_d{ C.shape() };
         if (C_d.size() != C.num_entries()) {
-            C_d = device_ptr_type<real_type>{ C.shape() };
+            C_d = device_ptr_type{ C.shape() };
         }
         C_d.copy_to_device(C.data());
 
@@ -378,19 +328,18 @@ void gpu_csvm<device_ptr_t, queue_t>::blas_gemm_impl(const solver_type solver, c
 //                   predict, score                  //
 //***************************************************//
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-std::vector<real_type> gpu_csvm<device_ptr_t, queue_t>::calculate_w(const std::vector<device_ptr_type<real_type>> &data_d,
-                                                                    const std::vector<device_ptr_type<real_type>> &data_last_d,
-                                                                    const std::vector<device_ptr_type<real_type>> &alpha_d,
+std::vector<real_type> gpu_csvm<device_ptr_t, queue_t>::calculate_w(const std::vector<device_ptr_type> &data_d,
+                                                                    const std::vector<device_ptr_type> &data_last_d,
+                                                                    const std::vector<device_ptr_type> &alpha_d,
                                                                     const std::size_t num_data_points,
                                                                     const std::vector<std::size_t> &feature_ranges) const {
     PLSSVM_ASSERT(!data_d.empty(), "The data_d array may not be empty!");
-    PLSSVM_ASSERT(std::all_of(data_d.cbegin(), data_d.cend(), [](const device_ptr_type<real_type> &ptr) { return !ptr.empty(); }), "Each device_ptr in data_d must at least contain one data point!");
+    PLSSVM_ASSERT(std::all_of(data_d.cbegin(), data_d.cend(), [](const device_ptr_type &ptr) { return !ptr.empty(); }), "Each device_ptr in data_d must at least contain one data point!");
     PLSSVM_ASSERT(!data_last_d.empty(), "The data_last_d array may not be empty!");
-    PLSSVM_ASSERT(std::all_of(data_last_d.cbegin(), data_last_d.cend(), [](const device_ptr_type<real_type> &ptr) { return !ptr.empty(); }), "Each device_ptr in data_last_d must at least contain one data point!");
+    PLSSVM_ASSERT(std::all_of(data_last_d.cbegin(), data_last_d.cend(), [](const device_ptr_type &ptr) { return !ptr.empty(); }), "Each device_ptr in data_last_d must at least contain one data point!");
     PLSSVM_ASSERT(data_d.size() == data_last_d.size(), "The number of used devices to the data_d and data_last_d vectors must be equal!: {} != {}", data_d.size(), data_last_d.size());
     PLSSVM_ASSERT(!alpha_d.empty(), "The alpha_d array may not be empty!");
-    PLSSVM_ASSERT(std::all_of(alpha_d.cbegin(), alpha_d.cend(), [](const device_ptr_type<real_type> &ptr) { return !ptr.empty(); }), "Each device_ptr in alpha_d must at least contain one data point!");
+    PLSSVM_ASSERT(std::all_of(alpha_d.cbegin(), alpha_d.cend(), [](const device_ptr_type &ptr) { return !ptr.empty(); }), "Each device_ptr in alpha_d must at least contain one data point!");
     PLSSVM_ASSERT(data_d.size() == alpha_d.size(), "The number of used devices to the data_d and alpha_d vectors must be equal!: {} != {}", data_d.size(), alpha_d.size());
     PLSSVM_ASSERT(num_data_points > 0, "At least one data point must be used to calculate q!");
     PLSSVM_ASSERT(feature_ranges.size() == data_d.size() + 1, "The number of values in the feature_range vector must be exactly one more than the number of used devices!: {} != {} + 1", feature_ranges.size(), data_d.size());
@@ -407,7 +356,7 @@ std::vector<real_type> gpu_csvm<device_ptr_t, queue_t>::calculate_w(const std::v
         const std::size_t num_features_in_range = feature_ranges[device + 1] - feature_ranges[device];
 
         // create the w vector on the device
-        device_ptr_type<real_type> w_d = device_ptr_type<real_type>{ num_features_in_range, devices_[device] };
+        device_ptr_type w_d = device_ptr_type{ num_features_in_range, devices_[device] };
 
         const detail::execution_range range({ static_cast<std::size_t>(std::ceil(static_cast<real_type>(num_features_in_range) / static_cast<real_type>(THREAD_BLOCK_SIZE))) },
                                             { std::min<std::size_t>(THREAD_BLOCK_SIZE, num_features_in_range) });
@@ -423,8 +372,7 @@ std::vector<real_type> gpu_csvm<device_ptr_t, queue_t>::calculate_w(const std::v
 }
 
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-void gpu_csvm<device_ptr_t, queue_t>::run_device_kernel(const std::size_t device, const parameter<real_type> &params, const device_ptr_type<real_type> &q_d, device_ptr_type<real_type> &r_d, const device_ptr_type<real_type> &x_d, const device_ptr_type<real_type> &data_d, const std::vector<std::size_t> &feature_ranges, const real_type QA_cost, const real_type add, const std::size_t dept, const std::size_t boundary_size) const {
+void gpu_csvm<device_ptr_t, queue_t>::run_device_kernel(const std::size_t device, const parameter<real_type> &params, const device_ptr_type &q_d, device_ptr_type &r_d, const device_ptr_type &x_d, const device_ptr_type &data_d, const std::vector<std::size_t> &feature_ranges, const real_type QA_cost, const real_type add, const std::size_t dept, const std::size_t boundary_size) const {
     PLSSVM_ASSERT(device < devices_.size(), "Requested device {}, but only {} device(s) are available!", device, devices_.size());
     PLSSVM_ASSERT(!q_d.empty(), "The q_d device_ptr may not be empty!");
     PLSSVM_ASSERT(!r_d.empty(), "The r_d device_ptr may not be empty!");
@@ -442,8 +390,7 @@ void gpu_csvm<device_ptr_t, queue_t>::run_device_kernel(const std::size_t device
 
 
 template <template <typename> typename device_ptr_t, typename queue_t>
-template <typename real_type>
-aos_matrix<real_type> gpu_csvm<device_ptr_t, queue_t>::predict_values_impl(const parameter<real_type> &params,
+aos_matrix<real_type> gpu_csvm<device_ptr_t, queue_t>::predict_values(const parameter<real_type> &params,
                                                                                    const aos_matrix<real_type> &support_vectors,
                                                                                    const aos_matrix<real_type> &alpha,
                                                                                    const std::vector<real_type> &rho,
@@ -466,15 +413,15 @@ aos_matrix<real_type> gpu_csvm<device_ptr_t, queue_t>::predict_values_impl(const
     const std::size_t num_predict_points = predict_points.num_rows();
     const std::size_t num_features = predict_points.num_cols();
 
-    device_ptr_type<real_type> sv_d{ num_support_vectors * num_features };
+    device_ptr_type sv_d{ num_support_vectors * num_features };
     sv_d.copy_to_device(support_vectors.data());
-    device_ptr_type<real_type> predict_points_d{ num_predict_points * num_features };
+    device_ptr_type predict_points_d{ num_predict_points * num_features };
     predict_points_d.copy_to_device(predict_points.data());
 
-    device_ptr_type<real_type> w_d;  // only used when predicting linear kernel functions
-    device_ptr_type<real_type> alpha_d{ num_classes * num_support_vectors };
+    device_ptr_type w_d;  // only used when predicting linear kernel functions
+    device_ptr_type alpha_d{ num_classes * num_support_vectors };
     alpha_d.copy_to_device(alpha.data());
-    device_ptr_type<real_type> rho_d{ num_classes };
+    device_ptr_type rho_d{ num_classes };
     rho_d.copy_to_device(rho);
 
     if (params.kernel_type == kernel_function_type::linear) {
@@ -488,13 +435,13 @@ aos_matrix<real_type> gpu_csvm<device_ptr_t, queue_t>::predict_values_impl(const
             w_d.copy_to_host(w.data());
         } else {
             // w already provided -> copy to device
-            w_d = device_ptr_type<real_type>{ num_classes * num_features };
+            w_d = device_ptr_type{ num_classes * num_features };
             w_d.copy_to_device(w.data());
         }
     }
 
     // predict
-    const device_ptr_type<real_type> out_d = run_predict_kernel(params, w_d, alpha_d, rho_d, sv_d, predict_points_d, num_classes, num_support_vectors, num_predict_points, num_features);;
+    const device_ptr_type out_d = run_predict_kernel(params, w_d, alpha_d, rho_d, sv_d, predict_points_d, num_classes, num_support_vectors, num_predict_points, num_features);;
 
     // copy results back to host
     aos_matrix<real_type> out_ret{ num_predict_points, num_classes };

--- a/include/plssvm/constants.hpp
+++ b/include/plssvm/constants.hpp
@@ -13,6 +13,8 @@
 #define PLSSVM_CONSTANTS_HPP_
 #pragma once
 
+#include "plssvm/detail/type_list.hpp"  // plssvm::detail::type_list_contains_v
+
 #include <type_traits>  // std::is_same_v
 
 namespace plssvm {
@@ -50,7 +52,7 @@ constexpr kernel_index_type OPENMP_BLOCK_SIZE = 64;
 #endif
 
 // perform sanity checks
-static_assert(std::is_same_v<real_type, float> || std::is_same_v<real_type, double>, "the real_type must either be float or double!");
+static_assert(detail::type_list_contains_v<real_type, detail::real_type_list>, "Illegal real type provided! See the 'real_type_list' in the type_list.hpp header for a list of the allowed types.");
 static_assert(THREAD_BLOCK_SIZE > 0, "THREAD_BLOCK_SIZE must be greater than 0!");
 static_assert(INTERNAL_BLOCK_SIZE > 0, "INTERNAL_BLOCK_SIZE must be greater than 0!");
 static_assert(OPENMP_BLOCK_SIZE > 0, "OPENMP_BLOCK_SIZE must be greater than 0!");

--- a/include/plssvm/constants.hpp
+++ b/include/plssvm/constants.hpp
@@ -22,7 +22,6 @@ namespace plssvm {
 /// Integer type used inside kernels.
 using kernel_index_type = int;  // TODO: remove and replace by backend specific type?
 
-// TODO: implement in CMake
 /// The used floating point type. May be changed during the CMake configuration step.
 #if defined(PLSSVM_FLOAT_AS_REAL_TYPE)
 using real_type = float;

--- a/include/plssvm/constants.hpp
+++ b/include/plssvm/constants.hpp
@@ -13,10 +13,20 @@
 #define PLSSVM_CONSTANTS_HPP_
 #pragma once
 
+#include <type_traits>  // std::is_same_v
+
 namespace plssvm {
 
 /// Integer type used inside kernels.
 using kernel_index_type = int;  // TODO: remove and replace by backend specific type?
+
+// TODO: implement in CMake
+/// The used floating point type. May be changed during the CMake configuration step.
+#if defined(PLSSVM_FLOAT_AS_REAL_TYPE)
+using real_type = float;
+#else
+using real_type = double;
+#endif
 
 /// Global compile-time constant used for internal caching. May be changed during the CMake configuration step.
 #if defined(PLSSVM_THREAD_BLOCK_SIZE)
@@ -40,6 +50,7 @@ constexpr kernel_index_type OPENMP_BLOCK_SIZE = 64;
 #endif
 
 // perform sanity checks
+static_assert(std::is_same_v<real_type, float> || std::is_same_v<real_type, double>, "the real_type must either be float or double!");
 static_assert(THREAD_BLOCK_SIZE > 0, "THREAD_BLOCK_SIZE must be greater than 0!");
 static_assert(INTERNAL_BLOCK_SIZE > 0, "INTERNAL_BLOCK_SIZE must be greater than 0!");
 static_assert(OPENMP_BLOCK_SIZE > 0, "OPENMP_BLOCK_SIZE must be greater than 0!");

--- a/include/plssvm/csvm.hpp
+++ b/include/plssvm/csvm.hpp
@@ -134,7 +134,7 @@ class csvm {
      * @return the learned model (`[[nodiscard]]`)
      */
     template <typename label_type, typename... Args>
-    [[nodiscard]] model<label_type> fit(const data_set<label_type> &data, Args &&...named_args);
+    [[nodiscard]] model<label_type> fit(const data_set<label_type> &data, Args &&...named_args) const;
 
     //*************************************************************************************************************************************//
     //                                                          predict and score                                                          //
@@ -322,7 +322,7 @@ void csvm::set_params(Args &&...named_args) {
 }
 
 template <typename label_type, typename... Args>
-model<label_type> csvm::fit(const data_set<label_type> &data, Args &&...named_args) {
+model<label_type> csvm::fit(const data_set<label_type> &data, Args &&...named_args) const {
     if (!data.has_labels()) {
         throw invalid_parameter_exception{ "No labels given for training! Maybe the data is only usable for prediction?" };
     }

--- a/include/plssvm/csvm.hpp
+++ b/include/plssvm/csvm.hpp
@@ -357,7 +357,7 @@ model<label_type> csvm::fit(const data_set<label_type> &data, Args &&...named_ar
     parameter params{ params_ };
     if (params.gamma.is_default()) {
         // no gamma provided -> use default value which depends on the number of features in the data set
-        params.gamma = 1.0 / data.num_features();
+        params.gamma = real_type{ 1.0 } / data.num_features();
     }
 
     // create model

--- a/include/plssvm/detail/cmd/data_set_variants.hpp
+++ b/include/plssvm/detail/cmd/data_set_variants.hpp
@@ -13,7 +13,6 @@
 #define PLSSVM_DETAIL_CMD_DATA_SET_VARIANTS_HPP_
 #pragma once
 
-#include "plssvm/constants.hpp"                  // plssvm::real_type
 #include "plssvm/data_set.hpp"                   // plssvm::data_set
 #include "plssvm/detail/cmd/parser_predict.hpp"  // plssvm::detail::cmd::parser_predict
 #include "plssvm/detail/cmd/parser_scale.hpp"    // plssvm::detail::cmd::parser_scale
@@ -28,7 +27,7 @@ namespace plssvm::detail::cmd {
 /**
  * @brief Two different type combinations are allowed in the command line invocation: `real_type` + `int` and `real_type` + `std::string`.
  */
-using data_set_variants = std::variant<plssvm::data_set<real_type, int>, plssvm::data_set<real_type, std::string>>;
+using data_set_variants = std::variant<plssvm::data_set<int>, plssvm::data_set<std::string>>;
 // clang-format on
 
 /**
@@ -37,9 +36,9 @@ using data_set_variants = std::variant<plssvm::data_set<real_type, int>, plssvm:
  * @param[in] cmd_parser the provided command line parser
  * @return the data set type based on the provided command line parser (`[[nodiscard]]`)
  */
-template <typename label_type = typename data_set<real_type>::label_type>
+template <typename label_type = typename data_set<>::label_type>
 [[nodiscard]] inline data_set_variants data_set_factory_impl(const cmd::parser_train &cmd_parser) {
-    return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename } };
+    return data_set_variants{ plssvm::data_set<label_type>{ cmd_parser.input_filename } };
 }
 /**
  * @brief Return the correct data set type based on the plssvm::detail::cmd::parser_predict command line options.
@@ -47,9 +46,9 @@ template <typename label_type = typename data_set<real_type>::label_type>
  * @param[in] cmd_parser the provided command line parser
  * @return the data set type based on the provided command line parser (`[[nodiscard]]`)
  */
-template <typename label_type = typename data_set<real_type>::label_type>
+template <typename label_type = typename data_set<>::label_type>
 [[nodiscard]] inline data_set_variants data_set_factory_impl(const cmd::parser_predict &cmd_parser) {
-    return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename } };
+    return data_set_variants{ plssvm::data_set<label_type>{ cmd_parser.input_filename } };
 }
 /**
  * @brief Return the correct data set type based on the plssvm::detail::cmd::parser_scale command line options.
@@ -57,12 +56,12 @@ template <typename label_type = typename data_set<real_type>::label_type>
  * @param[in] cmd_parser the provided command line parser
  * @return the data set type based on the provided command line parser (`[[nodiscard]]`)
  */
-template <typename label_type = typename data_set<real_type>::label_type>
+template <typename label_type = typename data_set<>::label_type>
 [[nodiscard]] inline data_set_variants data_set_factory_impl(const cmd::parser_scale &cmd_parser) {
     if (!cmd_parser.restore_filename.empty()) {
-        return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename, { cmd_parser.restore_filename } } };
+        return data_set_variants{ plssvm::data_set<label_type>{ cmd_parser.input_filename, { cmd_parser.restore_filename } } };
     } else {
-        return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename, { static_cast<real_type>(cmd_parser.lower), static_cast<real_type>(cmd_parser.upper) } } };
+        return data_set_variants{ plssvm::data_set<label_type>{ cmd_parser.input_filename, { cmd_parser.lower, cmd_parser.upper } } };
     }
 }
 

--- a/include/plssvm/detail/cmd/data_set_variants.hpp
+++ b/include/plssvm/detail/cmd/data_set_variants.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_DETAIL_CMD_DATA_SET_VARIANTS_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"                  // plssvm::real_type
 #include "plssvm/data_set.hpp"                   // plssvm::data_set
 #include "plssvm/detail/cmd/parser_predict.hpp"  // plssvm::detail::cmd::parser_predict
 #include "plssvm/detail/cmd/parser_scale.hpp"    // plssvm::detail::cmd::parser_scale
@@ -25,43 +26,38 @@ namespace plssvm::detail::cmd {
 
 // clang-format off
 /**
- * @brief Four different type combinations are allowed in the command line invocation:
- *        `float` + `int`, `float` + `std::string`, `double` + `int`, and `double` + `std::string`.
+ * @brief Two different type combinations are allowed in the command line invocation: `real_type` + `int` and `real_type` + `std::string`.
  */
-using data_set_variants = std::variant<plssvm::data_set<float, int>, plssvm::data_set<float, std::string>,
-                                       plssvm::data_set<double, int>, plssvm::data_set<double, std::string>>;
+using data_set_variants = std::variant<plssvm::data_set<real_type, int>, plssvm::data_set<real_type, std::string>>;
 // clang-format on
 
 /**
  * @brief Return the correct data set type based on the plssvm::detail::cmd::parser_train command line options.
- * @tparam real_type the type of the data points
  * @tparam label_type the type of the labels
  * @param[in] cmd_parser the provided command line parser
  * @return the data set type based on the provided command line parser (`[[nodiscard]]`)
  */
-template <typename real_type, typename label_type = typename data_set<real_type>::label_type>
+template <typename label_type = typename data_set<real_type>::label_type>
 [[nodiscard]] inline data_set_variants data_set_factory_impl(const cmd::parser_train &cmd_parser) {
     return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename } };
 }
 /**
  * @brief Return the correct data set type based on the plssvm::detail::cmd::parser_predict command line options.
- * @tparam real_type the type of the data points
  * @tparam label_type the type of the labels
  * @param[in] cmd_parser the provided command line parser
  * @return the data set type based on the provided command line parser (`[[nodiscard]]`)
  */
-template <typename real_type, typename label_type = typename data_set<real_type>::label_type>
+template <typename label_type = typename data_set<real_type>::label_type>
 [[nodiscard]] inline data_set_variants data_set_factory_impl(const cmd::parser_predict &cmd_parser) {
     return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename } };
 }
 /**
  * @brief Return the correct data set type based on the plssvm::detail::cmd::parser_scale command line options.
- * @tparam real_type the type of the data points
  * @tparam label_type the type of the labels
  * @param[in] cmd_parser the provided command line parser
  * @return the data set type based on the provided command line parser (`[[nodiscard]]`)
  */
-template <typename real_type, typename label_type = typename data_set<real_type>::label_type>
+template <typename label_type = typename data_set<real_type>::label_type>
 [[nodiscard]] inline data_set_variants data_set_factory_impl(const cmd::parser_scale &cmd_parser) {
     if (!cmd_parser.restore_filename.empty()) {
         return data_set_variants{ plssvm::data_set<real_type, label_type>{ cmd_parser.input_filename, { cmd_parser.restore_filename } } };
@@ -78,16 +74,13 @@ template <typename real_type, typename label_type = typename data_set<real_type>
  */
 template <typename cmd_parser_type>
 [[nodiscard]] inline data_set_variants data_set_factory(const cmd_parser_type &cmd_parser) {
-    if (cmd_parser.float_as_real_type && cmd_parser.strings_as_labels) {
-        return data_set_factory_impl<float, std::string>(cmd_parser);
-    } else if (cmd_parser.float_as_real_type && !cmd_parser.strings_as_labels) {
-        return data_set_factory_impl<float>(cmd_parser);
-    } else if (!cmd_parser.float_as_real_type && cmd_parser.strings_as_labels) {
-        return data_set_factory_impl<double, std::string>(cmd_parser);
+    if (cmd_parser.strings_as_labels) {
+        return data_set_factory_impl<std::string>(cmd_parser);
     } else {
-        return data_set_factory_impl<double>(cmd_parser);
+        return data_set_factory_impl(cmd_parser);
     }
 }
+
 }  // namespace plssvm::detail::cmd
 
 #endif  // PLSSVM_DETAIL_CMD_DATA_SET_VARIANTS_HPP_

--- a/include/plssvm/detail/cmd/parser_predict.hpp
+++ b/include/plssvm/detail/cmd/parser_predict.hpp
@@ -45,8 +45,6 @@ class parser_predict {
 
     /// `true` if `std::string` should be used as label type instead of the default type `ìnt`.
     bool strings_as_labels{ false };
-    /// `true` if `float` should be used as real type instead of the default type `double`.
-    bool float_as_real_type{ false };
 
     /// The name of the data file to predict.
     std::string input_filename{};

--- a/include/plssvm/detail/cmd/parser_scale.hpp
+++ b/include/plssvm/detail/cmd/parser_scale.hpp
@@ -42,8 +42,6 @@ class parser_scale {
 
     /// `true` if `std::string` should be used as label type instead of the default type `ìnt`.
     bool strings_as_labels{ false };
-    /// `true` if `float` should be used as real type instead of the default type `double`.
-    bool float_as_real_type{ false };
 
     /// The name of the data file to scale.
     std::string input_filename{};

--- a/include/plssvm/detail/cmd/parser_scale.hpp
+++ b/include/plssvm/detail/cmd/parser_scale.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_DETAIL_CMD_PARSER_SCALE_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"          // plssvm::real_type
 #include "plssvm/file_format_types.hpp"  // plssvm::file_format_type
 
 #include <iosfwd>                        // forward declare std::ostream
@@ -34,9 +35,9 @@ class parser_scale {
     parser_scale(int argc, char **argv);
 
     /// The lower bound of the scaled data values.
-    double lower{ -1.0 };
+    real_type lower{ -1.0 };
     /// The upper bound of the scaled data values.
-    double upper{ +1.0 };
+    real_type upper{ +1.0 };
     /// The file type (currently either LIBSVM or ARFF) to which the scaled data should be written to.
     file_format_type format{ file_format_type::libsvm };
 

--- a/include/plssvm/detail/cmd/parser_train.hpp
+++ b/include/plssvm/detail/cmd/parser_train.hpp
@@ -17,6 +17,7 @@
 #include "plssvm/backends/SYCL/implementation_type.hpp"     // plssvm::sycl::implementation_type
 #include "plssvm/backends/SYCL/kernel_invocation_type.hpp"  // plssvm::sycl::kernel_invocation_type
 #include "plssvm/classification_types.hpp"                  // plssvm::classification_type
+#include "plssvm/constants.hpp"                             // plssvm::real_type
 #include "plssvm/default_value.hpp"                         // plssvm::default_value
 #include "plssvm/parameter.hpp"                             // plssvm::parameter
 #include "plssvm/solver_types.hpp"                          // plssvm::solving_type
@@ -45,7 +46,7 @@ class parser_train {
     plssvm::parameter csvm_params{};
 
     /// The error tolerance parameter for the CG algorithm.
-    default_value<double> epsilon{ default_init<double>{ 0.001 } };
+    default_value<real_type> epsilon{ default_init<real_type>{ 0.001 } };
     /// The maximum number of iterations in the CG algorithm.
     default_value<std::size_t> max_iter{ default_init<std::size_t>{ 0 } };
     /// The multi-class classification strategy used.

--- a/include/plssvm/detail/cmd/parser_train.hpp
+++ b/include/plssvm/detail/cmd/parser_train.hpp
@@ -65,8 +65,6 @@ class parser_train {
 
     /// `true` if `std::string` should be used as label type instead of the default type `ìnt`.
     bool strings_as_labels{ false };
-    /// `true` if `float` should be used as real type instead of the default type `double`.
-    bool float_as_real_type{ false };
 
     /// The name of the data/test file to parse.
     std::string input_filename{};

--- a/include/plssvm/detail/io/arff_parsing.hpp
+++ b/include/plssvm/detail/io/arff_parsing.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_DETAIL_IO_ARFF_PARSING_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"                 // plssvm::real_type
 #include "plssvm/detail/io/file_reader.hpp"     // plssvm::detail::io::file_reader
 #include "plssvm/detail/operators.hpp"          // plssvm::operator::sign
 #include "plssvm/detail/string_conversion.hpp"  // plssvm::detail::convert_to
@@ -216,7 +217,6 @@ template <typename label_type>
  * 0.57650218263054642,1.01405596624706053,0.13009428079760464,0.7261913886869387,-1
  * 1.88494043717792,1.00518564317278263,0.298499933047586044,1.6464627048813514,-1
  * @endcode
- * @tparam real_type the floating point type
  * @tparam label_type the type of the labels (any arithmetic type or std::string)
  * @param[in] reader the file_reader used to read the ARFF data
  * @note The features must be provided with zero-based indices!
@@ -233,7 +233,7 @@ template <typename label_type>
  * @throws plssvm::invalid_file_format_exception if a label in the data section has been found, that did not appear in the header
  * @return a std::tuple containing: [the number of data points, the number of features per data point, the data points, the labels (optional)] (`[[nodiscard]]`)
  */
-template <typename real_type, typename label_type>
+template <typename label_type>
 [[nodiscard]] inline std::tuple<std::size_t, std::size_t, aos_matrix<real_type>, std::vector<label_type>> parse_arff_data(const file_reader &reader) {
     PLSSVM_ASSERT(reader.is_open(), "The file_reader is currently not associated with a file!");
 
@@ -396,7 +396,6 @@ template <typename real_type, typename label_type>
  * 1.88494043717792,1.00518564317278263,0.298499933047586044,1.6464627048813514,-1
  * @endcode
  * Note that the output will always be dense, i.e., all features with a value of `0.0` are explicitly written in the resulting file.
- * @tparam real_type the floating point type
  * @tparam label_type the type of the labels (any arithmetic type or std::string)
  * @tparam has_label if `true` the provided labels are also written to the file, if `false` **no** labels are outputted
  * @param[in] filename the filename to write the data to
@@ -405,7 +404,7 @@ template <typename real_type, typename label_type>
  * @note The resulting order of the data points in the ARFF file is unspecified!
  * @note The features are written using zero-based indices!
  */
-template <typename real_type, typename label_type, bool has_label>
+template <typename label_type, bool has_label>
 inline void write_arff_data_impl(const std::string &filename, const aos_matrix<real_type> &data, const std::vector<label_type> &label) {
     if constexpr (has_label) {
         PLSSVM_ASSERT(data.empty() || !label.empty(), "has_label is 'true' but no labels were provided!");
@@ -484,7 +483,6 @@ inline void write_arff_data_impl(const std::string &filename, const aos_matrix<r
  * 1.88494043717792,1.00518564317278263,0.298499933047586044,1.6464627048813514,-1
  * @endcode
  * Note that the output will always be dense, i.e., all features with a value of `0.0` are explicitly written in the resulting file.
- * @tparam real_type the floating point type
  * @tparam label_type the type of the labels (any arithmetic type or std::string)
  * @param[in] filename the filename to write the data to
  * @param[in] data the data points to write to the file
@@ -492,9 +490,9 @@ inline void write_arff_data_impl(const std::string &filename, const aos_matrix<r
  * @note The resulting order of the data points in the ARFF file is unspecified!
  * @note The features are written using zero-based indices!
  */
-template <typename real_type, typename label_type>
+template <typename label_type>
 inline void write_arff_data(const std::string &filename, const aos_matrix<real_type> &data, const std::vector<label_type> &label) {
-    write_arff_data_impl<real_type, label_type, true>(filename, data, label);
+    write_arff_data_impl<label_type, true>(filename, data, label);
 }
 
 /**
@@ -516,15 +514,13 @@ inline void write_arff_data(const std::string &filename, const aos_matrix<real_t
  * 1.88494043717792,1.00518564317278263,0.298499933047586044,1.6464627048813514
  * @endcode
  * Note that the output will always be dense, i.e., all features with a value of `0.0` are explicitly written in the resulting file.
- * @tparam real_type the floating point type
  * @param[in] filename the filename to write the data to
  * @param[in] data the data points to write to the file
  * @note The resulting order of the data points in the ARFF file is unspecified!
  * @note The features are written using zero-based indices!
  */
-template <typename real_type>
 inline void write_arff_data(const std::string &filename, const aos_matrix<real_type> &data) {
-    write_arff_data_impl<real_type, real_type, false>(filename, data, {});
+    write_arff_data_impl<real_type, false>(filename, data, {});
 }
 
 }  // namespace plssvm::detail::io

--- a/include/plssvm/detail/io/libsvm_model_parsing.hpp
+++ b/include/plssvm/detail/io/libsvm_model_parsing.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "plssvm/classification_types.hpp"      // plssvm::classification_type
+#include "plssvm/constants.hpp"                 // plssvm::real_type
 #include "plssvm/data_set.hpp"                  // plssvm::data_set
 #include "plssvm/detail/assert.hpp"             // PLSSVM_ASSERT
 #include "plssvm/detail/io/libsvm_parsing.hpp"  // plssvm::detail::io::parse_libsvm_num_features
@@ -100,7 +101,6 @@ namespace plssvm::detail::io {
  * nr_sv 4 2 2
  * SV
  * @endcode
- * @tparam real_type the floating point type
  * @tparam label_type the type of the labels (any arithmetic type, except bool, or std::string)
  * @tparam size_type the size type
  * @param[in] lines the LIBSVM model file header to parse>
@@ -126,7 +126,7 @@ namespace plssvm::detail::io {
  * @attention The PLSSVM model file is only compatible with LIBSVM for the one vs. one classification type.
  * @return the necessary header information: [the SVM parameter, the values of rho, the labels, the different classes, num_header_lines] (`[[nodiscard]]`)
  */
-template <typename real_type, typename label_type, typename size_type>
+template <typename label_type, typename size_type>
 [[nodiscard]] inline std::tuple<plssvm::parameter, std::vector<real_type>, std::vector<label_type>, std::vector<label_type>, std::vector<size_type>, std::size_t> parse_libsvm_model_header(const std::vector<std::string_view> &lines) {
     // data to read
     plssvm::parameter params{};
@@ -326,7 +326,6 @@ template <typename real_type, typename label_type, typename size_type>
  * 1.2048548972e+00 -4.5199224962e-02 -9.1864283628e-01 1:5.6054664148e-02 2:6.6037150647e-01 3:2.6221749918e-01 4:3.7216083001e-02
  * -6.9331414578e-01 4.0173372861e-01 8.7072111162e-01 1:2.3912649397e-02 2:3.4604367826e-01 3:-2.5696199624e-01 4:6.0591633490e-01
  * @endcode
- * @tparam real_type the floating point type
  * @param[in] reader the file_reader used to read the LIBSVM data
  * @param[in] num_sv_per_class the number of support vectors per class
  * @param[in] skipped_lines the number of lines that should be skipped at the beginning
@@ -341,7 +340,6 @@ template <typename real_type, typename label_type, typename size_type>
  * @attention The PLSSVM model file is only compatible with LIBSVM for the one vs. one classification type.
  * @return a std::tuple containing: [num_data_points, num_features, data_points, labels, classification type] (`[[nodiscard]]`)
  */
-template <typename real_type>
 [[nodiscard]] inline std::tuple<std::size_t, std::size_t, aos_matrix<real_type>, std::vector<aos_matrix<real_type>>, classification_type> parse_libsvm_model_data(const file_reader &reader, const std::vector<std::size_t> &num_sv_per_class, const std::size_t skipped_lines) {
     PLSSVM_ASSERT(reader.is_open(), "The file_reader is currently not associated with a file!");
     PLSSVM_ASSERT(num_sv_per_class.size() > 1, "At least two classes must be present!");
@@ -525,7 +523,6 @@ template <typename real_type>
  * nr_sv 4 2 2
  * SV
  * @endcode
- * @tparam real_type the floating point type
  * @tparam label_type the type of the labels (any arithmetic type, except bool, or std::string)
  * @param[in,out] out the output-stream to write the header information to
  * @param[in] params the SVM parameters
@@ -533,8 +530,8 @@ template <typename real_type>
  * @param[in] data the data used to create the model
  * @attention The PLSSVM model file is only compatible with LIBSVM for the one vs. one classification type.
  */
-template <typename real_type, typename label_type>
-inline std::vector<label_type> write_libsvm_model_header(fmt::ostream &out, const plssvm::parameter &params, const std::vector<real_type> &rho, const data_set<real_type, label_type> &data) {
+template <typename label_type>
+inline std::vector<label_type> write_libsvm_model_header(fmt::ostream &out, const plssvm::parameter &params, const std::vector<real_type> &rho, const data_set<label_type> &data) {
     PLSSVM_ASSERT(data.has_labels(), "Cannot write a model file that does not include labels!");
 
     // save model file header
@@ -562,7 +559,7 @@ inline std::vector<label_type> write_libsvm_model_header(fmt::ostream &out, cons
     }
     // fill vector with number of occurrences in correct order
     std::vector<std::size_t> label_counts(data.num_classes());
-    for (typename data_set<real_type, label_type>::size_type i = 0; i < data.num_classes(); ++i) {
+    for (typename data_set<label_type>::size_type i = 0; i < data.num_classes(); ++i) {
         label_counts[i] = label_counts_map[label_values[i]];
     }
 
@@ -604,7 +601,6 @@ inline std::vector<label_type> write_libsvm_model_header(fmt::ostream &out, cons
  * 1.2048548972e+00 -4.5199224962e-02 -9.1864283628e-01 1:5.6054664148e-02 2:6.6037150647e-01 3:2.6221749918e-01 4:3.7216083001e-02
  * -6.9331414578e-01 4.0173372861e-01 8.7072111162e-01 1:2.3912649397e-02 2:3.4604367826e-01 3:-2.5696199624e-01 4:6.0591633490e-01
  * @endcode
- * @tparam real_type the floating point type
  * @tparam label_type the type of the labels (any arithmetic type, except bool, or std::string)
  * @param[in] filename the file to write the LIBSVM model to
  * @param[in] params the SVM parameters
@@ -615,8 +611,8 @@ inline std::vector<label_type> write_libsvm_model_header(fmt::ostream &out, cons
  * @param[in] support_vectors the support vectors (no access to private member of plssvm::data_set in this function -> must be explicitly passed as parameter)
  * @attention The PLSSVM model file is only compatible with LIBSVM for the one vs. one classification type.
  */
-template <typename real_type, typename label_type>
-inline void write_libsvm_model_data(const std::string &filename, const plssvm::parameter &params, const classification_type classification, const std::vector<real_type> &rho, const std::vector<aos_matrix<real_type>> &alpha, const std::vector<std::vector<std::size_t>> &indices, const data_set<real_type, label_type> &data, const aos_matrix<real_type> &support_vectors) {
+template <typename label_type>
+inline void write_libsvm_model_data(const std::string &filename, const plssvm::parameter &params, const classification_type classification, const std::vector<real_type> &rho, const std::vector<aos_matrix<real_type>> &alpha, const std::vector<std::vector<std::size_t>> &indices, const data_set<label_type> &data, const aos_matrix<real_type> &support_vectors) {
     PLSSVM_ASSERT(data.has_labels(), "Cannot write a model file that does not include labels!");
     PLSSVM_ASSERT(rho.size() == calculate_number_of_classifiers(classification, data.num_classes()),
                   "The number of different labels is {} (nr_class). Therefore, the number of rho values must either be {} (one vs. all) or {} (one vs. vs), but is {}!",

--- a/include/plssvm/detail/io/scaling_factors_parsing.hpp
+++ b/include/plssvm/detail/io/scaling_factors_parsing.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_DETAIL_IO_SCALING_FACTORS_PARSING_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"                 // plssvm::real_type
 #include "plssvm/detail/assert.hpp"             // PLSSVM_ASSERT
 #include "plssvm/detail/utility.hpp"            // plssvm:detail::current_date_time
 #include "plssvm/detail/io/file_reader.hpp"     // plssvm::detail::io::file_reader
@@ -43,7 +44,6 @@ namespace plssvm::detail::io {
  * 4 0.10805254527169827 1.6464627048813514
  * @endcode
  * Note that the scaling factors are given using an one-based indexing scheme, but are internally stored using zero-based indexing.
- * @tparam real_type the used floating point type
  * @tparam factors_type plssvm::data_set<real_type>::scaling::factors (cannot be forward declared or included)
  * @param[in] reader the file_reader used to read the scaling factors
  * @throws plssvm::invalid_file_format_exception if the header is omitted ('x' and the scaling interval)
@@ -53,7 +53,7 @@ namespace plssvm::detail::io {
  * @throws plssvm::invalid_file_format_exception if the scaling factors feature index is zero-based instead of one-based
  * @return the read scaling interval and factors (`[[nodiscard]]`)
  */
-template <typename real_type, typename factors_type>
+template <typename factors_type>
 [[nodiscard]] inline std::tuple<std::pair<real_type, real_type>, std::vector<factors_type>> parse_scaling_factors(const file_reader &reader) {
     PLSSVM_ASSERT(reader.is_open(), "The file_reader is currently not associated with a file!");
 
@@ -129,13 +129,12 @@ template <typename real_type, typename factors_type>
  * 3 -0.13086851759108944 0.6663834427003914
  * 4 0.10805254527169827 1.6464627048813514
  * @endcode
- * @tparam real_type the used floating point type
  * @tparam factors_type plssvm::data_set<real_type>::scaling::factors (cannot be forward declared or included)
  * @param[in] filename the filename to write the data to
  * @param[in] scaling_interval the valid scaling interval, i.e., [first, second]
  * @param[in] scaling_factors the scaling factor for each feature; given **zero** based, but written to file **one** based!
  */
-template <typename real_type, typename factors_type>
+template <typename factors_type>
 inline void write_scaling_factors(const std::string &filename, const std::pair<real_type, real_type> &scaling_interval, const std::vector<factors_type> &scaling_factors) {
     PLSSVM_ASSERT(scaling_interval.first < scaling_interval.second, "Illegal interval specification: lower ({}) < upper ({}).", scaling_interval.first, scaling_interval.second);
 

--- a/include/plssvm/detail/performance_tracker.hpp
+++ b/include/plssvm/detail/performance_tracker.hpp
@@ -17,6 +17,10 @@
 #include "plssvm/parameter.hpp"           // plssvm::parameter
 #include "plssvm/detail/type_traits.hpp"  // plssvm::detail::remove_cvref_t
 
+#include "plssvm/detail/cmd/parser_train.hpp"    // plssvm::detail::cmd::parser_train
+#include "plssvm/detail/cmd/parser_predict.hpp"  // plssvm::detail::cmd::parser_predict
+#include "plssvm/detail/cmd/parser_scale.hpp"    // plssvm::detail::cmd::parser_scale
+
 #include "fmt/chrono.h"                   // format std::chrono types
 #include "fmt/format.h"                   // fmt::format, fmt::join
 #include "fmt/ostream.h"                         // format types with an operator<< overload
@@ -29,15 +33,6 @@
 #include <utility>                        // std::move
 
 namespace plssvm::detail {
-
-// forward declare cmd parser
-namespace cmd {
-
-class parser_train;
-class parser_predict;
-class parser_scale;
-
-}
 
 /**
  * @brief A single tracking entry containing a specific category, a unique name, and the actual value to be tracked.

--- a/include/plssvm/detail/performance_tracker.hpp
+++ b/include/plssvm/detail/performance_tracker.hpp
@@ -146,7 +146,7 @@ class performance_tracker {
      *          Adds all values stored in the plssvm::parameter as tracking entries.
      * @param[in] entry the entry to add
      */
-    void add_tracking_entry(const tracking_entry<::plssvm::parameter> &entry);
+    void add_tracking_entry(const tracking_entry<plssvm::parameter> &entry);
     /**
      * @brief Add a tracking_entry encapsulating a plssvm::detail::cmd::parser_train to this performance tracker.
      * @details Saves a string containing the entry name and value in a map with the entry category as key.

--- a/include/plssvm/kernel_function_types.hpp
+++ b/include/plssvm/kernel_function_types.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_KERNEL_FUNCTION_TYPES_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"              // plssvm::real_type
 #include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT
 #include "plssvm/detail/operators.hpp"       // dot product, plssvm::squared_euclidean_dist
 #include "plssvm/detail/type_traits.hpp"     // plssvm::detail::always_false_v
@@ -67,14 +68,13 @@ std::istream &operator>>(std::istream &in, kernel_function_type &kernel);
 /**
  * @brief Computes the value of the two vectors @p xi and @p xj using the @p kernel function determined at compile-time.
  * @tparam kernel the type of the kernel
- * @tparam real_type the type of the values
  * @tparam Args additional parameters used in the respective kernel function
  * @param[in] xi the first vector
  * @param[in] xj the second vector
  * @param[in] args additional parameters
  * @return the value computed by the @p kernel function (`[[nodiscard]]`)
  */
-template <kernel_function_type kernel, typename real_type, typename... Args>
+template <kernel_function_type kernel, typename... Args>
 [[nodiscard]] inline real_type kernel_function(const std::vector<real_type> &xi, const std::vector<real_type> &xj, Args &&...args) {
     using namespace plssvm::operators;
 
@@ -110,32 +110,26 @@ template <kernel_function_type kernel, typename real_type, typename... Args>
         }
         return std::exp(-gamma * temp);
     } else {
-        static_assert(detail::always_false_v<real_type>, "Unknown kernel type!");
+        static_assert(detail::always_false_v<Args...>, "Unknown kernel type!");
     }
 }
 
 // forward declare parameter class
-namespace detail {
-template <typename>
 struct parameter;
-}
 
 /**
  * @brief Computes the value of the two vectors @p xi and @p xj using the kernel function and kernel parameter stored in @p params.
- * @tparam real_type the type of the values
  * @param[in] xi the first vector
  * @param[in] xj the second vector
  * @param[in] params class encapsulating the kernel type and kernel parameters
  * @throws plssvm::unsupported_kernel_type_exception if the kernel function in @p params is not supported
  * @return the computed kernel function value (`[[nodiscard]]`)
  */
-template <typename real_type>
-[[nodiscard]] real_type kernel_function(const std::vector<real_type> &xi, const std::vector<real_type> &xj, const detail::parameter<real_type> &params);
+[[nodiscard]] real_type kernel_function(const std::vector<real_type> &xi, const std::vector<real_type> &xj, const parameter &params);
 
 /**
  * @brief Computes the value of the two matrix rows @p i in @p x and @p j in @p y using the @p kernel function determined at compile-time.
  * @tparam kernel the type of the kernel
- * @tparam real_type the type of the values
  * @tparam layout the layout type of the two matrices
  * @tparam Args additional parameters used in the respective kernel function
  * @param[in] x the first matrix
@@ -145,7 +139,7 @@ template <typename real_type>
  * @param[in] args additional parameters
  * @return the value computed by the @p kernel function (`[[nodiscard]]`)
  */
-template <kernel_function_type kernel, typename real_type, layout_type layout, typename... Args>
+template <kernel_function_type kernel, layout_type layout, typename... Args>
 [[nodiscard]] real_type kernel_function(const matrix<real_type, layout> &x, const std::size_t i, const matrix<real_type, layout> &y, const std::size_t j, Args &&...args) {
     PLSSVM_ASSERT(x.num_cols() == y.num_cols(), "Sizes mismatch!: {} != {}", x.num_cols(), y.num_cols());
     using size_type = typename matrix<real_type, layout>::size_type;
@@ -180,13 +174,12 @@ template <kernel_function_type kernel, typename real_type, layout_type layout, t
         }
         return std::exp(-gamma * temp);
     } else {
-        static_assert(detail::always_false_v<real_type>, "Unknown kernel type!");
+        static_assert(detail::always_false_v<Args...>, "Unknown kernel type!");
     }
 }
 
 /**
  * @brief Computes the value of the two matrix rows @p i in @p x and @p j in @p y using the kernel function and kernel parameter stored in @p params.
- * @tparam real_type the type of the values
  * @tparam layout the layout type of the two matrices
  * @param[in] x the first matrix
  * @param[in] i the row in the first matrix
@@ -196,8 +189,8 @@ template <kernel_function_type kernel, typename real_type, layout_type layout, t
  * @throws plssvm::unsupported_kernel_type_exception if the kernel function in @p params is not supported
  * @return the computed kernel function value (`[[nodiscard]]`)
  */
-template <typename real_type, layout_type layout>
-[[nodiscard]] real_type kernel_function(const matrix<real_type, layout> &x, std::size_t i, const matrix<real_type, layout> &y, std::size_t j, const detail::parameter<real_type> &params);
+template <layout_type layout>
+[[nodiscard]] real_type kernel_function(const matrix<real_type, layout> &x, std::size_t i, const matrix<real_type, layout> &y, std::size_t j, const parameter &params);
 
 
 }  // namespace plssvm

--- a/include/plssvm/model.hpp
+++ b/include/plssvm/model.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "plssvm/classification_types.hpp"            // plssvm::classification_type
+#include "plssvm/constants.hpp"                       // plssvm::real_type
 #include "plssvm/data_set.hpp"                        // plssvm::data_set
 #include "plssvm/detail/assert.hpp"                   // PLSSVM_ASSERT
 #include "plssvm/detail/io/libsvm_model_parsing.hpp"  // plssvm::detail::io::{parse_libsvm_model_header, parse_libsvm_model_data, write_libsvm_model_data}
@@ -44,21 +45,17 @@ namespace plssvm {
 
 /**
  * @brief Implements a class encapsulating the result of a call to the SVM fit function. A model is used to predict the labels of a new data set.
- * @tparam T the floating point type of the data (must either be `float` or `double`)
  * @tparam U the type of the used labels (must be an arithmetic type or `std:string`; default: `int`)
  */
-template <typename T, typename U = int>
+template <typename U = int>
 class model {
     // make sure only valid template types are used
-    static_assert(detail::type_list_contains_v<T, detail::real_type_list>, "Illegal real type provided! See the 'real_type_list' in the type_list.hpp header for a list of the allowed types.");
     static_assert(detail::type_list_contains_v<U, detail::label_type_list>, "Illegal label type provided! See the 'label_type_list' in the type_list.hpp header for a list of the allowed types.");
 
     // plssvm::csvm needs the private constructor
     friend class csvm;
 
   public:
-    /// The type of the data points: either `float` or `double`.
-    using real_type = T;
     /// The type of the labels: any arithmetic type or `std::string`.
     using label_type = U;
     /// The unsigned size type.
@@ -152,14 +149,14 @@ class model {
      * @param[in] data the data used to learn this model
      * @param[in] classification_strategy the classification strategy used to fit this model
      */
-    model(parameter params, data_set<real_type, label_type> data, classification_type classification_strategy);
+    model(parameter params, data_set<label_type> data, classification_type classification_strategy);
 
     /// The SVM parameter used to learn this model.
     parameter params_{};
     /// The classification strategy (one vs. all or one vs. one) used to fit this model.
     classification_type classification_strategy_{};
     /// The data (support vectors + respective label) used to learn this model.
-    data_set<real_type, label_type> data_{};
+    data_set<label_type> data_{};
     /// The number of support vectors representing this model.
     size_type num_support_vectors_{ 0 };
     /// The number of features per support vector.
@@ -191,12 +188,12 @@ class model {
     std::shared_ptr<aos_matrix<real_type>> w_ptr_{ std::make_shared<aos_matrix<real_type>>() };
 };
 
-template <typename T, typename U>
-model<T, U>::model(parameter params, data_set<real_type, label_type> data, const classification_type classification_strategy) :
+template <typename U>
+model<U>::model(parameter params, data_set<label_type> data, const classification_type classification_strategy) :
     params_{ std::move(params) }, classification_strategy_{ classification_strategy }, data_{ std::move(data) }, num_support_vectors_{ data_.num_data_points() }, num_features_{ data_.num_features() } {}
 
-template <typename T, typename U>
-model<T, U>::model(const std::string &filename) {
+template <typename U>
+model<U>::model(const std::string &filename) {
     const std::chrono::time_point start_time = std::chrono::steady_clock::now();
 
     // open the file
@@ -208,7 +205,7 @@ model<T, U>::model(const std::string &filename) {
     std::vector<label_type> unique_labels{};
     std::vector<size_type> num_sv_per_class{};
     std::size_t num_header_lines{};
-    std::tie(params_, *rho_ptr_, labels, unique_labels, num_sv_per_class, num_header_lines) = detail::io::parse_libsvm_model_header<real_type, label_type, size_type>(reader.lines());
+    std::tie(params_, *rho_ptr_, labels, unique_labels, num_sv_per_class, num_header_lines) = detail::io::parse_libsvm_model_header<label_type, size_type>(reader.lines());
 
     // fill indices -> support vectors are sorted!
     indices_ptr_ = std::make_shared<std::vector<std::vector<std::size_t>>>(unique_labels.size());
@@ -223,13 +220,13 @@ model<T, U>::model(const std::string &filename) {
     aos_matrix<real_type> support_vectors{};
 
     // parse libsvm model data
-    std::tie(num_support_vectors_, num_features_, support_vectors, *alpha_ptr_, classification_strategy_) = detail::io::parse_libsvm_model_data<real_type>(reader, num_sv_per_class, num_header_lines);
+    std::tie(num_support_vectors_, num_features_, support_vectors, *alpha_ptr_, classification_strategy_) = detail::io::parse_libsvm_model_data(reader, num_sv_per_class, num_header_lines);
 
     // create data set
     PLSSVM_ASSERT(support_vectors.num_rows() == labels.size(), "Number of labels ({}) must match the number of data points ({})!", labels.size(), support_vectors.num_rows());
     const verbosity_level old_verbosity = verbosity;
     verbosity = verbosity_level::quiet;
-    data_ = data_set<real_type, label_type>{};
+    data_ = data_set<label_type>{};
     (*data_.data_ptr_) = std::move(support_vectors);
     data_.labels_ptr_ = std::make_shared<typename decltype(data_.labels_ptr_)::element_type>(std::move(labels));  // prevent multiple calls to "create_mapping"
     data_.create_mapping(unique_labels);
@@ -248,8 +245,8 @@ model<T, U>::model(const std::string &filename) {
     PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY((plssvm::detail::tracking_entry{ "model_read", "classification_type", classification_strategy_ }));
 }
 
-template <typename T, typename U>
-void model<T, U>::save(const std::string &filename) const {
+template <typename U>
+void model<U>::save(const std::string &filename) const {
     PLSSVM_ASSERT(rho_ptr_ != nullptr, "The rho_ptr may never be a nullptr!");
     PLSSVM_ASSERT(alpha_ptr_ != nullptr, "The alpha_ptr may never be a nullptr!");
     PLSSVM_ASSERT(indices_ptr_ != nullptr, "The indices_ptr may never be a nullptr!");

--- a/include/plssvm/parameter.hpp
+++ b/include/plssvm/parameter.hpp
@@ -13,8 +13,8 @@
 #define PLSSVM_PARAMETER_HPP_
 #pragma once
 
+#include "plssvm/constants.hpp"              // plssvm::real_type
 #include "plssvm/default_value.hpp"          // plssvm::default_value, plssvm::is_default_value_v
-#include "plssvm/detail/type_list.hpp"       // plssvm::detail::{real_type_list, type_list_contains_v}
 #include "plssvm/detail/type_traits.hpp"     // PLSSVM_REQUIRES, plssvm::detail::{remove_cvref_t, always_false_v}
 #include "plssvm/detail/utility.hpp"         // plssvm::detail::unreachable
 #include "plssvm/kernel_function_types.hpp"  // plssvm::kernel_function_type, plssvm::kernel_function_type_to_math_string
@@ -103,17 +103,17 @@ ExpectedType get_value_from_named_parameter(const IgorParser &parser, const Name
     detail::unreachable();
 }
 
+}  // namespace detail
+
+/**
+ * @example parameter_examples.cpp
+ * @brief A few examples regarding the plssvm::parameter class.
+ */
+
 /**
  * @brief Class for encapsulating all important C-SVM parameters.
- * @tparam T the used real_type, must either be `float` or `double`
  */
-template <typename T>
 struct parameter {
-    // make sure only valid template types are used
-    static_assert(detail::type_list_contains_v<T, detail::real_type_list>, "Illegal real type provided! See the 'real_type_list' in the type_list.hpp header for a list of the allowed types.");
-
-    /// The type of the data. Must be either `float` or `double`.
-    using real_type = T;
 
     /**
      * @brief Default construct a parameter set, i.e., each SVM parameter has its default value.
@@ -142,7 +142,7 @@ struct parameter {
      * @param[in] params the parameters used to overwrite the default values
      * @param[in] named_args the potential named-parameters
      */
-    template <typename... Args, PLSSVM_REQUIRES(has_only_named_args_v<Args...>)>
+    template <typename... Args, PLSSVM_REQUIRES(detail::has_only_named_args_v<Args...>)>
     constexpr explicit parameter(const parameter &params, Args &&...named_args) :
         parameter{ params } {
         this->set_named_arguments(std::forward<Args>(named_args)...);
@@ -153,7 +153,7 @@ struct parameter {
      * @tparam Args the type of the named-parameters
      * @param[in] named_args the potential named-parameters
      */
-    template <typename... Args, PLSSVM_REQUIRES(has_only_named_args_v<Args...>)>
+    template <typename... Args, PLSSVM_REQUIRES(detail::has_only_named_args_v<Args...>)>
     constexpr explicit parameter(Args &&...named_args) noexcept {
         this->set_named_arguments(std::forward<Args>(named_args)...);
     }
@@ -168,22 +168,6 @@ struct parameter {
     default_value<real_type> coef0{ default_init<real_type>{ 0.0 } };
     /// The cost parameter in the C-SVM.
     default_value<real_type> cost{ default_init<real_type>{ 1.0 } };
-
-    /**
-     * @brief Convert a `plssvm::parameter<T>`to a `plssvm::parameter<U>` (i.e., conversion between float <-> double).
-     * @tparam U the type to convert to
-     * @return the `plssvm::parameter` values converted to @p U (`[[nodiscard]]`)
-     */
-    template <typename U>
-    [[nodiscard]] constexpr explicit operator parameter<U>() const {
-        if constexpr (std::is_same_v<U, real_type>) {
-            // no special conversions needed
-            return parameter<real_type>{ *this };
-        } else {
-            // convert between parameter<float> <-> parameter<double>
-            return parameter<U>{ kernel_type, degree, default_value<U>{ gamma }, default_value<U>{ coef0 }, default_value<U>{ cost } };
-        }
-    }
 
     /**
      * @brief Checks whether the current parameter set is **equivalent** to the one given by @p other.
@@ -237,11 +221,11 @@ struct parameter {
         // compile time/runtime check: the values must have the correct types
         if constexpr (parser.has(plssvm::kernel_type)) {
             // get the value of the provided named parameter
-            kernel_type = get_value_from_named_parameter<typename decltype(kernel_type)::value_type>(parser, plssvm::kernel_type);
+            kernel_type = detail::get_value_from_named_parameter<typename decltype(kernel_type)::value_type>(parser, plssvm::kernel_type);
         }
         if constexpr (parser.has(plssvm::gamma)) {
             // get the value of the provided named parameter
-            gamma = get_value_from_named_parameter<typename decltype(gamma)::value_type>(parser, plssvm::gamma);
+            gamma = detail::get_value_from_named_parameter<typename decltype(gamma)::value_type>(parser, plssvm::gamma);
             // runtime check: the value may only be used with a specific kernel type
             if (kernel_type == kernel_function_type::linear) {
                 print_warning("gamma", kernel_type);
@@ -249,7 +233,7 @@ struct parameter {
         }
         if constexpr (parser.has(plssvm::degree)) {
             // get the value of the provided named parameter
-            degree = get_value_from_named_parameter<typename decltype(degree)::value_type>(parser, plssvm::degree);
+            degree = detail::get_value_from_named_parameter<typename decltype(degree)::value_type>(parser, plssvm::degree);
             // runtime check: the value may only be used with a specific kernel type
             if (kernel_type == kernel_function_type::linear || kernel_type == kernel_function_type::rbf) {
                 print_warning("degree", kernel_type);
@@ -257,7 +241,7 @@ struct parameter {
         }
         if constexpr (parser.has(plssvm::coef0)) {
             // get the value of the provided named parameter
-            coef0 = get_value_from_named_parameter<typename decltype(coef0)::value_type>(parser, plssvm::coef0);
+            coef0 = detail::get_value_from_named_parameter<typename decltype(coef0)::value_type>(parser, plssvm::coef0);
             // runtime check: the value may only be used with a specific kernel type
             if (kernel_type == kernel_function_type::linear || kernel_type == kernel_function_type::rbf) {
                 print_warning("coef0", kernel_type);
@@ -265,36 +249,29 @@ struct parameter {
         }
         if constexpr (parser.has(plssvm::cost)) {
             // get the value of the provided named parameter
-            cost = get_value_from_named_parameter<typename decltype(cost)::value_type>(parser, plssvm::cost);
+            cost = detail::get_value_from_named_parameter<typename decltype(cost)::value_type>(parser, plssvm::cost);
         }
     }
 };
 
-extern template struct parameter<float>;
-extern template struct parameter<double>;
-
 /**
  * @brief Compares the two parameter sets @p lhs and @p rhs for equality.
  * @details Two parameter sets are equal if and only if **all** SVM parameters are equal.
- * @tparam T the real_type
  * @param[in] lhs the first parameter set
  * @param[in] rhs the second parameter set
  * @return `true` if both parameter sets are equal, `false` otherwise (`[[nodiscard]]`)
  */
-template <typename T>
-[[nodiscard]] constexpr bool operator==(const parameter<T> &lhs, const parameter<T> &rhs) noexcept {
+[[nodiscard]] constexpr bool operator==(const parameter &lhs, const parameter &rhs) noexcept {
     return lhs.kernel_type == rhs.kernel_type && lhs.degree == rhs.degree && lhs.gamma == rhs.gamma && lhs.coef0 == rhs.coef0 && lhs.cost == rhs.cost;
 }
 /**
  * @brief Compares the two parameter sets @p lhs and @p rhs for inequality.
  * @details Two parameter sets are unequal if **any** of the SVM parameters are unequal.
- * @tparam T the real_type
  * @param[in] lhs the first parameter set
  * @param[in] rhs the second parameter set
  * @return `true` if both parameter sets are unequal, `false` otherwise (`[[nodiscard]]`)
  */
-template <typename T>
-[[nodiscard]] constexpr bool operator!=(const parameter<T> &lhs, const parameter<T> &rhs) noexcept {
+[[nodiscard]] constexpr bool operator!=(const parameter &lhs, const parameter &rhs) noexcept {
     return !(lhs == rhs);
 }
 
@@ -307,37 +284,18 @@ template <typename T>
  * @param[in] rhs the second parameter set
  * @return `true` if both parameter sets are equivalent, `false` otherwise (`[[nodiscard]]`)
  */
-template <typename T>
-[[nodiscard]] constexpr bool equivalent(const parameter<T> &lhs, const parameter<T> &rhs) noexcept {
+[[nodiscard]] constexpr bool equivalent(const parameter &lhs, const parameter &rhs) noexcept {
     return lhs.equivalent(rhs);
 }
 
 /**
  * @brief Output all parameters encapsulated by @p params to the given output-stream @p out.
- * @tparam T the type of the data
  * @param[in,out] out the output-stream to write the parameters to
  * @param[in] params the parameter set
  * @return the output-stream
  */
 template <typename T>
-std::ostream &operator<<(std::ostream &out, const parameter<T> &params);
-
-}  // namespace detail
-
-/**
- * @example parameter_examples.cpp
- * @brief A few examples regarding the plssvm::parameter class.
- */
-
-/// The public parameter type uses `double` to store the SVM parameters.
-using parameter = detail::parameter<double>;
-
-/**
- * @copydoc plssvm::detail::equivalent
- */
-[[nodiscard]] constexpr bool equivalent(const parameter &lhs, const parameter &rhs) noexcept {
-    return detail::equivalent(lhs, rhs);
-}
+std::ostream &operator<<(std::ostream &out, const parameter &params);
 
 }  // namespace plssvm
 

--- a/src/main_predict.cpp
+++ b/src/main_predict.cpp
@@ -40,11 +40,10 @@ int main(int argc, char *argv[]) {
 
         // create data set
         std::visit([&](auto &&data) {
-            using real_type = typename std::remove_reference_t<decltype(data)>::real_type;
             using label_type = typename std::remove_reference_t<decltype(data)>::label_type;
 
             // create model
-            const plssvm::model<real_type, label_type> model{ cmd_parser.model_filename };
+            const plssvm::model<label_type> model{ cmd_parser.model_filename };
             // create default csvm
             const auto svm = plssvm::make_csvm(cmd_parser.backend, cmd_parser.target);
             // predict labels

--- a/src/main_scale.cpp
+++ b/src/main_scale.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
                 data.save(cmd_parser.scaled_filename, cmd_parser.format);
             } else {
                 fmt::print("\n");
-                using real_type = typename plssvm::detail::remove_cvref_t<decltype(data)>::real_type;
+                using real_type = plssvm::real_type;
                 using label_type = typename plssvm::detail::remove_cvref_t<decltype(data)>::label_type;
 
                 // output to console if no output filename is provided

--- a/src/main_train.cpp
+++ b/src/main_train.cpp
@@ -35,7 +35,6 @@ int main(int argc, char *argv[]) {
 
         // create data set
         std::visit([&](auto &&data) {
-            using real_type = typename std::remove_reference_t<decltype(data)>::real_type;
             using label_type = typename std::remove_reference_t<decltype(data)>::label_type;
 
             // create SVM
@@ -43,7 +42,7 @@ int main(int argc, char *argv[]) {
                                                                                                          : plssvm::make_csvm(cmd_parser.backend, cmd_parser.target, cmd_parser.csvm_params);
 
             // only specify plssvm::max_iter if it isn't its default value
-            const plssvm::model<real_type, label_type> model =
+            const plssvm::model<label_type> model =
                 cmd_parser.max_iter.is_default() ? svm->fit(data,
                                                             plssvm::epsilon = cmd_parser.epsilon,
                                                             plssvm::classification = cmd_parser.classification,

--- a/src/plssvm/backends/CUDA/cg_explicit/blas.cu
+++ b/src/plssvm/backends/CUDA/cg_explicit/blas.cu
@@ -8,9 +8,10 @@
 
 #include "plssvm/backends/CUDA/cg_explicit/blas.cuh"
 
+#include "plssvm/constants.hpp"  // plssvm::real_type
+
 namespace plssvm::cuda {
 
-template <typename real_type>
 __global__ void device_kernel_gemm(const kernel_index_type m, const kernel_index_type n, const kernel_index_type k, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
     // compute: C = alpha * A * B + beta * C with A in m x k, B in n x k, and C in n x m, alpha, beta as scalar
     const unsigned long long i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -24,8 +25,5 @@ __global__ void device_kernel_gemm(const kernel_index_type m, const kernel_index
         C[j * m + i] = alpha * temp + beta * C[j * m + i];
     }
 }
-
-template __global__ void device_kernel_gemm(const kernel_index_type, const kernel_index_type, const kernel_index_type, const float, const float *, const float *, const float, float *);
-template __global__ void device_kernel_gemm(const kernel_index_type, const kernel_index_type, const kernel_index_type, const double, const double *, const double *, const double, double *);
 
 }  // namespace plssvm::cuda

--- a/src/plssvm/backends/CUDA/cg_explicit/kernel_matrix_assembly.cu
+++ b/src/plssvm/backends/CUDA/cg_explicit/kernel_matrix_assembly.cu
@@ -8,11 +8,10 @@
 
 #include "plssvm/backends/CUDA/cg_explicit/kernel_matrix_assembly.cuh"
 
-#include "plssvm/constants.hpp"  // plssvm::kernel_index_type
+#include "plssvm/constants.hpp"  // plssvm::real_type, plssvm::kernel_index_type
 
 namespace plssvm::cuda {
 
-template <typename real_type>
 __global__ void device_kernel_assembly_linear(const real_type *q, real_type *ret, const real_type *data_d, const real_type QA_cost, const real_type cost, const kernel_index_type dept, const kernel_index_type num_features) {
     const unsigned long long i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned long long j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -30,10 +29,7 @@ __global__ void device_kernel_assembly_linear(const real_type *q, real_type *ret
         ret[i * dept + j] = temp;
     }
 }
-template __global__ void device_kernel_assembly_linear(const float *, float *, const float *, const float, const float, const kernel_index_type, const kernel_index_type);
-template __global__ void device_kernel_assembly_linear(const double *, double *, const double *, const double, const double, const kernel_index_type, const kernel_index_type);
 
-template <typename real_type>
 __global__ void device_kernel_assembly_polynomial(const real_type *q, real_type *ret, const real_type *data_d, const real_type QA_cost, const real_type cost, const kernel_index_type num_rows, const kernel_index_type num_features, const int degree, const real_type gamma, const real_type coef0) {
     const unsigned long long i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned long long j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -51,10 +47,7 @@ __global__ void device_kernel_assembly_polynomial(const real_type *q, real_type 
         ret[i * num_rows + j] = temp;
     }
 }
-template __global__ void device_kernel_assembly_polynomial(const float *, float *, const float *, const float, const float, const kernel_index_type, const kernel_index_type, const int, const float, const float);
-template __global__ void device_kernel_assembly_polynomial(const double *, double *, const double *, const double, const double, const kernel_index_type, const kernel_index_type, const int, const double, const double);
 
-template <typename real_type>
 __global__ void device_kernel_assembly_rbf(const real_type *q, real_type *ret, const real_type *data_d, const real_type QA_cost, const real_type cost, const kernel_index_type num_rows, const kernel_index_type num_features, const real_type gamma) {
     const unsigned long long i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned long long j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -73,7 +66,5 @@ __global__ void device_kernel_assembly_rbf(const real_type *q, real_type *ret, c
         ret[i * num_rows + j] = temp;
     }
 }
-template __global__ void device_kernel_assembly_rbf(const float *, float *, const float *, const float, const float, const kernel_index_type, const kernel_index_type, const float);
-template __global__ void device_kernel_assembly_rbf(const double *, double *, const double *, const double, const double, const kernel_index_type, const kernel_index_type, const double);
 
 }  // namespace plssvm::cuda

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -24,7 +24,7 @@
 #include "plssvm/detail/simple_any.hpp"                                 // plssvm::detail::simple_any
 #include "plssvm/exceptions/exceptions.hpp"                             // plssvm::exception
 #include "plssvm/kernel_function_types.hpp"                             // plssvm::kernel_function_type
-#include "plssvm/parameter.hpp"                                         // plssvm::parameter, plssvm::detail::parameter
+#include "plssvm/parameter.hpp"                                         // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                                  // plssvm::target_platform
 
 #include "cuda.h"                                      // cuda runtime functions
@@ -122,7 +122,7 @@ std::pair<dim3, dim3> execution_range_to_native(const ::plssvm::detail::executio
 //                        fit                        //
 //***************************************************//
 
-auto csvm::run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
+auto csvm::run_assemble_kernel_matrix_explicit(const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const std::size_t num_rows_reduced = data_d.size(0) - 1;
     const std::size_t num_features = data_d.size(1);
 
@@ -180,7 +180,7 @@ auto csvm::run_w_kernel(const device_ptr_type &alpha_d, const device_ptr_type &s
     return w_d;
 }
 
-auto csvm::run_predict_kernel(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type &w_d, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const -> device_ptr_type {
+auto csvm::run_predict_kernel(const parameter &params, const device_ptr_type &w_d, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const -> device_ptr_type {
     device_ptr_type out_d{ { num_predict_points, num_classes } };
 
     detail::set_device(0);

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -16,6 +16,7 @@
 #include "plssvm/backends/CUDA/detail/utility.cuh"                      // plssvm::cuda::detail::{device_synchronize, get_device_count, set_device, peek_at_last_error}
 #include "plssvm/backends/CUDA/exceptions.hpp"                          // plssvm::cuda::backend_exception
 #include "plssvm/backends/CUDA/predict_kernel.cuh"                      // plssvm::cuda::detail::{device_kernel_w_linear, device_kernel_predict_polynomial, device_kernel_predict_rbf}
+#include "plssvm/constants.hpp"                                         // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                                     // PLSSVM_ASSERT
 #include "plssvm/detail/execution_range.hpp"                            // plssvm::detail::execution_range
 #include "plssvm/detail/logger.hpp"                                     // plssvm::detail::log, plssvm::verbosity_level
@@ -121,8 +122,7 @@ std::pair<dim3, dim3> execution_range_to_native(const ::plssvm::detail::executio
 //                        fit                        //
 //***************************************************//
 
-template <typename real_type>
-auto csvm::run_assemble_kernel_matrix_explicit_impl(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type<real_type> &data_d, const device_ptr_type<real_type> &q_red_d, real_type QA_cost) const -> device_ptr_type<real_type> {
+auto csvm::run_assemble_kernel_matrix_explicit(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const std::size_t num_rows_reduced = data_d.size(0) - 1;
     const std::size_t num_features = data_d.size(1);
 
@@ -131,7 +131,7 @@ auto csvm::run_assemble_kernel_matrix_explicit_impl(const ::plssvm::detail::para
     const dim3 grid(static_cast<int>(std::ceil(num_rows_reduced / static_cast<double>(block.x))),
                     static_cast<int>(std::ceil(num_rows_reduced / static_cast<double>(block.y))));
 
-    device_ptr_type<real_type> kernel_matrix_d{ { num_rows_reduced, num_rows_reduced } };
+    device_ptr_type kernel_matrix_d{ { num_rows_reduced, num_rows_reduced } };
 
     detail::set_device(0);
     switch (params.kernel_type) {
@@ -151,11 +151,7 @@ auto csvm::run_assemble_kernel_matrix_explicit_impl(const ::plssvm::detail::para
     return kernel_matrix_d;
 }
 
-template auto csvm::run_assemble_kernel_matrix_explicit_impl(const ::plssvm::detail::parameter<float> &, const device_ptr_type<float> &, const device_ptr_type<float> &, float) const -> device_ptr_type<float>;
-template auto csvm::run_assemble_kernel_matrix_explicit_impl(const ::plssvm::detail::parameter<double> &, const device_ptr_type<double> &, const device_ptr_type<double> &, double) const -> device_ptr_type<double>;
-
-template <typename real_type>
-void csvm::run_gemm_kernel_explicit_impl(const std::size_t m, const std::size_t n, const std::size_t k, const real_type alpha, const device_ptr_type<real_type> &A_d, const device_ptr_type<real_type> &B_d, const real_type beta, device_ptr_type<real_type> &C_d) const {
+void csvm::run_gemm_kernel_explicit(const std::size_t m, const std::size_t n, const std::size_t k, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
     const dim3 block(32, 32);
     const dim3 grid(static_cast<int>(std::ceil(m / static_cast<double>(block.x))),
                     static_cast<int>(std::ceil(n / static_cast<double>(block.y))));
@@ -166,21 +162,16 @@ void csvm::run_gemm_kernel_explicit_impl(const std::size_t m, const std::size_t 
     detail::device_synchronize(0);
 }
 
-template void csvm::run_gemm_kernel_explicit_impl(const std::size_t, const std::size_t, const std::size_t, const float, const device_ptr_type<float> &, const device_ptr_type<float> &, const float, device_ptr_type<float> &) const;
-template void csvm::run_gemm_kernel_explicit_impl(const std::size_t, const std::size_t, const std::size_t, const double, const device_ptr_type<double> &, const device_ptr_type<double> &, const double, device_ptr_type<double> &) const;
-
-
 //***************************************************//
 //                   predict, score                  //
 //***************************************************//
 
-template <typename real_type>
-auto csvm::run_w_kernel_impl(const device_ptr_type<real_type> &alpha_d, const device_ptr_type<real_type> &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const -> device_ptr_type<real_type> {
+auto csvm::run_w_kernel(const device_ptr_type &alpha_d, const device_ptr_type &sv_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_features) const -> device_ptr_type {
     const dim3 block(256, 4);
     const dim3 grid(static_cast<int>(std::ceil(num_features / static_cast<double>(block.x))),
                     static_cast<int>(std::ceil(num_classes / static_cast<double>(block.y))));
 
-    device_ptr_type<real_type> w_d{ { num_classes, num_features } };
+    device_ptr_type w_d{ { num_classes, num_features } };
 
     detail::set_device(0);
     cuda::device_kernel_w_linear<<<grid, block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, num_features);
@@ -189,12 +180,8 @@ auto csvm::run_w_kernel_impl(const device_ptr_type<real_type> &alpha_d, const de
     return w_d;
 }
 
-template auto csvm::run_w_kernel_impl(const device_ptr_type<float> &, const device_ptr_type<float> &, std::size_t, std::size_t, std::size_t) const -> device_ptr_type<float>;
-template auto csvm::run_w_kernel_impl(const device_ptr_type<double> &, const device_ptr_type<double> &, std::size_t, std::size_t, std::size_t) const -> device_ptr_type<double>;
-
-template <typename real_type>
-auto csvm::run_predict_kernel_impl(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type<real_type> &w_d, const device_ptr_type<real_type> &alpha_d, const device_ptr_type<real_type> &rho_d, const device_ptr_type<real_type> &sv_d, const device_ptr_type<real_type> &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const -> device_ptr_type<real_type> {
-    device_ptr_type<real_type> out_d{ { num_predict_points, num_classes } };
+auto csvm::run_predict_kernel(const ::plssvm::detail::parameter<real_type> &params, const device_ptr_type &w_d, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_d, const device_ptr_type &predict_points_d, std::size_t num_classes, std::size_t num_sv, std::size_t num_predict_points, std::size_t num_features) const -> device_ptr_type {
+    device_ptr_type out_d{ { num_predict_points, num_classes } };
 
     detail::set_device(0);
     if (params.kernel_type == kernel_function_type::linear) {
@@ -226,8 +213,5 @@ auto csvm::run_predict_kernel_impl(const ::plssvm::detail::parameter<real_type> 
 
     return out_d;
 }
-
-template auto csvm::run_predict_kernel_impl(const ::plssvm::detail::parameter<float> &, const device_ptr_type<float> &, const device_ptr_type<float> &, const device_ptr_type<float> &, const device_ptr_type<float> &, const device_ptr_type<float> &, std::size_t, std::size_t, std::size_t, std::size_t) const -> device_ptr_type<float>;
-template auto csvm::run_predict_kernel_impl(const ::plssvm::detail::parameter<double> &, const device_ptr_type<double> &, const device_ptr_type<double> &, const device_ptr_type<double> &, const device_ptr_type<double> &, const device_ptr_type<double> &, std::size_t, std::size_t, std::size_t, std::size_t) const -> device_ptr_type<double>;
 
 }  // namespace plssvm::cuda

--- a/src/plssvm/backends/CUDA/predict_kernel.cu
+++ b/src/plssvm/backends/CUDA/predict_kernel.cu
@@ -9,11 +9,10 @@
 #include "plssvm/backends/CUDA/predict_kernel.cuh"
 
 #include "plssvm/backends/CUDA/detail/atomics.cuh"  // atomicAdd for double precision floating point numbers on older CUDA hardware
-#include "plssvm/constants.hpp"                     // plssvm::kernel_index_type, plssvm::THREAD_BLOCK_SIZE, plssvm::INTERNAL_BLOCK_SIZE
+#include "plssvm/constants.hpp"                     // plssvm::real_type, plssvm::kernel_index_type, plssvm::THREAD_BLOCK_SIZE, plssvm::INTERNAL_BLOCK_SIZE
 
 namespace plssvm::cuda {
 
-template <typename real_type>
 __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const kernel_index_type num_classes, const kernel_index_type num_sv, const kernel_index_type num_features) {
     const kernel_index_type feature_idx = blockIdx.x * blockDim.x + threadIdx.x;
     const kernel_index_type class_idx = blockIdx.y * blockDim.y + threadIdx.y;
@@ -27,10 +26,6 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
     }
 }
 
-template __global__ void device_kernel_w_linear(float *w_d, const float *, const float *, const kernel_index_type, const kernel_index_type, const kernel_index_type);
-template __global__ void device_kernel_w_linear(double *w_d, const double *, const double *, const kernel_index_type, const kernel_index_type, const kernel_index_type);
-
-template <typename real_type>
 __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const kernel_index_type num_classes, const kernel_index_type num_predict_points, const kernel_index_type num_features) {
     const kernel_index_type predict_point_idx = blockIdx.x * blockDim.x + threadIdx.x;
     const kernel_index_type class_idx = blockIdx.y * blockDim.y + threadIdx.y;
@@ -44,11 +39,6 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
     }
 }
 
-template __global__ void device_kernel_predict_linear(float *, const float *, const float *, const float *, const kernel_index_type, const kernel_index_type, const kernel_index_type);
-template __global__ void device_kernel_predict_linear(double *, const double *, const double *, const double *, const kernel_index_type, const kernel_index_type, const kernel_index_type);
-
-
-template <typename real_type>
 __global__ void device_kernel_predict_polynomial(real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const kernel_index_type num_classes, const kernel_index_type num_sv, const kernel_index_type num_predict_points, const kernel_index_type num_features, const int degree, const real_type gamma, const real_type coef0) {
     const kernel_index_type sv_idx = blockIdx.x * blockDim.x + threadIdx.x;
     const kernel_index_type predict_points_idx = blockIdx.y * blockDim.y + threadIdx.y;
@@ -71,10 +61,6 @@ __global__ void device_kernel_predict_polynomial(real_type *out_d, const real_ty
     }
 }
 
-template __global__ void device_kernel_predict_polynomial(float *, const float *, const float *, const float *, const float *, const kernel_index_type, const kernel_index_type, const kernel_index_type, const kernel_index_type, const int, const float, const float);
-template __global__ void device_kernel_predict_polynomial(double *, const double *, const double *, const double *, const double *, const kernel_index_type, const kernel_index_type, const kernel_index_type, const kernel_index_type, const int, const double, const double);
-
-template <typename real_type>
 __global__ void device_kernel_predict_rbf(real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const kernel_index_type num_classes, const kernel_index_type num_sv, const kernel_index_type num_predict_points, const kernel_index_type num_features, const real_type gamma) {
     const kernel_index_type sv_idx = blockIdx.x * blockDim.x + threadIdx.x;
     const kernel_index_type predict_points_idx = blockIdx.y * blockDim.y + threadIdx.y;
@@ -97,9 +83,5 @@ __global__ void device_kernel_predict_rbf(real_type *out_d, const real_type *alp
         atomicAdd(&out_d[predict_points_idx * num_classes + class_idx], temp);
     }
 }
-
-template __global__ void device_kernel_predict_rbf(float *, const float *, const float *, const float *, const float *, const kernel_index_type, const kernel_index_type, const kernel_index_type, const kernel_index_type,  const float);
-template __global__ void device_kernel_predict_rbf(double *, const double *, const double *, const double *, const double *, const kernel_index_type, const kernel_index_type, const kernel_index_type, const kernel_index_type,  const double);
-
 
 }  // namespace plssvm::cuda

--- a/src/plssvm/backends/OpenMP/cg_explicit/kernel_matrix_assembly.cpp
+++ b/src/plssvm/backends/OpenMP/cg_explicit/kernel_matrix_assembly.cpp
@@ -8,7 +8,7 @@
 
 #include "plssvm/backends/OpenMP/cg_explicit/kernel_matrix_assembly.hpp"
 
-#include "plssvm/constants.hpp"              // plssvm::kernel_index_type, plssvm::OPENMP_BLOCK_SIZE
+#include "plssvm/constants.hpp"              // plssvm::real_type, plssvm::kernel_index_type, plssvm::OPENMP_BLOCK_SIZE
 #include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT
 #include "plssvm/kernel_function_types.hpp"  // plssvm::kernel_function_type, plssvm::kernel_function
 #include "plssvm/matrix.hpp"                 // plssvm::aos_matrix
@@ -20,7 +20,7 @@ namespace plssvm::openmp {
 
 namespace detail {
 
-template <kernel_function_type kernel, typename real_type, typename... Args>
+template <kernel_function_type kernel, typename... Args>
 void kernel_matrix_assembly(const std::vector<real_type> &q, aos_matrix<real_type> &ret, const aos_matrix<real_type> &data, const real_type QA_cost, const real_type cost, Args &&...args) {
     PLSSVM_ASSERT(q.size() == data.num_rows() - 1, "Sizes mismatch!: {} != {}", q.size(), data.num_rows() - 1);
     PLSSVM_ASSERT(q.size() == ret.num_rows(), "Sizes mismatch!: {} != {}", q.size(), ret.num_rows());
@@ -46,29 +46,20 @@ void kernel_matrix_assembly(const std::vector<real_type> &q, aos_matrix<real_typ
 
 }  // namespace detail
 
-template <typename real_type>
 void linear_kernel_matrix_assembly(const std::vector<real_type> &q, aos_matrix<real_type> &ret, const aos_matrix<real_type> &data, const real_type QA_cost, const real_type cost) {
     detail::kernel_matrix_assembly<kernel_function_type::linear>(q, ret, data, QA_cost, cost);
 }
-template void linear_kernel_matrix_assembly(const std::vector<float> &, aos_matrix<float> &, const aos_matrix<float> &, float, float);
-template void linear_kernel_matrix_assembly(const std::vector<double> &, aos_matrix<double> &, const aos_matrix<double> &, double, double);
 
-template <typename real_type>
 void polynomial_kernel_matrix_assembly(const std::vector<real_type> &q, aos_matrix<real_type> &ret, const aos_matrix<real_type> &data, const real_type QA_cost, const real_type cost, const int degree, const real_type gamma, const real_type coef0) {
     PLSSVM_ASSERT(gamma > real_type{ 0.0 }, "gamma must be greater than 0, but is {}!", gamma);
 
     detail::kernel_matrix_assembly<kernel_function_type::polynomial>(q, ret, data, QA_cost, cost, degree, gamma, coef0);
 }
-template void polynomial_kernel_matrix_assembly(const std::vector<float> &, aos_matrix<float> &, const aos_matrix<float> &, float, float, int, float, float);
-template void polynomial_kernel_matrix_assembly(const std::vector<double> &, aos_matrix<double> &, const aos_matrix<double> &, double, double, int, double, double);
 
-template <typename real_type>
 void rbf_kernel_matrix_assembly(const std::vector<real_type> &q, aos_matrix<real_type> &ret, const aos_matrix<real_type> &data, const real_type QA_cost, const real_type cost, const real_type gamma) {
     PLSSVM_ASSERT(gamma > real_type{ 0.0 }, "gamma must be greater than 0, but is {}!", gamma);
 
     detail::kernel_matrix_assembly<kernel_function_type::rbf>(q, ret, data, QA_cost, cost, gamma);
 }
-template void rbf_kernel_matrix_assembly(const std::vector<float> &, aos_matrix<float> &, const aos_matrix<float> &, float, float, float);
-template void rbf_kernel_matrix_assembly(const std::vector<double> &, aos_matrix<double> &, const aos_matrix<double> &, double, double, double);
 
 }  // namespace plssvm::openmp

--- a/src/plssvm/backends/OpenMP/csvm.cpp
+++ b/src/plssvm/backends/OpenMP/csvm.cpp
@@ -12,6 +12,7 @@
 #include "plssvm/backends/OpenMP/cg_explicit/kernel_matrix_assembly.hpp"  // plssvm::openmp::linear_kernel_matrix_assembly, plssvm::openmp::polynomial_kernel_matrix_assembly, plssvm::openmp::rbf_kernel_matrix_assembly
 #include "plssvm/backends/OpenMP/exceptions.hpp"                          // plssvm::openmp::backend_exception
 #include "plssvm/backends/OpenMP/q_kernel.hpp"                            // plssvm::openmp::device_kernel_q_linear, plssvm::openmp::device_kernel_q_polynomial, plssvm::openmp::device_kernel_q_rbf
+#include "plssvm/constants.hpp"                                           // plssvm::real_type
 #include "plssvm/csvm.hpp"                                                // plssvm::csvm
 #include "plssvm/detail/assert.hpp"                                       // PLSSVM_ASSERT
 #include "plssvm/detail/logger.hpp"                                       // plssvm::detail::log, plssvm::verbosity_level
@@ -78,8 +79,7 @@ unsigned long long csvm::get_device_memory() const {
 //                        fit                        //
 //***************************************************//
 
-template <typename real_type>
-detail::simple_any csvm::setup_data_on_devices_impl(const solver_type solver, const aos_matrix<real_type> &A) const {
+detail::simple_any csvm::setup_data_on_devices(const solver_type solver, const aos_matrix<real_type> &A) const {
     PLSSVM_ASSERT(!A.empty(), "The matrix to setup on the devices may not be empty!");
     PLSSVM_ASSERT(solver != solver_type::automatic, "An explicit solver type must be provided instead of solver_type::automatic!");
 
@@ -91,11 +91,7 @@ detail::simple_any csvm::setup_data_on_devices_impl(const solver_type solver, co
     }
 }
 
-template detail::simple_any csvm::setup_data_on_devices_impl(const solver_type, const aos_matrix<float> &) const;
-template detail::simple_any csvm::setup_data_on_devices_impl(const solver_type, const aos_matrix<double> &) const;
-
-template <typename real_type>
-detail::simple_any csvm::assemble_kernel_matrix_impl(const solver_type solver, const detail::parameter<real_type> &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const {
+detail::simple_any csvm::assemble_kernel_matrix(const solver_type solver, const detail::parameter<real_type> &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const {
     PLSSVM_ASSERT(!q_red.empty(), "The q_red vector may not be empty!");
     PLSSVM_ASSERT(solver != solver_type::automatic, "An explicit solver type must be provided instead of solver_type::automatic!");
 
@@ -131,11 +127,7 @@ detail::simple_any csvm::assemble_kernel_matrix_impl(const solver_type solver, c
     }
 }
 
-template detail::simple_any csvm::assemble_kernel_matrix_impl(const solver_type, const detail::parameter<float> &, const detail::simple_any &, const std::vector<float> &, const float) const;
-template detail::simple_any csvm::assemble_kernel_matrix_impl(const solver_type, const detail::parameter<double> &, const detail::simple_any &, const std::vector<double> &, const double) const;
-
-template <typename real_type>
-void csvm::blas_gemm_impl(const solver_type solver, const real_type alpha, const detail::simple_any &A, const aos_matrix<real_type> &B, const real_type beta, aos_matrix<real_type> &C) const {
+void csvm::blas_gemm(const solver_type solver, const real_type alpha, const detail::simple_any &A, const aos_matrix<real_type> &B, const real_type beta, aos_matrix<real_type> &C) const {
     PLSSVM_ASSERT(!B.empty(), "The B matrix may not be empty!");
     PLSSVM_ASSERT(!C.empty(), "The C matrix may not be empty!");
     PLSSVM_ASSERT(B.num_rows() == C.num_rows(), "The C matrix must have {} rows, but has {}!", B.num_rows(), C.num_rows());
@@ -167,15 +159,11 @@ void csvm::blas_gemm_impl(const solver_type solver, const real_type alpha, const
     }
 }
 
-template void csvm::blas_gemm_impl(const solver_type, const float, const detail::simple_any &, const aos_matrix<float> &, const float, aos_matrix<float> &) const;
-template void csvm::blas_gemm_impl(const solver_type, const double, const detail::simple_any &, const aos_matrix<double> &, const double, aos_matrix<double> &) const;
-
 //***************************************************//
 //                   predict, score                  //
 //***************************************************//
 
-template <typename real_type>
-aos_matrix<real_type> csvm::predict_values_impl(const detail::parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const {
+aos_matrix<real_type> csvm::predict_values(const detail::parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const {
     PLSSVM_ASSERT(!support_vectors.empty(), "The support vectors must not be empty!");
     PLSSVM_ASSERT(!alpha.empty(), "The alpha vectors (weights) must not be empty!");
     PLSSVM_ASSERT(support_vectors.num_rows() == alpha.num_cols(), "The number of support vectors ({}) and number of weights ({}) must be the same!", support_vectors.num_rows(), alpha.num_cols());
@@ -243,8 +231,5 @@ aos_matrix<real_type> csvm::predict_values_impl(const detail::parameter<real_typ
     }
     return out;
 }
-
-template aos_matrix<float> csvm::predict_values_impl(const detail::parameter<float> &, const aos_matrix<float> &, const aos_matrix<float> &, const std::vector<float> &, aos_matrix<float> &, const aos_matrix<float> &) const;
-template aos_matrix<double> csvm::predict_values_impl(const detail::parameter<double> &, const aos_matrix<double> &, const aos_matrix<double> &, const std::vector<double> &, aos_matrix<double> &, const aos_matrix<double> &) const;
 
 }  // namespace plssvm::openmp

--- a/src/plssvm/backends/OpenMP/csvm.cpp
+++ b/src/plssvm/backends/OpenMP/csvm.cpp
@@ -20,7 +20,7 @@
 #include "plssvm/detail/performance_tracker.hpp"                          // plssvm::detail::tracking_entry, PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY
 #include "plssvm/kernel_function_types.hpp"                               // plssvm::kernel_function_type
 #include "plssvm/matrix.hpp"                                              // plssvm::aos_matrix
-#include "plssvm/parameter.hpp"                                           // plssvm::parameter, plssvm::detail::parameter
+#include "plssvm/parameter.hpp"                                           // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                                    // plssvm::target_platform
 
 #include "fmt/chrono.h"   // directly print std::chrono literals with fmt
@@ -91,7 +91,7 @@ detail::simple_any csvm::setup_data_on_devices(const solver_type solver, const a
     }
 }
 
-detail::simple_any csvm::assemble_kernel_matrix(const solver_type solver, const detail::parameter<real_type> &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const {
+detail::simple_any csvm::assemble_kernel_matrix(const solver_type solver, const parameter &params, const detail::simple_any &data, const std::vector<real_type> &q_red, const real_type QA_cost) const {
     PLSSVM_ASSERT(!q_red.empty(), "The q_red vector may not be empty!");
     PLSSVM_ASSERT(solver != solver_type::automatic, "An explicit solver type must be provided instead of solver_type::automatic!");
 
@@ -163,7 +163,7 @@ void csvm::blas_gemm(const solver_type solver, const real_type alpha, const deta
 //                   predict, score                  //
 //***************************************************//
 
-aos_matrix<real_type> csvm::predict_values(const detail::parameter<real_type> &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const {
+aos_matrix<real_type> csvm::predict_values(const parameter &params, const aos_matrix<real_type> &support_vectors, const aos_matrix<real_type> &alpha, const std::vector<real_type> &rho, aos_matrix<real_type> &w, const aos_matrix<real_type> &predict_points) const {
     PLSSVM_ASSERT(!support_vectors.empty(), "The support vectors must not be empty!");
     PLSSVM_ASSERT(!alpha.empty(), "The alpha vectors (weights) must not be empty!");
     PLSSVM_ASSERT(support_vectors.num_rows() == alpha.num_cols(), "The number of support vectors ({}) and number of weights ({}) must be the same!", support_vectors.num_rows(), alpha.num_cols());

--- a/src/plssvm/csvm.cpp
+++ b/src/plssvm/csvm.cpp
@@ -8,6 +8,7 @@
 
 #include "plssvm/csvm.hpp"
 
+#include "plssvm/constants.hpp"                   // plssvm::real_type
 #include "plssvm/detail/assert.hpp"               // PLSSVM_ASSERT
 #include "plssvm/detail/logger.hpp"               // plssvm::detail::log, plssvm::verbosity_level
 #include "plssvm/detail/operators.hpp"            // plssvm operator overloads for vectors
@@ -45,7 +46,6 @@ void csvm::sanity_check_parameter() const {
     // cost: all allowed
 }
 
-template <typename real_type>
 aos_matrix<real_type> csvm::conjugate_gradients(const detail::simple_any &A, const aos_matrix<real_type> &B, const real_type eps, const unsigned long long max_cg_iter, const solver_type cg_solver) const {
     using namespace plssvm::operators;
 
@@ -216,10 +216,6 @@ aos_matrix<real_type> csvm::conjugate_gradients(const detail::simple_any &A, con
     return X;
 }
 
-template aos_matrix<float> csvm::conjugate_gradients(const detail::simple_any &, const aos_matrix<float> &, const float, const unsigned long long, const solver_type) const;
-template aos_matrix<double> csvm::conjugate_gradients(const detail::simple_any &, const aos_matrix<double> &, const double, const unsigned long long, const solver_type) const;
-
-template <typename real_type>
 std::pair<std::vector<real_type>, real_type> csvm::perform_dimensional_reduction(const detail::parameter<real_type> &params, const aos_matrix<real_type> &A) const {
     const std::chrono::steady_clock::time_point dimension_reduction_start_time = std::chrono::steady_clock::now();
 
@@ -255,8 +251,5 @@ std::pair<std::vector<real_type>, real_type> csvm::perform_dimensional_reduction
 
     return std::make_pair(std::move(q_red), QA_cost);
 }
-
-template std::pair<std::vector<float>, float> csvm::perform_dimensional_reduction(const detail::parameter<float> &, const aos_matrix<float> &) const;
-template std::pair<std::vector<double>, double> csvm::perform_dimensional_reduction(const detail::parameter<double> &, const aos_matrix<double> &) const;
 
 }  // namespace plssvm

--- a/src/plssvm/csvm.cpp
+++ b/src/plssvm/csvm.cpp
@@ -38,7 +38,7 @@ void csvm::sanity_check_parameter() const {
     }
 
     // gamma: must be greater than 0 IF explicitly provided, but only in the polynomial and rbf kernel
-    if ((params_.kernel_type == kernel_function_type::polynomial || params_.kernel_type == kernel_function_type::rbf) && !params_.gamma.is_default() && params_.gamma.value() <= 0.0) {
+    if ((params_.kernel_type == kernel_function_type::polynomial || params_.kernel_type == kernel_function_type::rbf) && !params_.gamma.is_default() && params_.gamma.value() <= real_type{ 0.0 }) {
         throw invalid_parameter_exception{ fmt::format("gamma must be greater than 0.0, but is {}!", params_.gamma) };
     }
     // degree: all allowed

--- a/src/plssvm/csvm.cpp
+++ b/src/plssvm/csvm.cpp
@@ -17,7 +17,7 @@
 #include "plssvm/exceptions/exceptions.hpp"       // plssvm::invalid_parameter_exception
 #include "plssvm/kernel_function_types.hpp"       // plssvm::kernel_function_type, plssvm::kernel_function
 #include "plssvm/matrix.hpp"                      // plssvm::aos_matrix
-#include "plssvm/parameter.hpp"                   // plssvm::detail::parameter
+#include "plssvm/parameter.hpp"                   // plssvm::parameter
 #include "plssvm/solver_types.hpp"                // plssvm::solver_type
 
 #include "fmt/core.h"  // fmt::format
@@ -216,7 +216,7 @@ aos_matrix<real_type> csvm::conjugate_gradients(const detail::simple_any &A, con
     return X;
 }
 
-std::pair<std::vector<real_type>, real_type> csvm::perform_dimensional_reduction(const detail::parameter<real_type> &params, const aos_matrix<real_type> &A) const {
+std::pair<std::vector<real_type>, real_type> csvm::perform_dimensional_reduction(const parameter &params, const aos_matrix<real_type> &A) const {
     const std::chrono::steady_clock::time_point dimension_reduction_start_time = std::chrono::steady_clock::now();
 
     const std::size_t num_rows_reduced = A.num_rows() - 1;

--- a/src/plssvm/detail/cmd/parser_scale.cpp
+++ b/src/plssvm/detail/cmd/parser_scale.cpp
@@ -8,7 +8,7 @@
 
 #include "plssvm/detail/cmd/parser_scale.hpp"
 
-#include "plssvm/constants.hpp"        // plssvm::verbose_default, plssvm::verbose
+#include "plssvm/constants.hpp"        // plssvm::real_type
 #include "plssvm/detail/assert.hpp"    // PLSSVM_ASSERT
 #include "plssvm/detail/logger.hpp"    // plssvm::verbosity
 #include "plssvm/version/version.hpp"  // plssvm::version::detail::get_version_info
@@ -21,6 +21,7 @@
 #include <exception>                   // std::exception
 #include <filesystem>                  // std::filesystem::path
 #include <iostream>                    // std::cout, std::cerr, std::clog, std::endl
+#include <type_traits>                 // std::is_same_v
 
 namespace plssvm::detail::cmd {
 
@@ -48,7 +49,6 @@ parser_scale::parser_scale(int argc, char **argv) {
            ("performance_tracking", "the output YAML file where the performance tracking results are written to; if not provided, the results are dumped to stderr", cxxopts::value<decltype(performance_tracking_filename)>())
 #endif
            ("use_strings_as_labels", "use strings as labels instead of plane numbers", cxxopts::value<decltype(strings_as_labels)>()->default_value(fmt::format("{}", strings_as_labels)))
-           ("use_float_as_real_type", "use floats as real types instead of doubles", cxxopts::value<decltype(float_as_real_type)>()->default_value(fmt::format("{}", float_as_real_type)))
            ("verbosity", fmt::format("choose the level of verbosity: full|timing|libsvm|quiet (default: {})", fmt::format("{}", verbosity)), cxxopts::value<verbosity_level>())
            ("q,quiet", "quiet mode (no outputs regardless the provided verbosity level!)", cxxopts::value<bool>()->default_value(verbosity == verbosity_level::quiet ? "true" : "false"))
            ("h,help", "print this helper message", cxxopts::value<bool>())
@@ -105,9 +105,6 @@ parser_scale::parser_scale(int argc, char **argv) {
 
     // parse whether strings should be used as labels
     strings_as_labels = result["use_strings_as_labels"].as<decltype(strings_as_labels)>();
-
-    // parse whether floats should be used as real_type
-    float_as_real_type = result["use_float_as_real_type"].as<decltype(float_as_real_type)>();
 
     // parse whether output is quiet or not
     const bool quiet = result["quiet"].as<bool>();
@@ -181,7 +178,7 @@ std::ostream &operator<<(std::ostream &out, const parser_scale &params) {
         params.lower,
         params.upper,
         params.strings_as_labels ? "std::string" : "int (default)",
-        params.float_as_real_type ? "float" : "double (default)",
+        std::is_same_v<real_type, float> ? "float" : "double (default)",
         params.format,
         params.input_filename,
         params.scaled_filename,

--- a/src/plssvm/detail/cmd/parser_train.cpp
+++ b/src/plssvm/detail/cmd/parser_train.cpp
@@ -9,6 +9,7 @@
 #include "plssvm/detail/cmd/parser_train.hpp"
 
 #include "plssvm/classification_types.hpp"               // plssvm::classification_type, plssvm::classification_type_to_full_string
+#include "plssvm/constants.hpp"                          // plssvm::real_type
 #include "plssvm/backend_types.hpp"                      // plssvm::list_available_backends
 #include "plssvm/backends/SYCL/implementation_type.hpp"  // plssvm::sycl_generic::list_available_sycl_implementations
 #include "plssvm/constants.hpp"                          // plssvm::verbose_default, plssvm::verbose
@@ -32,6 +33,7 @@
 #include <exception>                                     // std::exception
 #include <filesystem>                                    // std::filesystem::path
 #include <iostream>                                      // std::cout, std::cerr, std::clog, std::endl
+#include <type_traits>                                   // std::is_same_v
 
 namespace plssvm::detail::cmd {
 
@@ -68,7 +70,6 @@ parser_train::parser_train(int argc, char **argv) {
            ("performance_tracking", "the output YAML file where the performance tracking results are written to; if not provided, the results are dumped to stderr", cxxopts::value<decltype(performance_tracking_filename)>())
 #endif
            ("use_strings_as_labels", "use strings as labels instead of plane numbers", cxxopts::value<decltype(strings_as_labels)>()->default_value(fmt::format("{}", strings_as_labels)))
-           ("use_float_as_real_type", "use floats as real types instead of doubles", cxxopts::value<decltype(float_as_real_type)>()->default_value(fmt::format("{}", float_as_real_type)))
            ("verbosity", fmt::format("choose the level of verbosity: full|timing|libsvm|quiet (default: {})", fmt::format("{}", verbosity)), cxxopts::value<verbosity_level>())
            ("q,quiet", "quiet mode (no outputs regardless the provided verbosity level!)", cxxopts::value<bool>()->default_value(verbosity == verbosity_level::quiet ? "true" : "false"))
            ("h,help", "print this helper message", cxxopts::value<bool>())
@@ -199,9 +200,6 @@ parser_train::parser_train(int argc, char **argv) {
     // parse whether strings should be used as labels
     strings_as_labels = result["use_strings_as_labels"].as<decltype(strings_as_labels)>();
 
-    // parse whether floats should be used as real_type
-    float_as_real_type = result["use_float_as_real_type"].as<decltype(float_as_real_type)>();
-
     // parse whether output is quiet or not
     const bool quiet = result["quiet"].as<bool>();
 
@@ -282,7 +280,7 @@ std::ostream &operator<<(std::ostream &out, const parser_train &params) {
         classification_type_to_full_string(params.classification.value()),
         params.classification.is_default() ? " (default)" : "",
         params.strings_as_labels ? "std::string" : "int (default)",
-        params.float_as_real_type ? "float" : "double (default)",
+        std::is_same_v<real_type, float> ? "float" : "double (default)",
         params.input_filename,
         params.model_filename);
     if (!params.performance_tracking_filename.empty()) {

--- a/src/plssvm/detail/performance_tracker.cpp
+++ b/src/plssvm/detail/performance_tracker.cpp
@@ -13,6 +13,8 @@
 #include "plssvm/detail/cmd/parser_predict.hpp"          // plssvm::detail::cmd::parser_predict
 #include "plssvm/detail/cmd/parser_scale.hpp"            // plssvm::detail::cmd::parser_scale
 #include "plssvm/detail/cmd/parser_train.hpp"            // plssvm::detail::cmd::parser_train
+#include "plssvm/constants.hpp"                          // plssvm::real_type
+#include "plssvm/detail/arithmetic_type_name.hpp"        // plssvm::detail::arithmetic_type_name
 #include "plssvm/detail/string_conversion.hpp"           // plssvm::detail::split_as
 #include "plssvm/detail/string_utility.hpp"              // plssvm::detail::trim
 #include "plssvm/detail/utility.hpp"                     // plssvm::detail::current_date_time
@@ -72,7 +74,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<cmd::parser_tr
                                                                       "  sycl_kernel_invocation_type: {}\n"
                                                                       "  sycl_implementation_type:    {}\n"
                                                                       "  strings_as_labels:           {}\n"
-                                                                      "  float_as_real_type:          {}\n"
+                                                                      "  real_type:                   {}\n"
                                                                       "  input_filename:              \"{}\"\n"
                                                                       "  model_filename:              \"{}\"\n",
                                                                       entry.entry_value.csvm_params.kernel_type.value(),
@@ -88,7 +90,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<cmd::parser_tr
                                                                       entry.entry_value.sycl_kernel_invocation_type,
                                                                       entry.entry_value.sycl_implementation_type,
                                                                       entry.entry_value.strings_as_labels,
-                                                                      entry.entry_value.float_as_real_type,
+                                                                      arithmetic_type_name<real_type>(),
                                                                       entry.entry_value.input_filename,
                                                                       entry.entry_value.model_filename));
     }
@@ -101,7 +103,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<cmd::parser_pr
                                                                       "  target:                   {}\n"
                                                                       "  sycl_implementation_type: {}\n"
                                                                       "  strings_as_labels:        {}\n"
-                                                                      "  float_as_real_type:       {}\n"
+                                                                      "  real_type:                {}\n"
                                                                       "  input_filename:           \"{}\"\n"
                                                                       "  model_filename:           \"{}\"\n"
                                                                       "  predict_filename:         \"{}\"\n",
@@ -109,7 +111,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<cmd::parser_pr
                                                                       entry.entry_value.target,
                                                                       entry.entry_value.sycl_implementation_type,
                                                                       entry.entry_value.strings_as_labels,
-                                                                      entry.entry_value.float_as_real_type,
+                                                                      arithmetic_type_name<real_type>(),
                                                                       entry.entry_value.input_filename,
                                                                       entry.entry_value.model_filename,
                                                                       entry.entry_value.predict_filename));
@@ -123,7 +125,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<cmd::parser_sc
                                                                       "  upper:              {}\n"
                                                                       "  format:             {}\n"
                                                                       "  strings_as_labels:  {}\n"
-                                                                      "  float_as_real_type: {}\n"
+                                                                      "  real_type:          {}\n"
                                                                       "  input_filename:     \"{}\"\n"
                                                                       "  scaled_filename:    \"{}\"\n"
                                                                       "  save_filename:      \"{}\"\n"
@@ -132,7 +134,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<cmd::parser_sc
                                                                       entry.entry_value.upper,
                                                                       entry.entry_value.format,
                                                                       entry.entry_value.strings_as_labels,
-                                                                      entry.entry_value.float_as_real_type,
+                                                                      arithmetic_type_name<real_type>(),
                                                                       entry.entry_value.input_filename,
                                                                       entry.entry_value.scaled_filename,
                                                                       entry.entry_value.save_filename,

--- a/src/plssvm/detail/performance_tracker.cpp
+++ b/src/plssvm/detail/performance_tracker.cpp
@@ -8,6 +8,7 @@
 
 #include "plssvm/detail/performance_tracker.hpp"
 
+#include "plssvm/constants.hpp"                          // plssvm::real_type
 #include "plssvm/detail/arithmetic_type_name.hpp"        // plssvm::detail::arithmetic_type_name_v
 #include "plssvm/detail/assert.hpp"                      // PLSSVM_ASSERT
 #include "plssvm/detail/cmd/parser_predict.hpp"          // plssvm::detail::cmd::parser_predict
@@ -18,6 +19,7 @@
 #include "plssvm/detail/string_conversion.hpp"           // plssvm::detail::split_as
 #include "plssvm/detail/string_utility.hpp"              // plssvm::detail::trim
 #include "plssvm/detail/utility.hpp"                     // plssvm::detail::current_date_time
+#include "plssvm/parameter.hpp"                          // plssvm::parameter
 #include "plssvm/version/git_metadata/git_metadata.hpp"  // plssvm::version::git_metadata::commit_sha1
 #include "plssvm/version/version.hpp"                    // plssvm::version::{version, detail::target_platforms}
 
@@ -41,7 +43,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<std::string> &
     tracking_statistics.emplace(entry.entry_category, fmt::format("{}{}: \"{}\"\n", entry.entry_category.empty() ? "" : "  ", entry.entry_name, entry.entry_value));
 }
 
-void performance_tracker::add_tracking_entry(const tracking_entry<::plssvm::parameter> &entry) {
+void performance_tracker::add_tracking_entry(const tracking_entry<plssvm::parameter> &entry) {
     if (is_tracking()) {
         tracking_statistics.emplace("parameter", fmt::format("  kernel_type: {}\n"
                                                              "  degree:      {}\n"
@@ -54,7 +56,7 @@ void performance_tracker::add_tracking_entry(const tracking_entry<::plssvm::para
                                                              entry.entry_value.gamma.is_default() ? std::string{ "#data_points" } : fmt::format("{}", entry.entry_value.gamma.value()),
                                                              entry.entry_value.coef0.value(),
                                                              entry.entry_value.cost.value(),
-                                                             arithmetic_type_name<typename decltype(entry.entry_value)::real_type>()));
+                                                             arithmetic_type_name<real_type>()));
     }
 }
 

--- a/src/plssvm/kernel_function_types.cpp
+++ b/src/plssvm/kernel_function_types.cpp
@@ -95,7 +95,7 @@ real_type kernel_function(const matrix<real_type, layout> &x, const std::size_t 
     throw unsupported_kernel_type_exception{ fmt::format("Unknown kernel type (value: {})!", detail::to_underlying(params.kernel_type)) };
 }
 
-template double kernel_function(const matrix<real_type, layout_type::aos> &, const std::size_t, const matrix<real_type, layout_type::aos> &, const std::size_t, const parameter &);
-template double kernel_function(const matrix<real_type, layout_type::soa> &, const std::size_t, const matrix<real_type, layout_type::soa> &, const std::size_t, const parameter &);
+template real_type kernel_function(const matrix<real_type, layout_type::aos> &, const std::size_t, const matrix<real_type, layout_type::aos> &, const std::size_t, const parameter &);
+template real_type kernel_function(const matrix<real_type, layout_type::soa> &, const std::size_t, const matrix<real_type, layout_type::soa> &, const std::size_t, const parameter &);
 
 }  // namespace plssvm

--- a/src/plssvm/parameter.cpp
+++ b/src/plssvm/parameter.cpp
@@ -8,6 +8,7 @@
 
 #include "plssvm/parameter.hpp"
 
+#include "plssvm/constants.hpp"                    // plssvm::real_type
 #include "plssvm/detail/arithmetic_type_name.hpp"  // plssvm::detail::arithmetic_type_name
 
 #include "fmt/core.h"                              // fmt::format
@@ -17,12 +18,7 @@
 
 namespace plssvm::detail {
 
-// explicitly instantiate template class
-template struct parameter<float>;
-template struct parameter<double>;
-
-template <typename T>
-std::ostream &operator<<(std::ostream &out, const parameter<T> &params) {
+std::ostream &operator<<(std::ostream &out, const parameter &params) {
     return out << fmt::format(
                "kernel_type                 {}\n"
                "degree                      {}\n"
@@ -35,9 +31,7 @@ std::ostream &operator<<(std::ostream &out, const parameter<T> &params) {
                params.gamma,
                params.coef0,
                params.cost,
-               detail::arithmetic_type_name<typename parameter<T>::real_type>());
+               detail::arithmetic_type_name<real_type>());
 }
-template std::ostream &operator<<(std::ostream &, const parameter<float> &);
-template std::ostream &operator<<(std::ostream &, const parameter<double> &);
 
 }  // namespace plssvm::detail


### PR DESCRIPTION
Remove float/double templatisations in favor of a static real_type changeable during the CMake configuration step, reducing compilation times and code duplication in virtual member functions.