### PR TITLE
New warning verbosity level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ set(PLSSVM_BASE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/cmd/parser_scale.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/cmd/parser_train.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/io/file_reader.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/logger.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/memory_size.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/performance_tracker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/sha256.cpp
@@ -91,6 +90,7 @@ set(PLSSVM_BASE_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/parameter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/solver_types.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/target_platforms.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/verbosity_levels.cpp
 )
 
 ## create base library: linked against all backend libraries

--- a/bindings/Python/CMakeLists.txt
+++ b/bindings/Python/CMakeLists.txt
@@ -34,7 +34,6 @@ endif ()
 set(PLSSVM_PYTHON_BINDINGS_SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/exceptions/exceptions.cpp
 
-        ${CMAKE_CURRENT_LIST_DIR}/detail/logger.cpp
         ${CMAKE_CURRENT_LIST_DIR}/detail/performance_tracker.cpp
 
         ${CMAKE_CURRENT_LIST_DIR}/version/version.cpp
@@ -49,6 +48,7 @@ set(PLSSVM_PYTHON_BINDINGS_SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/parameter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/solver_types.cpp
         ${CMAKE_CURRENT_LIST_DIR}/target_platforms.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/verbosity_levels.cpp
 
         ${CMAKE_CURRENT_LIST_DIR}/sklearn.cpp
 

--- a/bindings/Python/detail/logger.cpp
+++ b/bindings/Python/detail/logger.cpp
@@ -6,7 +6,7 @@
  *          See the LICENSE.md file in the project root for full license information.
  */
 
-#include "plssvm/detail/logger.hpp"
+#include "plssvm/verbosity_levels.hpp"
 
 #include "pybind11/operators.h"  // pybind operator overloading
 #include "pybind11/pybind11.h"   // py::module_

--- a/bindings/Python/main.cpp
+++ b/bindings/Python/main.cpp
@@ -15,7 +15,7 @@
 namespace py = pybind11;
 
 // forward declare binding functions
-void init_logger(py::module_ &);
+void init_verbosity_levels(py::module_ &);
 void init_performance_tracker(py::module_ &);
 void init_target_platforms(py::module_ &);
 void init_solver_types(py::module_ &);
@@ -52,7 +52,7 @@ PYBIND11_MODULE(plssvm, m) {
     });
 
     // NOTE: the order matters. DON'T CHANGE IT!
-    init_logger(m);
+    init_verbosity_levels(m);
     init_performance_tracker(m);
     init_target_platforms(m);
     init_solver_types(m);

--- a/bindings/Python/sklearn.cpp
+++ b/bindings/Python/sklearn.cpp
@@ -120,7 +120,11 @@ void parse_provided_params(svc &self, const py::kwargs &args) {
     }
     if (args.contains("verbose")) {
         if (args["verbose"].cast<bool>()) {
-            plssvm::verbosity = plssvm::verbosity_level::full;
+            if (plssvm::verbosity == plssvm::verbosity_level::quiet) {
+                // if current verbosity is quiet, override with full verbosity, since 'verbose=TRUE' should never result in no output
+                plssvm::verbosity = plssvm::verbosity_level::full;
+            }
+            // otherwise: use currently active verbosity level
         } else {
             plssvm::verbosity = plssvm::verbosity_level::quiet;
         }
@@ -217,7 +221,11 @@ void init_sklearn(py::module_ &m) {
                    // to silence constructor messages
                    if (args.contains("verbose")) {
                        if (args["verbose"].cast<bool>()) {
-                           plssvm::verbosity = plssvm::verbosity_level::full;
+                           if (plssvm::verbosity == plssvm::verbosity_level::quiet) {
+                               // if current verbosity is quiet, override with full verbosity, since 'verbose=TRUE' should never result in no output
+                               plssvm::verbosity = plssvm::verbosity_level::full;
+                           }
+                           // otherwise: use currently active verbosity level
                        } else {
                            plssvm::verbosity = plssvm::verbosity_level::quiet;
                        }

--- a/bindings/Python/verbosity_levels.cpp
+++ b/bindings/Python/verbosity_levels.cpp
@@ -13,12 +13,13 @@
 
 namespace py = pybind11;
 
-void init_logger(py::module_ &m) {
+void init_verbosity_levels(py::module_ &m) {
     // bind enum class
     py::enum_<plssvm::verbosity_level> verb_enum(m, "VerbosityLevel");
     verb_enum.value("QUIET", plssvm::verbosity_level::quiet, "nothing is logged to the standard output to stdout")
         .value("LIBSVM", plssvm::verbosity_level::libsvm, "log the same messages as LIBSVM (used for better LIBSVM conformity) to stdout")
         .value("TIMING", plssvm::verbosity_level::timing, "log all messages related to timing information to stdout")
+        .value("WARNING", plssvm::verbosity_level::warning, "log all messages related to warning to stdcerr")
         .value("FULL", plssvm::verbosity_level::full, "log all messages to stdout");
 
     // bind the bitwise operations

--- a/include/plssvm/backends/gpu_csvm.hpp
+++ b/include/plssvm/backends/gpu_csvm.hpp
@@ -21,11 +21,10 @@
 
 #include "fmt/core.h"  // fmt::format
 
-#include <algorithm>   // std::min, std::all_of
-#include <cstddef>     // std::size_t
-#include <iostream>    // std::clog, std::endl
-#include <utility>     // std::forward, std::move
-#include <vector>      // std::vector
+#include <algorithm>  // std::min, std::all_of
+#include <cstddef>    // std::size_t
+#include <utility>    // std::forward, std::move
+#include <vector>     // std::vector
 
 namespace plssvm::detail {
 

--- a/include/plssvm/core.hpp
+++ b/include/plssvm/core.hpp
@@ -30,6 +30,7 @@
 #include "plssvm/kernel_function_types.hpp"                 // all supported kernel function types
 #include "plssvm/solver_types.hpp"                          // all supported solver types (e.g., Conjugate Gradients with explicit, streaming, or implicit kernel matrix generation)
 #include "plssvm/target_platforms.hpp"                      // all supported target platforms
+#include "plssvm/verbosity_levels.hpp"                      // all supported verbosity levels
 
 #include "plssvm/backends/SYCL/implementation_type.hpp"     // the SYCL implementation type
 #include "plssvm/backends/SYCL/kernel_invocation_type.hpp"  // the SYCL specific kernel invocation typ

--- a/include/plssvm/csvm.hpp
+++ b/include/plssvm/csvm.hpp
@@ -18,7 +18,7 @@
 #include "plssvm/data_set.hpp"                    // plssvm::data_set
 #include "plssvm/default_value.hpp"               // plssvm::default_value, plssvm::default_init
 #include "plssvm/detail/igor_utility.hpp"         // plssvm::detail::{get_value_from_named_parameter, has_only_parameter_named_args_v}
-#include "plssvm/detail/logger.hpp"               // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"              // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"          // plssvm::detail::memory_size
 #include "plssvm/detail/operators.hpp"            // plssvm::operators::sign
 #include "plssvm/detail/performance_tracker.hpp"  // plssvm::detail::performance_tracker
@@ -32,6 +32,7 @@
 #include "plssvm/parameter.hpp"                   // plssvm::parameter
 #include "plssvm/solver_types.hpp"                // plssvm::solver_type
 #include "plssvm/target_platforms.hpp"            // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"            // plssvm::verbosity_level
 
 #include "fmt/color.h"    // fmt::fg, fmt::color::orange
 #include "fmt/core.h"     // fmt::format

--- a/include/plssvm/csvm.hpp
+++ b/include/plssvm/csvm.hpp
@@ -818,10 +818,9 @@ std::tuple<aos_matrix<real_type>, std::vector<real_type>, unsigned long long> cs
                         "The biggest single allocation ({}) exceeds the guaranteed maximum memory allocation size ({}), falling back to solver_type::cg_streaming.\n",
                         max_single_allocation_size,
                         max_mem_alloc_size);
-            std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                     "Warning: if you are sure that the guaranteed maximum memory allocation size can be safely ignored on your deivce, "
-                                     "this check can be disabled via \"-DPLSSVM_ENFORCE_MAX_MEM_ALLOC_SIZE=OFF\" during the CMake configuration!")
-                      << std::endl;
+            plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                                "WARNING: if you are sure that the guaranteed maximum memory allocation size can be safely ignored on your device, "
+                                "this check can be disabled via \"-DPLSSVM_ENFORCE_MAX_MEM_ALLOC_SIZE=OFF\" during the CMake configuration!\n");
             used_solver = solver_type::cg_streaming;
         }
 #endif

--- a/include/plssvm/data_set.hpp
+++ b/include/plssvm/data_set.hpp
@@ -19,7 +19,7 @@
 #include "plssvm/detail/io/file_reader.hpp"              // plssvm::detail::io::file_reader
 #include "plssvm/detail/io/libsvm_parsing.hpp"           // plssvm::detail::io::{read_arff_data, write_arff_data}
 #include "plssvm/detail/io/scaling_factors_parsing.hpp"  // plssvm::detail::io::{parse_scaling_factors, read_scaling_factors}
-#include "plssvm/detail/logger.hpp"                      // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                     // plssvm::detail::log
 #include "plssvm/detail/performance_tracker.hpp"         // plssvm::detail::tracking_entry
 #include "plssvm/detail/string_utility.hpp"              // plssvm::detail::ends_with
 #include "plssvm/detail/type_list.hpp"                   // plssvm::detail::{supported_label_types, tuple_contains_v}
@@ -27,6 +27,7 @@
 #include "plssvm/exceptions/exceptions.hpp"              // plssvm::data_set_exception
 #include "plssvm/file_format_types.hpp"                  // plssvm::file_format_type
 #include "plssvm/matrix.hpp"                             // plssvm::soa_matrix
+#include "plssvm/verbosity_levels.hpp"                   // plssvm::verbosity_level
 
 #include "fmt/chrono.h"   // directly output std::chrono times via fmt
 #include "fmt/core.h"     // fmt::format

--- a/include/plssvm/detail/io/libsvm_model_parsing.hpp
+++ b/include/plssvm/detail/io/libsvm_model_parsing.hpp
@@ -18,10 +18,11 @@
 #include "plssvm/data_set.hpp"                  // plssvm::data_set
 #include "plssvm/detail/assert.hpp"             // PLSSVM_ASSERT
 #include "plssvm/detail/io/libsvm_parsing.hpp"  // plssvm::detail::io::parse_libsvm_num_features
-#include "plssvm/detail/logger.hpp"             // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"            // plssvm::detail::log
 #include "plssvm/detail/utility.hpp"            // plssvm::detail::current_date_time
 #include "plssvm/matrix.hpp"                    // plssvm::soa_matrix
 #include "plssvm/parameter.hpp"                 // plssvm::parameter
+#include "plssvm/verbosity_levels.hpp"          // plssvm::verbosity_level
 
 #include "fmt/compile.h"  // FMT_COMPILE
 #include "fmt/format.h"   // fmt::format, fmt::format_to

--- a/include/plssvm/detail/logging.hpp
+++ b/include/plssvm/detail/logging.hpp
@@ -1,0 +1,59 @@
+/**
+ * @file
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Defines a simple logging function.
+ * @details Also used for the plssvm::detail::performance_tracker.
+ */
+
+#ifndef PLSSVM_DETAIL_LOGGER_HPP_
+#define PLSSVM_DETAIL_LOGGER_HPP_
+#pragma once
+
+#include "plssvm/detail/performance_tracker.hpp"  // plssvm::detail::is_tracking_entry_v, PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY
+#include "plssvm/verbosity_levels.hpp"            // plssvm::verbosity_level, plssvm::verbosity
+
+#include "fmt/chrono.h"  // format std::chrono types
+#include "fmt/color.h"   // fmt::fg, fmt::color
+#include "fmt/format.h"  // fmt::format
+
+#include <iostream>     // std::cout, std::clog
+#include <string_view>  // std::string_view
+#include <utility>      // std::forward
+
+namespace plssvm::detail {
+
+/**
+ * @breif Output the message @p msg filling the {fmt} like placeholders with @p args to the standard output stream.
+ * @details If a value in @p Args is of type plssvm::detail::tracking_entry and performance tracking is enabled,
+ *          this is also added to the plssvm::detail::performance_tracker.
+ *          Only logs the message if the verbosity level matches the `plssvm::verbosity` level.
+ * @tparam Args the types of the placeholder values
+ * @param[in] verb the verbosity level of the message to log; must match the `plssvm::verbosity` level to log the message
+ * @param[in] msg the message to print on the standard output stream if requested (i.e., plssvm::verbose is `true`)
+ * @param[in] args the values to fill the {fmt}-like placeholders in @p msg
+ */
+template <typename... Args>
+void log(const verbosity_level verb, const std::string_view msg, Args &&...args) {
+    // if the verbosity level is quiet, nothing is logged
+    // otherwise verb must contain the bit-flag set by plssvm::verbosity
+    if (verbosity != verbosity_level::quiet && (verb & verbosity) != verbosity_level::quiet) {
+        std::cout << fmt::format(msg, args...);
+    }
+
+    // if performance tracking has been enabled, add tracking entries
+    ([](auto &&arg) {
+        if constexpr (detail::is_tracking_entry_v<decltype(arg)>) {
+            PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY(std::forward<decltype(arg)>(arg));
+        }
+    }(std::forward<Args>(args)),
+     ...);
+}
+
+}  // namespace plssvm::detail
+
+#endif  // PLSSVM_DETAIL_LOGGER_HPP_

--- a/include/plssvm/detail/logging_without_performance_tracking.hpp
+++ b/include/plssvm/detail/logging_without_performance_tracking.hpp
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Defines a simple logging function. Wrapper that disables performance tracking due to circular dependencies.
+ */
+
+#ifndef PLSSVM_DETAIL_LOGGING_WITHOUT_PERFORMANCE_TRACKING_HPP_
+#define PLSSVM_DETAIL_LOGGING_WITHOUT_PERFORMANCE_TRACKING_HPP_
+#pragma once
+
+#define PLSSVM_LOG_WITHOUT_PERFORMANCE_TRACKING
+#include "plssvm/detail/logging.hpp"  // plssvm::detail::log
+#undef PLSSVM_LOG_WITHOUT_PERFORMANCE_TRACKING
+
+#endif  // PLSSVM_DETAIL_LOGGING_WITHOUT_PERFORMANCE_TRACKING_HPP_

--- a/include/plssvm/matrix.hpp
+++ b/include/plssvm/matrix.hpp
@@ -13,9 +13,11 @@
 #define PLSSVM_DETAIL_MATRIX_HPP_
 #pragma once
 
-#include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT
-#include "plssvm/detail/utility.hpp"         // plssvm::detail::always_false_v
-#include "plssvm/exceptions/exceptions.hpp"  // plssvm::matrix_exception
+#include "plssvm/detail/assert.hpp"                                // PLSSVM_ASSERT
+#include "plssvm/detail/logging_without_performance_tracking.hpp"  // plssvm::detail::log
+#include "plssvm/detail/utility.hpp"                               // plssvm::detail::always_false_v
+#include "plssvm/exceptions/exceptions.hpp"                        // plssvm::matrix_exception
+#include "plssvm/verbosity_levels.hpp"                             // plssvm::verbosity_level
 
 #include "fmt/color.h"    // fmt::fg, fmt::color::orange
 #include "fmt/core.h"     // fmt::format
@@ -26,7 +28,6 @@
 #include <cstddef>      // std::size_t
 #include <cstring>      // std::memcpy, std::memset
 #include <iosfwd>       // std::istream forward declaration
-#include <iostream>     // std::clog, std::endl
 #include <ostream>      // std::ostream
 #include <string_view>  // std::string_view
 #include <type_traits>  // std::enable_if, std::is_convertible_v, std::is_arithmetic_v
@@ -619,20 +620,18 @@ auto matrix<T, layout_>::at(const size_type row, const size_type col) const -> v
     if (row >= this->num_rows_padded()) {
         throw matrix_exception{ fmt::format("The current row ({}) must be smaller than the number of rows including padding ({} + {})!", row, num_rows_, row_padding_) };
     } else if (row >= this->num_rows()) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: attempting to access padding row {} (only {} real rows exist)!",
-                                 row,
-                                 num_rows_)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: attempting to access padding row {} (only {} real rows exist)!\n",
+                    row,
+                    num_rows_);
     }
     if (col >= this->num_cols_padded()) {
         throw matrix_exception{ fmt::format("The current column ({}) must be smaller than the number of columns including padding ({} + {})!", col, num_cols_, col_padding_) };
     } else if (col >= this->num_cols()) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: attempting to access padding column {} (only {} real columns exist)!",
-                                 col,
-                                 num_cols_)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: attempting to access padding column {} (only {} real columns exist)!\n",
+                    col,
+                    num_cols_);
     }
 
     return (*this)(row, col);
@@ -642,20 +641,18 @@ auto matrix<T, layout_>::at(const size_type row, const size_type col) -> referen
     if (row >= this->num_rows_padded()) {
         throw matrix_exception{ fmt::format("The current row ({}) must be smaller than the number of rows including padding ({} + {})!", row, num_rows_, row_padding_) };
     } else if (row >= this->num_rows()) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: attempting to access padding row {} (only {} real rows exist)!",
-                                 row,
-                                 num_rows_)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: attempting to access padding row {} (only {} real rows exist)!\n",
+                    row,
+                    num_rows_);
     }
     if (col >= this->num_cols_padded()) {
         throw matrix_exception{ fmt::format("The current column ({}) must be smaller than the number of columns including padding ({} + {})!", col, num_cols_, col_padding_) };
     } else if (col >= this->num_cols()) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: attempting to access padding column {} (only {} real columns exist)!",
-                                 col,
-                                 num_cols_)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: attempting to access padding column {} (only {} real columns exist)!\n",
+                    col,
+                    num_cols_);
     }
 
     return (*this)(row, col);

--- a/include/plssvm/model.hpp
+++ b/include/plssvm/model.hpp
@@ -18,11 +18,12 @@
 #include "plssvm/data_set.hpp"                        // plssvm::data_set
 #include "plssvm/detail/assert.hpp"                   // PLSSVM_ASSERT
 #include "plssvm/detail/io/libsvm_model_parsing.hpp"  // plssvm::detail::io::{parse_libsvm_model_header, parse_libsvm_model_data, write_libsvm_model_data}
-#include "plssvm/detail/logger.hpp"                   // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                  // plssvm::detail::log
 #include "plssvm/detail/performance_tracker.hpp"      // plssvm::detail::tracking_entry
 #include "plssvm/detail/type_list.hpp"                // plssvm::detail::{supported_label_types, tuple_contains_v}
 #include "plssvm/matrix.hpp"                          // plssvm::soa_matrix
 #include "plssvm/parameter.hpp"                       // plssvm::parameter
+#include "plssvm/verbosity_levels.hpp"                // plssvm::verbosity_level
 
 #include "fmt/chrono.h"  // format std::chrono types using fmt
 #include "fmt/core.h"    // fmt::format

--- a/include/plssvm/parameter.hpp
+++ b/include/plssvm/parameter.hpp
@@ -19,6 +19,7 @@
 #include "plssvm/detail/type_traits.hpp"     // PLSSVM_REQUIRES, plssvm::detail::{remove_cvref_t, always_false_v}
 #include "plssvm/detail/utility.hpp"         // plssvm::detail::unreachable
 #include "plssvm/kernel_function_types.hpp"  // plssvm::kernel_function_type, plssvm::kernel_function_type_to_math_string
+#include "plssvm/verbosity_levels.hpp"       // plssvm::verbosity_level, plssvm::verbosity
 
 #include "fmt/core.h"     // fmt::format
 #include "fmt/ostream.h"  // fmt::formatter, fmt::ostream_formatter

--- a/include/plssvm/parameter.hpp
+++ b/include/plssvm/parameter.hpp
@@ -13,19 +13,20 @@
 #define PLSSVM_PARAMETER_HPP_
 #pragma once
 
-#include "plssvm/constants.hpp"              // plssvm::real_type
-#include "plssvm/default_value.hpp"          // plssvm::default_value, plssvm::is_default_value_v
-#include "plssvm/detail/igor_utility.hpp"    // plssvm::detail::{has_only_named_args_v, get_value_from_named_parameter}
-#include "plssvm/detail/type_traits.hpp"     // PLSSVM_REQUIRES, plssvm::detail::{remove_cvref_t, always_false_v}
-#include "plssvm/detail/utility.hpp"         // plssvm::detail::unreachable
-#include "plssvm/kernel_function_types.hpp"  // plssvm::kernel_function_type, plssvm::kernel_function_type_to_math_string
-#include "plssvm/verbosity_levels.hpp"       // plssvm::verbosity_level, plssvm::verbosity
+#include "plssvm/constants.hpp"                                    // plssvm::real_type
+#include "plssvm/default_value.hpp"                                // plssvm::default_value, plssvm::is_default_value_v
+#include "plssvm/detail/igor_utility.hpp"                          // plssvm::detail::{has_only_named_args_v, get_value_from_named_parameter}
+#include "plssvm/detail/logging_without_performance_tracking.hpp"  // plssvm::detail::log
+#include "plssvm/detail/type_traits.hpp"                           // PLSSVM_REQUIRES, plssvm::detail::{remove_cvref_t, always_false_v}
+#include "plssvm/detail/utility.hpp"                               // plssvm::detail::unreachable
+#include "plssvm/kernel_function_types.hpp"                        // plssvm::kernel_function_type, plssvm::kernel_function_type_to_math_string
+#include "plssvm/verbosity_levels.hpp"                             // plssvm::verbosity_level, plssvm::verbosity
 
 #include "fmt/core.h"     // fmt::format
 #include "fmt/ostream.h"  // fmt::formatter, fmt::ostream_formatter
 #include "igor/igor.hpp"  // IGOR_MAKE_NAMED_ARGUMENT, igor::parser, igor::has_unnamed_arguments, igor::has_other_than
 
-#include <iostream>     // std::clog, std::endl, std::ostream
+#include <iosfwd>       // forward declare std::ostream and std::istream
 #include <string_view>  // std::string_view
 #include <type_traits>  // std::is_same_v, std::is_convertible_v
 #include <utility>      // std::forward
@@ -183,7 +184,12 @@ struct parameter {
 
         // shorthand function for emitting a warning if a provided parameter is not used by the current kernel function
         [[maybe_unused]] const auto print_warning = [](const std::string_view param_name, const kernel_function_type kernel) {
-            std::clog << fmt::format("{} parameter provided, which is not used in the {} kernel ({})!", param_name, kernel, kernel_function_type_to_math_string(kernel)) << std::endl;
+            // NOTE: can't use the log function due to circular dependencies
+            detail::log(verbosity_level::full | verbosity_level::warning,
+                        "WARNING: {} parameter provided, which is not used in the {} kernel ({})!\n",
+                        param_name,
+                        kernel,
+                        kernel_function_type_to_math_string(kernel));
         };
 
         // compile time/runtime check: the values must have the correct types

--- a/include/plssvm/verbosity_levels.hpp
+++ b/include/plssvm/verbosity_levels.hpp
@@ -25,13 +25,15 @@ namespace plssvm {
  */
 enum class verbosity_level {
     /** Nothing is logged to the standard output. */
-    quiet = 0b000,
+    quiet = 0b0000,
     /** Log the same messages as LIBSVM (used for better LIBSVM conformity). */
-    libsvm = 0b001,
+    libsvm = 0b0001,
     /** Log all messages related to timing information. */
-    timing = 0b010,
+    timing = 0b0010,
+    /** Log all messages related to warnings. */
+    warning = 0b0100,
     /** Log all messages (i.e., timing, warning, and additional messages). */
-    full = 0b100
+    full = 0b1000
 };
 
 /// The verbosity level used in the logging function. My be changed by the user.

--- a/include/plssvm/verbosity_levels.hpp
+++ b/include/plssvm/verbosity_levels.hpp
@@ -6,25 +6,17 @@
  * @license This file is part of the PLSSVM project which is released under the MIT license.
  *          See the LICENSE.md file in the project root for full license information.
  *
- * @brief Defines a simple logging function.
- * @details Also used for the plssvm::detail::performance_tracker.
+ * @brief Defines an enumeration holding all possible verbosity levels.
  */
 
-#ifndef PLSSVM_DETAIL_LOGGER_HPP_
-#define PLSSVM_DETAIL_LOGGER_HPP_
-#pragma once
+#ifndef PLSSVM_VERBOSITY_LEVELS_HPP_
+#define PLSSVM_VERBOSITY_LEVELS_HPP_
 
-#include "plssvm/detail/performance_tracker.hpp"  // plssvm::detail::is_tracking_entry_v, PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY
-#include "plssvm/detail/utility.hpp"              // PLSSVM_EXTERN
+#include "plssvm/detail/utility.hpp"  // PLSSVM_EXTERN
 
-#include "fmt/chrono.h"   // format std::chrono types
-#include "fmt/format.h"   // fmt::format
 #include "fmt/ostream.h"  // fmt::formatter, fmt::ostream_formatter
 
-#include <iosfwd>       // std::istream, std::ostream
-#include <iostream>     // std::cout
-#include <string_view>  // std::string_view
-#include <utility>      // std::forward
+#include <iosfwd>  // std::istream, std::ostream
 
 namespace plssvm {
 
@@ -38,7 +30,7 @@ enum class verbosity_level {
     libsvm = 0b001,
     /** Log all messages related to timing information. */
     timing = 0b010,
-    /** Log all messages. */
+    /** Log all messages (i.e., timing, warning, and additional messages). */
     full = 0b100
 };
 
@@ -94,40 +86,9 @@ verbosity_level operator|=(verbosity_level &lhs, verbosity_level rhs);
  */
 verbosity_level operator&=(verbosity_level &lhs, verbosity_level rhs);
 
-namespace detail {
-
-/**
- * @breif Output the message @p msg filling the {fmt} like placeholders with @p args to the standard output stream.
- * @details If a value in @p Args is of type plssvm::detail::tracking_entry and performance tracking is enabled,
- *          this is also added to the plssvm::detail::performance_tracker.
- *          Only logs the message if the verbosity level matches the `plssvm::verbosity` level.
- * @tparam Args the types of the placeholder values
- * @param[in] verb the verbosity level of the message to log; must match the `plssvm::verbosity` level to log the message
- * @param[in] msg the message to print on the standard output stream if requested (i.e., plssvm::verbose is `true`)
- * @param[in] args the values to fill the {fmt}-like placeholders in @p msg
- */
-template <typename... Args>
-void log(const verbosity_level verb, const std::string_view msg, Args &&...args) {
-    // if the verbosity level is quiet, nothing is logged
-    // otherwise verb must contain the bit-flag set by plssvm::verbosity
-    if (verbosity != verbosity_level::quiet && (verb & verbosity) != verbosity_level::quiet) {
-        std::cout << fmt::format(msg, args...);
-    }
-
-    // if performance tracking has been enabled, add tracking entries
-    ([](auto &&arg) {
-        if constexpr (detail::is_tracking_entry_v<decltype(arg)>) {
-            PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY(std::forward<decltype(arg)>(arg));
-        }
-    }(std::forward<Args>(args)),
-     ...);
-}
-
-}  // namespace detail
-
 }  // namespace plssvm
 
 template <>
 struct fmt::formatter<plssvm::verbosity_level> : fmt::ostream_formatter {};
 
-#endif  // PLSSVM_DETAIL_LOGGER_HPP_
+#endif  // PLSSVM_VERBOSITY_LEVELS_HPP_

--- a/src/main_predict.cpp
+++ b/src/main_predict.cpp
@@ -23,7 +23,7 @@
 #include <cstdlib>                                  // EXIT_SUCCESS, EXIT_FAILURE
 #include <exception>                                // std::exception
 #include <fstream>                                  // std::ofstream
-#include <iostream>                                 // std::cerr, std::clog, std::endl
+#include <iostream>                                 // std::cerr, std::endl
 #include <variant>                                  // std::visit
 #include <vector>                                   // std::vector
 

--- a/src/main_predict.cpp
+++ b/src/main_predict.cpp
@@ -12,8 +12,9 @@
 
 #include "plssvm/detail/cmd/data_set_variants.hpp"  // plssvm::detail::cmd::data_set_factory
 #include "plssvm/detail/cmd/parser_predict.hpp"     // plssvm::detail::cmd::parser_predict
-#include "plssvm/detail/logger.hpp"                 // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                // plssvm::detail::log
 #include "plssvm/detail/performance_tracker.hpp"    // plssvm::detail::tracking_entry, PLSSVM_DETAIL_PERFORMANCE_TRACKER_SAVE, PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY
+#include "plssvm/verbosity_levels.hpp"              // plssvm::verbosity_level
 
 #include "fmt/format.h"                             // fmt::print, fmt::join
 #include "fmt/os.h"                                 // fmt::ostream, fmt::output_file

--- a/src/main_scale.cpp
+++ b/src/main_scale.cpp
@@ -20,7 +20,7 @@
 #include <chrono>                                   // std::chrono::{steady_clock, duration}
 #include <cstdlib>                                  // std::exit, EXIT_SUCCESS, EXIT_FAILURE
 #include <exception>                                // std::exception
-#include <iostream>                                 // std::cerr, std::clog, std::endl
+#include <iostream>                                 // std::cerr, std::endl
 #include <utility>                                  // std::pair
 #include <variant>                                  // std::visit
 

--- a/src/main_scale.cpp
+++ b/src/main_scale.cpp
@@ -12,9 +12,10 @@
 
 #include "plssvm/detail/cmd/data_set_variants.hpp"  // plssvm::detail::cmd::data_set_factory
 #include "plssvm/detail/cmd/parser_scale.hpp"       // plssvm::detail::cmd::parser_scale
-#include "plssvm/detail/logger.hpp"                 // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                // plssvm::detail::log
 #include "plssvm/detail/performance_tracker.hpp"    // plssvm::detail::tracking_entry,PLSSVM_DETAIL_PERFORMANCE_TRACKER_SAVE
 #include "plssvm/matrix.hpp"                        // plssvm::matrix
+#include "plssvm/verbosity_levels.hpp"              // plssvm::verbosity_level
 
 #include <chrono>                                   // std::chrono::{steady_clock, duration}
 #include <cstdlib>                                  // std::exit, EXIT_SUCCESS, EXIT_FAILURE

--- a/src/main_train.cpp
+++ b/src/main_train.cpp
@@ -12,8 +12,9 @@
 
 #include "plssvm/detail/cmd/data_set_variants.hpp"  // plssvm::detail::cmd::data_set_factory
 #include "plssvm/detail/cmd/parser_train.hpp"       // plssvm::detail::cmd::parser_train
-#include "plssvm/detail/logger.hpp"                 // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                // plssvm::detail::log
 #include "plssvm/detail/performance_tracker.hpp"    // plssvm::detail::tracking_entry, PLSSVM_DETAIL_PERFORMANCE_TRACKER_SAVE
+#include "plssvm/verbosity_levels.hpp"              // plssvm::verbosity_level
 
 #include <chrono>                                   // std::chrono::{steady_clock, duration}
 #include <cstdlib>                                  // EXIT_SUCCESS, EXIT_FAILURE

--- a/src/main_train.cpp
+++ b/src/main_train.cpp
@@ -19,7 +19,7 @@
 #include <chrono>                                   // std::chrono::{steady_clock, duration}
 #include <cstdlib>                                  // EXIT_SUCCESS, EXIT_FAILURE
 #include <exception>                                // std::exception
-#include <iostream>                                 // std::cerr, std::clog, std::endl
+#include <iostream>                                 // std::cerr, std::endl
 #include <variant>                                  // std::visit
 
 int main(int argc, char *argv[]) {

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -17,13 +17,14 @@
 #include "plssvm/backends/CUDA/predict_kernel.cuh"                      // plssvm::cuda::detail::{device_kernel_w_linear, device_kernel_predict_polynomial, device_kernel_predict_rbf}
 #include "plssvm/constants.hpp"                                         // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                                     // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                                     // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                                    // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"                                // plssvm::detail::memory_size
 #include "plssvm/detail/performance_tracker.hpp"                        // plssvm::detail::tracking_entry
 #include "plssvm/exceptions/exceptions.hpp"                             // plssvm::exception
 #include "plssvm/kernel_function_types.hpp"                             // plssvm::kernel_function_type
 #include "plssvm/parameter.hpp"                                         // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                                  // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                                  // plssvm::verbosity_level
 
 #include "cuda.h"              // cuda runtime functions
 #include "cuda_runtime_api.h"  // cuda runtime functions

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -87,7 +87,9 @@ void csvm::init(const target_platform target) {
 
     // currently only single GPU execution is supported
     if (devices_.size() != 1) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange), "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!", devices_.size()) << std::endl;
+        plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                            "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!\n",
+                            devices_.size());
         devices_.resize(1);
     }
 

--- a/src/plssvm/backends/HIP/csvm.hip.cpp
+++ b/src/plssvm/backends/HIP/csvm.hip.cpp
@@ -72,7 +72,9 @@ void csvm::init(const target_platform target) {
 
     // currently only single GPU execution is supported
     if (devices_.size() != 1) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange), "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!", devices_.size()) << std::endl;
+        plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                            "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!\n",
+                            devices_.size());
         devices_.resize(1);
     }
 

--- a/src/plssvm/backends/HIP/csvm.hip.cpp
+++ b/src/plssvm/backends/HIP/csvm.hip.cpp
@@ -17,13 +17,14 @@
 #include "plssvm/backends/HIP/predict_kernel.hip.hpp"                      // plssvm::hip::detail::{device_kernel_w_linear, device_kernel_predict_polynomial, device_kernel_predict_rbf}
 #include "plssvm/constants.hpp"                                            // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                                        // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                                        // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                                       // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"                                   // plssvm::detail::memory_size
 #include "plssvm/detail/performance_tracker.hpp"                           // plssvm::detail::tracking_entry
 #include "plssvm/exceptions/exceptions.hpp"                                // plssvm::exception
 #include "plssvm/kernel_function_types.hpp"                                // plssvm::kernel_function_type
 #include "plssvm/parameter.hpp"                                            // plssvm::parameter, plssvm::detail::parameter
 #include "plssvm/target_platforms.hpp"                                     // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                                     // plssvm::verbosity_level
 
 #include "hip/hip_runtime_api.h"  // HIP runtime functions
 

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -17,13 +17,14 @@
 #include "plssvm/backends/OpenCL/exceptions.hpp"            // plssvm::opencl::backend_exception
 #include "plssvm/constants.hpp"                             // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                         // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                         // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                        // plssvm::detail::log
 #include "plssvm/detail/performance_tracker.hpp"            // plssvm::detail::tracking_entry
 #include "plssvm/detail/utility.hpp"                        // plssvm::detail::contains
 #include "plssvm/exceptions/exceptions.hpp"                 // plssvm::exception
 #include "plssvm/kernel_function_types.hpp"                 // plssvm::kernel_function_type
 #include "plssvm/parameter.hpp"                             // plssvm::parameter, plssvm::detail::parameter
 #include "plssvm/target_platforms.hpp"                      // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                      // plssvm::verbosity_level
 
 #include "fmt/chrono.h"   // can directly print std::chrono literals
 #include "fmt/color.h"    // fmt::fg, fmt::color::orange

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -8,6 +8,7 @@
 
 #include "plssvm/backends/OpenCL/csvm.hpp"
 
+#include "plssvm/backend_types.hpp"                         // plssvm::backend_type
 #include "plssvm/backends/OpenCL/detail/command_queue.hpp"  // plssvm::opencl::detail::command_queue
 #include "plssvm/backends/OpenCL/detail/context.hpp"        // plssvm::opencl::detail::context
 #include "plssvm/backends/OpenCL/detail/device_ptr.hpp"     // plssvm::opencl::detail::device_ptr

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -125,7 +125,9 @@ void csvm::init(const target_platform target) {
 
     // currently only single GPU execution is supported
     if (devices_.size() != 1) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange), "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!", devices_.size()) << std::endl;
+        plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                            "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!\n",
+                            devices_.size());
         devices_.resize(1);
     }
 

--- a/src/plssvm/backends/OpenCL/detail/utility.cpp
+++ b/src/plssvm/backends/OpenCL/detail/utility.cpp
@@ -15,13 +15,14 @@
 #include "plssvm/backends/OpenCL/exceptions.hpp"            // plssvm::opencl::backend_exception
 #include "plssvm/constants.hpp"                             // plssvm::real_type, plssvm::THREAD_BLOCK_SIZE, plssvm::FEATURE_BLOCK_SIZE
 #include "plssvm/detail/arithmetic_type_name.hpp"           // plssvm::detail::arithmetic_type_name
-#include "plssvm/detail/logger.hpp"                         // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                        // plssvm::detail::log
 #include "plssvm/detail/sha256.hpp"                         // plssvm::detail::sha256
 #include "plssvm/detail/string_conversion.hpp"              // plssvm::detail::extract_first_integer_from_string
 #include "plssvm/detail/string_utility.hpp"                 // plssvm::detail::replace_all, plssvm::detail::to_lower_case, plssvm::detail::contains
 #include "plssvm/detail/utility.hpp"                        // plssvm::detail::erase_if
 #include "plssvm/exceptions/exceptions.hpp"                 // plssvm::unsupported_kernel_type_exception, plssvm::invalid_file_format_exception
 #include "plssvm/target_platforms.hpp"                      // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                      // plssvm::verbosity_level
 
 #include "CL/cl.h"        // cl_program, cl_platform_id, cl_device_id, cl_uint, cl_device_type, cl_context,
                           // CL_DEVICE_NAME, CL_QUEUE_DEVICE, CL_DEVICE_TYPE_ALL, CL_DEVICE_TYPE_CPU, CL_DEVICE_TYPE_GPU, CL_DEVICE_VENDOR, CL_PROGRAM_BUILD_LOG, CL_PROGRAM_BINARY_SIZES, CL_PROGRAM_BINARIES,

--- a/src/plssvm/backends/OpenMP/csvm.cpp
+++ b/src/plssvm/backends/OpenMP/csvm.cpp
@@ -15,7 +15,7 @@
 #include "plssvm/constants.hpp"                                           // plssvm::real_type
 #include "plssvm/csvm.hpp"                                                // plssvm::csvm
 #include "plssvm/detail/assert.hpp"                                       // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                                       // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                                      // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"                                  // plssvm::detail::memory_size
 #include "plssvm/detail/operators.hpp"                                    // various operator overloads for std::vector and scalars
 #include "plssvm/detail/performance_tracker.hpp"                          // plssvm::detail::tracking_entry, PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY
@@ -23,6 +23,7 @@
 #include "plssvm/matrix.hpp"                                              // plssvm::aos_matrix, plssvm::soa_matrix
 #include "plssvm/parameter.hpp"                                           // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                                    // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                                    // plssvm::verbosity_level
 
 #include "fmt/chrono.h"   // directly print std::chrono literals with fmt
 #include "fmt/core.h"     // fmt::format

--- a/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
+++ b/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
@@ -12,6 +12,7 @@
 #include "plssvm/backends/SYCL/DPCPP/detail/queue_impl.hpp"  // plssvm::dpcpp::detail::queue (PImpl implementation)
 #include "plssvm/backends/SYCL/DPCPP/detail/utility.hpp"     // plssvm::dpcpp::detail::get_device_list, plssvm::dpcpp::device_synchronize
 
+#include "plssvm/backend_types.hpp"                                     // plssvm::backend_type
 #include "plssvm/backends/SYCL/cg_explicit/blas.hpp"                    // plssvm::sycl::device_kernel_gemm
 #include "plssvm/backends/SYCL/cg_explicit/kernel_matrix_assembly.hpp"  // plssvm::sycl::{device_kernel_assembly_linear, device_kernel_assembly_polynomial, device_kernel_assembly_rbf}
 #include "plssvm/backends/SYCL/exceptions.hpp"                          // plssvm::dpcpp::backend_exception

--- a/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
+++ b/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
@@ -81,7 +81,9 @@ void csvm::init(const target_platform target) {
 
     // currently only single GPU execution is supported
     if (devices_.size() != 1) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange), "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!", devices_.size()) << std::endl;
+        plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                            "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!\n",
+                            devices_.size());
         devices_.resize(1);
     }
 

--- a/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
+++ b/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
@@ -19,13 +19,14 @@
 #include "plssvm/backends/SYCL/predict_kernel.hpp"                      // plssvm::sycl::detail::{kernel_w, device_kernel_predict_polynomial, device_kernel_predict_rbf}
 #include "plssvm/constants.hpp"                                         // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                                     // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                                     // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                                    // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"                                // plssvm::detail::memory_size
 #include "plssvm/detail/performance_tracker.hpp"                        // plssvm::detail::tracking_entry
 #include "plssvm/exceptions/exceptions.hpp"                             // plssvm::exception
 #include "plssvm/kernel_function_types.hpp"                             // plssvm::kernel_type
 #include "plssvm/parameter.hpp"                                         // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                                  // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                                  // plssvm::verbosity_level
 
 #include "fmt/color.h"    // fmt::fg, fmt::color::orange
 #include "fmt/core.h"     // fmt::format

--- a/src/plssvm/backends/SYCL/hipSYCL/csvm.cpp
+++ b/src/plssvm/backends/SYCL/hipSYCL/csvm.cpp
@@ -12,6 +12,7 @@
 #include "plssvm/backends/SYCL/hipSYCL/detail/queue_impl.hpp"  // plssvm::hipsycl::detail::queue (PImpl implementation)
 #include "plssvm/backends/SYCL/hipSYCL/detail/utility.hpp"     // plssvm::hipsycl::detail::get_device_list, plssvm::hipsycl::device_synchronize
 
+#include "plssvm/backend_types.hpp"                                     // plssvm::backend_type
 #include "plssvm/backends/SYCL/cg_explicit/blas.hpp"                    // plssvm::sycl::device_kernel_gemm
 #include "plssvm/backends/SYCL/cg_explicit/kernel_matrix_assembly.hpp"  // plssvm::sycl::{device_kernel_assembly_linear, device_kernel_assembly_polynomial, device_kernel_assembly_rbf}
 #include "plssvm/backends/SYCL/exceptions.hpp"                          // plssvm::hipsycl::backend_exception

--- a/src/plssvm/backends/SYCL/hipSYCL/csvm.cpp
+++ b/src/plssvm/backends/SYCL/hipSYCL/csvm.cpp
@@ -82,7 +82,9 @@ void csvm::init(const target_platform target) {
 
     // currently only single GPU execution is supported
     if (devices_.size() != 1) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange), "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!", devices_.size()) << std::endl;
+        plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                            "WARNING: found {} devices, but currently only single GPU execution is supported. Continuing only with device 0!\n",
+                            devices_.size());
         devices_.resize(1);
     }
 
@@ -92,9 +94,8 @@ void csvm::init(const target_platform target) {
         invocation_type_ = sycl::kernel_invocation_type::nd_range;
         if (target_ == target_platform::cpu) {
 #if !defined(__HIPSYCL_USE_ACCELERATED_CPU__)
-            std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                     "WARNING: the hipSYCL automatic target for the CPU is set to nd_range, but hipSYCL hasn't been build with the \"omp.accelerated\" compilation flow resulting in major performance losses!")
-                      << std::endl;
+            plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                                "WARNING: the hipSYCL automatic target for the CPU is set to nd_range, but hipSYCL hasn't been build with the \"omp.accelerated\" compilation flow resulting in major performance losses!\n");
 #endif
         }
     }
@@ -155,7 +156,8 @@ void csvm::device_synchronize(const queue_type &queue) const {
 ::plssvm::detail::memory_size csvm::get_device_memory() const {
     const ::plssvm::detail::memory_size hipsycl_global_mem_size{ static_cast<unsigned long long>(devices_[0].impl->sycl_queue.get_device().get_info<::sycl::info::device::global_mem_size>()) };
     if (target_ == target_platform::cpu) {
-        std::clog << "Warning: the returned 'global_mem_size' for hipSYCL targeting the CPU is nonsensical ('std::numeric_limits<std::size_t>::max()'). Using 'get_system_memory()' instead." << std::endl;
+        plssvm::detail::log(verbosity_level::full | verbosity_level::warning,
+                            "WARNING: the returned 'global_mem_size' for hipSYCL targeting the CPU is nonsensical ('std::numeric_limits<std::size_t>::max()'). Using 'get_system_memory()' instead.\n");
         return std::min(hipsycl_global_mem_size, ::plssvm::detail::get_system_memory());
     } else {
         return hipsycl_global_mem_size;

--- a/src/plssvm/backends/SYCL/hipSYCL/csvm.cpp
+++ b/src/plssvm/backends/SYCL/hipSYCL/csvm.cpp
@@ -19,7 +19,7 @@
 #include "plssvm/backends/SYCL/predict_kernel.hpp"                      // plssvm::sycl::detail::{kernel_w, device_kernel_predict_polynomial, device_kernel_predict_rbf}
 #include "plssvm/constants.hpp"                                         // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                                     // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                                     // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"                                    // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"                                // plssvm::detail::memory_size
 #include "plssvm/detail/performance_tracker.hpp"                        // plssvm::detail::tracking_entry
 #include "plssvm/detail/utility.hpp"                                    // plssvm::detail::get_system_memory
@@ -27,6 +27,7 @@
 #include "plssvm/kernel_function_types.hpp"                             // plssvm::kernel_type
 #include "plssvm/parameter.hpp"                                         // plssvm::parameter, plssvm::detail::parameter
 #include "plssvm/target_platforms.hpp"                                  // plssvm::target_platform
+#include "plssvm/verbosity_levels.hpp"                                  // plssvm::verbosity_level
 
 #include "fmt/color.h"    // fmt::fg, fmt::color::orange
 #include "fmt/core.h"     // fmt::format

--- a/src/plssvm/classification_report.cpp
+++ b/src/plssvm/classification_report.cpp
@@ -8,6 +8,7 @@
 
 #include "plssvm/classification_report.hpp"
 
+#include "plssvm/detail/logging.hpp"         // plssvm::detail::log
 #include "plssvm/detail/string_utility.hpp"  // plssvm::detail::to_lower_case
 
 #include "fmt/format.h"  // fmt::format
@@ -32,8 +33,10 @@ double sanitize_nan(const double dividend, const double divisor, const classific
         // handle the correct zero division behavior
         switch (zero_div) {
             case classification_report::zero_division_behavior::warn:
-                std::clog << metric_name << " is ill-defined and is set to 0.0 in labels with no predicted samples. "
-                                            "Use 'plssvm::classification_report::zero_division' parameter to control this behavior.\n";
+                detail::log(verbosity_level::full,
+                            "{} is ill-defined and is set to 0.0 in labels with no predicted samples. "
+                            "Use 'plssvm::classification_report::zero_division' parameter to control this behavior.\n",
+                            metric_name);
                 [[fallthrough]];
             case classification_report::zero_division_behavior::zero:
                 return 0.0;

--- a/src/plssvm/csvm.cpp
+++ b/src/plssvm/csvm.cpp
@@ -10,7 +10,7 @@
 
 #include "plssvm/constants.hpp"                   // plssvm::real_type
 #include "plssvm/detail/assert.hpp"               // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"               // plssvm::detail::log, plssvm::verbosity_level
+#include "plssvm/detail/logging.hpp"              // plssvm::detail::log
 #include "plssvm/detail/operators.hpp"            // plssvm operator overloads for vectors
 #include "plssvm/detail/performance_tracker.hpp"  // PLSSVM_DETAIL_PERFORMANCE_TRACKER_ADD_TRACKING_ENTRY, plssvm::detail::tracking_entry
 #include "plssvm/detail/simple_any.hpp"           // plssvm::detail::simple_any
@@ -19,6 +19,7 @@
 #include "plssvm/matrix.hpp"                      // plssvm::aos_matrix
 #include "plssvm/parameter.hpp"                   // plssvm::parameter
 #include "plssvm/solver_types.hpp"                // plssvm::solver_type
+#include "plssvm/verbosity_levels.hpp"            // plssvm::verbosity_level
 
 #include "fmt/core.h"  // fmt::format
 
@@ -187,19 +188,19 @@ std::pair<std::vector<real_type>, real_type> csvm::perform_dimensional_reduction
     std::vector<real_type> q_red(num_rows_reduced);
     switch (params.kernel_type) {
         case kernel_function_type::linear:
-            #pragma omp parallel for default(none) shared(q_red, A) firstprivate(num_rows_reduced)
+#pragma omp parallel for default(none) shared(q_red, A) firstprivate(num_rows_reduced)
             for (std::size_t i = 0; i < num_rows_reduced; ++i) {
                 q_red[i] = kernel_function<kernel_function_type::linear>(A, i, A, num_rows_reduced);
             }
             break;
         case kernel_function_type::polynomial:
-            #pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
+#pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
             for (std::size_t i = 0; i < num_rows_reduced; ++i) {
                 q_red[i] = kernel_function<kernel_function_type::polynomial>(A, i, A, num_rows_reduced, params.degree.value(), params.gamma.value(), params.coef0.value());
             }
             break;
         case kernel_function_type::rbf:
-            #pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
+#pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
             for (std::size_t i = 0; i < num_rows_reduced; ++i) {
                 q_red[i] = kernel_function<kernel_function_type::rbf>(A, i, A, num_rows_reduced, params.gamma.value());
             }

--- a/src/plssvm/detail/cmd/parser_predict.cpp
+++ b/src/plssvm/detail/cmd/parser_predict.cpp
@@ -8,13 +8,14 @@
 
 #include "plssvm/detail/cmd/parser_predict.hpp"
 
-#include "plssvm/backend_types.hpp"                      // plssvm::list_available_backends
-#include "plssvm/backends/SYCL/implementation_type.hpp"  // plssvm::sycl::list_available_sycl_implementations
-#include "plssvm/constants.hpp"                          // plssvm::real_type
-#include "plssvm/detail/assert.hpp"                      // PLSSVM_ASSERT
-#include "plssvm/target_platforms.hpp"                   // plssvm::list_available_target_platforms
-#include "plssvm/verbosity_levels.hpp"                   // plssvm::verbosity
-#include "plssvm/version/version.hpp"                    // plssvm::version::detail::get_version_info
+#include "plssvm/backend_types.hpp"                                // plssvm::list_available_backends
+#include "plssvm/backends/SYCL/implementation_type.hpp"            // plssvm::sycl::list_available_sycl_implementations
+#include "plssvm/constants.hpp"                                    // plssvm::real_type
+#include "plssvm/detail/assert.hpp"                                // PLSSVM_ASSERT
+#include "plssvm/detail/logging_without_performance_tracking.hpp"  // plssvm::detail::log
+#include "plssvm/target_platforms.hpp"                             // plssvm::list_available_target_platforms
+#include "plssvm/verbosity_levels.hpp"                             // plssvm::verbosity, plssvm::verbosity_level
+#include "plssvm/version/version.hpp"                              // plssvm::version::detail::get_version_info
 
 #include "cxxopts.hpp"    // cxxopts::{Options, value, ParseResult}
 #include "fmt/color.h"    // fmt::fg, fmt::color::orange
@@ -24,7 +25,7 @@
 #include <cstdlib>      // std::exit, EXIT_SUCCESS, EXIT_FAILURE
 #include <exception>    // std::exception
 #include <filesystem>   // std::filesystem::path
-#include <iostream>     // std::cout, std::cerr, std::clog, std::endl
+#include <iostream>     // std::cout, std::cerr, std::endl
 #include <type_traits>  // std::is_same_v
 
 namespace plssvm::detail::cmd {
@@ -68,7 +69,7 @@ parser_predict::parser_predict(int argc, char **argv) {
         options.parse_positional({ "test", "model", "output" });
         result = options.parse(argc, argv);
     } catch (const std::exception &e) {
-        std::cerr << e.what() << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: {}\n", e.what()) << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }
@@ -87,7 +88,7 @@ parser_predict::parser_predict(int argc, char **argv) {
 
     // check if the number of positional arguments is not too large
     if (!result.unmatched().empty()) {
-        std::cerr << fmt::format("Only up to three positional options may be given, but {} (\"{}\") additional option(s) where provided!", result.unmatched().size(), fmt::join(result.unmatched(), " ")) << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: only up to three positional options may be given, but {} (\"{}\") additional option(s) where provided!", result.unmatched().size(), fmt::join(result.unmatched(), " ")) << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }
@@ -104,10 +105,9 @@ parser_predict::parser_predict(int argc, char **argv) {
 
     // warn if a SYCL implementation type is explicitly set but SYCL isn't the current backend
     if (backend != backend_type::sycl && sycl_implementation_type != sycl::implementation_type::automatic) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: explicitly set a SYCL implementation type but the current backend isn't SYCL; ignoring --sycl_implementation_type={}",
-                                 sycl_implementation_type)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: explicitly set a SYCL implementation type but the current backend isn't SYCL; ignoring --sycl_implementation_type={}\n",
+                    sycl_implementation_type);
     }
 #endif
 
@@ -121,10 +121,9 @@ parser_predict::parser_predict(int argc, char **argv) {
     if (result["verbosity"].count()) {
         const verbosity_level verb = result["verbosity"].as<verbosity_level>();
         if (quiet && verb != verbosity_level::quiet) {
-            std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                     "WARNING: explicitly set the -q/--quiet flag, but the provided verbosity level isn't \"quiet\"; setting --verbosity={} to --verbosity=quiet",
-                                     verb)
-                      << std::endl;
+            detail::log(verbosity_level::full | verbosity_level::warning,
+                        "WARNING: explicitly set the -q/--quiet flag, but the provided verbosity level isn't \"quiet\"; setting --verbosity={} to --verbosity=quiet\n",
+                        verb);
             verbosity = verbosity_level::quiet;
         } else {
             verbosity = verb;
@@ -135,7 +134,7 @@ parser_predict::parser_predict(int argc, char **argv) {
 
     // parse test data filename
     if (!result.count("test")) {
-        std::cerr << "Error missing test file!" << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: missing test file!\n") << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }
@@ -143,7 +142,7 @@ parser_predict::parser_predict(int argc, char **argv) {
 
     // parse model filename
     if (!result.count("model")) {
-        std::cerr << "Error missing model file!" << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: missing model file!\n") << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }

--- a/src/plssvm/detail/cmd/parser_predict.cpp
+++ b/src/plssvm/detail/cmd/parser_predict.cpp
@@ -10,6 +10,7 @@
 
 #include "plssvm/backend_types.hpp"                      // plssvm::list_available_backends
 #include "plssvm/backends/SYCL/implementation_type.hpp"  // plssvm::sycl::list_available_sycl_implementations
+#include "plssvm/constants.hpp"                          // plssvm::real_type
 #include "plssvm/detail/assert.hpp"                      // PLSSVM_ASSERT
 #include "plssvm/target_platforms.hpp"                   // plssvm::list_available_target_platforms
 #include "plssvm/verbosity_levels.hpp"                   // plssvm::verbosity

--- a/src/plssvm/detail/cmd/parser_predict.cpp
+++ b/src/plssvm/detail/cmd/parser_predict.cpp
@@ -11,8 +11,8 @@
 #include "plssvm/backend_types.hpp"                      // plssvm::list_available_backends
 #include "plssvm/backends/SYCL/implementation_type.hpp"  // plssvm::sycl::list_available_sycl_implementations
 #include "plssvm/detail/assert.hpp"                      // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                      // plssvm::verbosity
 #include "plssvm/target_platforms.hpp"                   // plssvm::list_available_target_platforms
+#include "plssvm/verbosity_levels.hpp"                   // plssvm::verbosity
 #include "plssvm/version/version.hpp"                    // plssvm::version::detail::get_version_info
 
 #include "cxxopts.hpp"    // cxxopts::{Options, value, ParseResult}

--- a/src/plssvm/detail/cmd/parser_scale.cpp
+++ b/src/plssvm/detail/cmd/parser_scale.cpp
@@ -9,7 +9,7 @@
 #include "plssvm/detail/cmd/parser_scale.hpp"
 
 #include "plssvm/detail/assert.hpp"    // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"    // plssvm::verbosity
+#include "plssvm/verbosity_levels.hpp"  // plssvm::verbosity
 #include "plssvm/version/version.hpp"  // plssvm::version::detail::get_version_info
 
 #include "cxxopts.hpp"    // cxxopts::{Options, value, ParseResult}

--- a/src/plssvm/detail/cmd/parser_train.cpp
+++ b/src/plssvm/detail/cmd/parser_train.cpp
@@ -8,29 +8,30 @@
 
 #include "plssvm/detail/cmd/parser_train.hpp"
 
-#include "plssvm/backend_types.hpp"                      // plssvm::list_available_backends
-#include "plssvm/backends/SYCL/implementation_type.hpp"  // plssvm::sycl_generic::list_available_sycl_implementations
-#include "plssvm/classification_types.hpp"               // plssvm::classification_type, plssvm::classification_type_to_full_string
-#include "plssvm/constants.hpp"                          // plssvm::real_type
-#include "plssvm/default_value.hpp"                      // plssvm::default_value
-#include "plssvm/detail/assert.hpp"                      // PLSSVM_ASSERT
-#include "plssvm/detail/string_utility.hpp"              // plssvm::detail::as_lower_case
-#include "plssvm/detail/utility.hpp"                     // plssvm::detail::to_underlying
-#include "plssvm/kernel_function_types.hpp"              // plssvm::kernel_type_to_math_string
-#include "plssvm/solver_types.hpp"                       // plssvm::solver_types
-#include "plssvm/target_platforms.hpp"                   // plssvm::list_available_target_platforms
-#include "plssvm/verbosity_levels.hpp"                   // plssvm::verbosity
-#include "plssvm/version/version.hpp"                    // plssvm::version::detail::get_version_info
+#include "plssvm/backend_types.hpp"                                // plssvm::list_available_backends
+#include "plssvm/backends/SYCL/implementation_type.hpp"            // plssvm::sycl_generic::list_available_sycl_implementations
+#include "plssvm/classification_types.hpp"                         // plssvm::classification_type, plssvm::classification_type_to_full_string
+#include "plssvm/constants.hpp"                                    // plssvm::real_type
+#include "plssvm/default_value.hpp"                                // plssvm::default_value
+#include "plssvm/detail/assert.hpp"                                // PLSSVM_ASSERT
+#include "plssvm/detail/logging_without_performance_tracking.hpp"  // plssvm::detail::log
+#include "plssvm/detail/string_utility.hpp"                        // plssvm::detail::as_lower_case
+#include "plssvm/detail/utility.hpp"                               // plssvm::detail::to_underlying
+#include "plssvm/kernel_function_types.hpp"                        // plssvm::kernel_type_to_math_string
+#include "plssvm/solver_types.hpp"                                 // plssvm::solver_types
+#include "plssvm/target_platforms.hpp"                             // plssvm::list_available_target_platforms
+#include "plssvm/verbosity_levels.hpp"                             // plssvm::verbosity, plssvm::verbosity_level
+#include "plssvm/version/version.hpp"                              // plssvm::version::detail::get_version_info
 
 #include "cxxopts.hpp"    // cxxopts::Options, cxxopts::value,cxxopts::ParseResult
-#include "fmt/color.h"    // fmt::fg, fmt::color::orange
+#include "fmt/color.h"    // fmt::fg, fmt::color::red
 #include "fmt/core.h"     // fmt::format, fmt::join
 #include "fmt/ostream.h"  // can use fmt using operator<< overloads
 
 #include <cstdlib>      // std::exit, EXIT_SUCCESS, EXIT_FAILURE
 #include <exception>    // std::exception
 #include <filesystem>   // std::filesystem::path
-#include <iostream>     // std::cout, std::cerr, std::clog, std::endl
+#include <iostream>     // std::cout, std::cerr, std::endl
 #include <type_traits>  // std::is_same_v
 
 namespace plssvm::detail::cmd {
@@ -82,7 +83,7 @@ parser_train::parser_train(int argc, char **argv) {
         options.parse_positional({ "input", "model" });
         result = options.parse(argc, argv);
     } catch (const std::exception &e) {
-        std::cerr << e.what() << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: {}\n", e.what()) << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }
@@ -101,7 +102,7 @@ parser_train::parser_train(int argc, char **argv) {
 
     // check if the number of positional arguments is not too large
     if (!result.unmatched().empty()) {
-        std::cerr << fmt::format("Only up to two positional options may be given, but {} (\"{}\") additional option(s) where provided!\n", result.unmatched().size(), fmt::join(result.unmatched(), " ")) << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: only up to two positional options may be given, but {} (\"{}\") additional option(s) where provided!\n", result.unmatched().size(), fmt::join(result.unmatched(), " ")) << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }
@@ -121,7 +122,7 @@ parser_train::parser_train(int argc, char **argv) {
         const typename decltype(csvm_params.gamma)::value_type gamma_input = result["gamma"].as<typename decltype(csvm_params.gamma)::value_type>();
         // check if the provided gamma is legal
         if (gamma_input <= decltype(gamma_input){ 0.0 }) {
-            std::cerr << fmt::format("gamma must be greater than 0.0, but is {}!", gamma_input) << std::endl;
+            std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: gamma must be greater than 0.0, but is {}!\n", gamma_input) << std::endl;
             std::cout << options.help() << std::endl;
             std::exit(EXIT_FAILURE);
         }
@@ -149,7 +150,7 @@ parser_train::parser_train(int argc, char **argv) {
         const auto max_iter_input = result["max_iter"].as<long long int>();
         // check if the provided max_iter is legal
         if (max_iter_input <= decltype(max_iter_input){ 0 }) {
-            std::cerr << fmt::format("max_iter must be greater than 0, but is {}!", max_iter_input) << std::endl;
+            std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: max_iter must be greater than 0, but is {}!\n", max_iter_input) << std::endl;
             std::cout << options.help() << std::endl;
             std::exit(EXIT_FAILURE);
         }
@@ -177,10 +178,9 @@ parser_train::parser_train(int argc, char **argv) {
 
     // warn if kernel invocation type is explicitly set but SYCL isn't the current backend
     if (backend != backend_type::sycl && sycl_kernel_invocation_type != sycl::kernel_invocation_type::automatic) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: explicitly set a SYCL kernel invocation type but the current backend isn't SYCL; ignoring --sycl_kernel_invocation_type={}",
-                                 sycl_kernel_invocation_type)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: explicitly set a SYCL kernel invocation type but the current backend isn't SYCL; ignoring --sycl_kernel_invocation_type={}\n",
+                    sycl_kernel_invocation_type);
     }
 
     // parse SYCL implementation used in the SYCL backend
@@ -188,10 +188,9 @@ parser_train::parser_train(int argc, char **argv) {
 
     // warn if a SYCL implementation type is explicitly set but SYCL isn't the current backend
     if (backend != backend_type::sycl && sycl_implementation_type != sycl::implementation_type::automatic) {
-        std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                 "WARNING: explicitly set a SYCL implementation type but the current backend isn't SYCL; ignoring --sycl_implementation_type={}",
-                                 sycl_implementation_type)
-                  << std::endl;
+        detail::log(verbosity_level::full | verbosity_level::warning,
+                    "WARNING: explicitly set a SYCL implementation type but the current backend isn't SYCL; ignoring --sycl_implementation_type={}\n",
+                    sycl_implementation_type);
     }
 #endif
 
@@ -205,10 +204,9 @@ parser_train::parser_train(int argc, char **argv) {
     if (result["verbosity"].count()) {
         const verbosity_level verb = result["verbosity"].as<verbosity_level>();
         if (quiet && verb != verbosity_level::quiet) {
-            std::clog << fmt::format(fmt::fg(fmt::color::orange),
-                                     "WARNING: explicitly set the -q/--quiet flag, but the provided verbosity level isn't \"quiet\"; setting --verbosity={} to --verbosity=quiet",
-                                     verb)
-                      << std::endl;
+            detail::log(verbosity_level::full | verbosity_level::warning,
+                        "WARNING: explicitly set the -q/--quiet flag, but the provided verbosity level isn't \"quiet\"; setting --verbosity={} to --verbosity=quiet\n",
+                        verb);
             verbosity = verbosity_level::quiet;
         } else {
             verbosity = verb;
@@ -219,7 +217,7 @@ parser_train::parser_train(int argc, char **argv) {
 
     // parse input data filename
     if (!result.count("input")) {
-        std::cerr << "Error missing input file!" << std::endl;
+        std::cerr << fmt::format(fmt::fg(fmt::color::red), "ERROR: missing input file!\n") << std::endl;
         std::cout << options.help() << std::endl;
         std::exit(EXIT_FAILURE);
     }

--- a/src/plssvm/detail/cmd/parser_train.cpp
+++ b/src/plssvm/detail/cmd/parser_train.cpp
@@ -14,12 +14,12 @@
 #include "plssvm/constants.hpp"                          // plssvm::real_type
 #include "plssvm/default_value.hpp"                      // plssvm::default_value
 #include "plssvm/detail/assert.hpp"                      // PLSSVM_ASSERT
-#include "plssvm/detail/logger.hpp"                      // plssvm::verbosity
 #include "plssvm/detail/string_utility.hpp"              // plssvm::detail::as_lower_case
 #include "plssvm/detail/utility.hpp"                     // plssvm::detail::to_underlying
 #include "plssvm/kernel_function_types.hpp"              // plssvm::kernel_type_to_math_string
 #include "plssvm/solver_types.hpp"                       // plssvm::solver_types
 #include "plssvm/target_platforms.hpp"                   // plssvm::list_available_target_platforms
+#include "plssvm/verbosity_levels.hpp"                   // plssvm::verbosity
 #include "plssvm/version/version.hpp"                    // plssvm::version::detail::get_version_info
 
 #include "cxxopts.hpp"    // cxxopts::Options, cxxopts::value,cxxopts::ParseResult

--- a/src/plssvm/verbosity_levels.cpp
+++ b/src/plssvm/verbosity_levels.cpp
@@ -66,7 +66,7 @@ std::istream &operator>>(std::istream &in, verbosity_level &verb) {
         if (verb_str == "full") {
             verb |= verbosity_level::full;
         } else if (verb_str == "warning") {
-            verb |= verbosity_level::timing;
+            verb |= verbosity_level::warning;
         } else if (verb_str == "timing") {
             verb |= verbosity_level::timing;
         } else if (verb_str == "libsvm") {

--- a/src/plssvm/verbosity_levels.cpp
+++ b/src/plssvm/verbosity_levels.cpp
@@ -6,7 +6,7 @@
  *          See the LICENSE.md file in the project root for full license information.
  */
 
-#include "plssvm/detail/logger.hpp"
+#include "plssvm/verbosity_levels.hpp"
 
 #include "plssvm/detail/string_utility.hpp"  // plssvm::detail::{to_lower_case, split, trim}
 #include "plssvm/detail/utility.hpp"         // plssvm::detail::to_underlying

--- a/src/plssvm/verbosity_levels.cpp
+++ b/src/plssvm/verbosity_levels.cpp
@@ -38,6 +38,9 @@ std::ostream &operator<<(std::ostream &out, const verbosity_level verb) {
     if ((verb & verbosity_level::timing) != verbosity_level::quiet) {
         level_names.emplace_back("timing");
     }
+    if ((verb & verbosity_level::warning) != verbosity_level::quiet) {
+        level_names.emplace_back("warning");
+    }
     if ((verb & verbosity_level::full) != verbosity_level::quiet) {
         level_names.emplace_back("full");
     }
@@ -62,6 +65,8 @@ std::istream &operator>>(std::istream &in, verbosity_level &verb) {
         verb_str = detail::trim(verb_str);
         if (verb_str == "full") {
             verb |= verbosity_level::full;
+        } else if (verb_str == "warning") {
+            verb |= verbosity_level::timing;
         } else if (verb_str == "timing") {
             verb |= verbosity_level::timing;
         } else if (verb_str == "libsvm") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,7 +134,7 @@ set(PLSSVM_BASE_TEST_SOURCES
 
         ${CMAKE_CURRENT_LIST_DIR}/detail/arithmetic_type_name.cpp
         ${CMAKE_CURRENT_LIST_DIR}/detail/assert.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/detail/logger.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/detail/logging.cpp
         ${CMAKE_CURRENT_LIST_DIR}/detail/memory_size.cpp
         ${CMAKE_CURRENT_LIST_DIR}/detail/operators.cpp
         ${CMAKE_CURRENT_LIST_DIR}/detail/performance_tracker.cpp
@@ -170,6 +170,7 @@ set(PLSSVM_BASE_TEST_SOURCES
         ${CMAKE_CURRENT_LIST_DIR}/parameter.cpp
         ${CMAKE_CURRENT_LIST_DIR}/solver_types.cpp
         ${CMAKE_CURRENT_LIST_DIR}/target_platforms.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/verbosity_levels.cpp
 )
 
 # create test executable

--- a/tests/classification_report.cpp
+++ b/tests/classification_report.cpp
@@ -16,7 +16,7 @@
 #include "gtest/gtest.h"  // TEST, TEST_F, EXPECT_EQ, EXPECT_TRUE, EXPECT_FALSE, ::testing::Test
 
 #include <cmath>     // std::isnan
-#include <iostream>  // std::clog
+#include <iostream>  // std::cout
 #include <sstream>   // std::istringstream
 #include <string>    // std::string
 #include <tuple>     // std::ignore
@@ -26,7 +26,7 @@
 //                                                        zero division behavior                                                       //
 //*************************************************************************************************************************************//
 
-class ZeroDivisionBehavior : public ::testing::Test, public util::redirect_output<&std::clog> {};
+class ZeroDivisionBehavior : public ::testing::Test, public util::redirect_output<&std::cout> {};
 
 // check whether the plssvm::classification_report::zero_division_behavior -> std::string conversions are correct
 TEST_F(ZeroDivisionBehavior, to_string) {

--- a/tests/csvm.cpp
+++ b/tests/csvm.cpp
@@ -30,14 +30,14 @@
 #include "utility.hpp"             // util::{redirect_output, temporary_file, instantiate_template_file, get_num_classes, calculate_number_of_classifiers,
                                    // generate_random_matrix, get_correct_data_file_labels}
 
-#include "gmock/gmock.h"  // EXPECT_CALL, ::testing::{An, Between, Return}
-#include "gtest/gtest.h"  // TEST, TYPED_TEST, TYPED_TEST_SUITE, EXPECT_EQ, EXPECT_TRUE, EXPECT_FALSE, ASSERT_EQ, GTEST_SKIP, ::testing::Test
-
-#include <cstddef>   // std::size_t
-#include <iostream>  // std::clog
-#include <string>    // std::string
-#include <tuple>     // std::ignore
-#include <vector>    // std::vector
+#include "gmock/gmock.h"           // EXPECT_CALL, ::testing::{An, Between, Return}
+#include "gtest/gtest-matchers.h"  // EXPECT_THAT, ::testing::HasSubstr
+#include "gtest/gtest.h"           // TEST, TYPED_TEST, TYPED_TEST_SUITE, EXPECT_EQ, EXPECT_TRUE, EXPECT_FALSE, EXPECT_THAT,
+#include <cstddef>                 // std::size_t
+#include <iostream>                // std::clog
+#include <string>                  // std::string
+#include <tuple>                   // std::ignore
+#include <vector>                  // std::vector
 
 class BaseCSVM : public ::testing::Test {};
 
@@ -248,21 +248,21 @@ TEST_F(BaseCSVMWarning, construct_unused_parameter_warning_degree) {
     [[maybe_unused]] const mock_csvm csvm{ plssvm::kernel_type = plssvm::kernel_function_type::linear, plssvm::degree = 2 };
     // end capture of std::clog
 
-    EXPECT_EQ(this->get_capture(), "degree parameter provided, which is not used in the linear kernel (u'*v)!\n");
+    EXPECT_THAT(this->get_capture(), ::testing::HasSubstr("WARNING: degree parameter provided, which is not used in the linear kernel (u'*v)!"));
 }
 TEST_F(BaseCSVMWarning, construct_unused_parameter_warning_gamma) {
     // start capture of std::clog
     [[maybe_unused]] const mock_csvm csvm{ plssvm::kernel_type = plssvm::kernel_function_type::linear, plssvm::gamma = 0.1 };
     // end capture of std::clog
 
-    EXPECT_EQ(this->get_capture(), "gamma parameter provided, which is not used in the linear kernel (u'*v)!\n");
+    EXPECT_THAT(this->get_capture(), ::testing::HasSubstr("WARNING: gamma parameter provided, which is not used in the linear kernel (u'*v)!"));
 }
 TEST_F(BaseCSVMWarning, construct_unused_parameter_warning_coef0) {
     // start capture of std::clog
     [[maybe_unused]] const mock_csvm csvm{ plssvm::kernel_type = plssvm::kernel_function_type::linear, plssvm::coef0 = 0.1 };
     // end capture of std::clog
 
-    EXPECT_EQ(this->get_capture(), "coef0 parameter provided, which is not used in the linear kernel (u'*v)!\n");
+    EXPECT_THAT(this->get_capture(), ::testing::HasSubstr("WARNING: coef0 parameter provided, which is not used in the linear kernel (u'*v)!"));
 }
 
 template <typename T>

--- a/tests/detail/cmd/cmd_utility.hpp
+++ b/tests/detail/cmd/cmd_utility.hpp
@@ -13,8 +13,8 @@
 #define PLSSVM_TESTS_DETAIL_CMD_UTILITY_HPP_
 #pragma once
 
-#include "plssvm/detail/logger.hpp"             // plssvm::verbosity_level, plssvm::verbosity
 #include "plssvm/detail/string_conversion.hpp"  // plssvm::detail::split_as
+#include "plssvm/verbosity_levels.hpp"          // plssvm::verbosity_level, plssvm::verbosity
 
 #include "utility.hpp"  // util::redirect_output
 

--- a/tests/detail/cmd/parser_predict.cpp
+++ b/tests/detail/cmd/parser_predict.cpp
@@ -10,8 +10,8 @@
 
 #include "plssvm/detail/cmd/parser_predict.hpp"
 
-#include "plssvm/constants.hpp"      // plssvm::real_type
-#include "plssvm/detail/logger.hpp"  // plssvm::verbosity
+#include "plssvm/constants.hpp"        // plssvm::real_type
+#include "plssvm/verbosity_levels.hpp"  // plssvm::verbosity
 
 #include "custom_test_macros.hpp"      // EXPECT_CONVERSION_TO_STRING
 #include "detail/cmd/cmd_utility.hpp"  // util::ParameterBase

--- a/tests/detail/cmd/parser_predict.cpp
+++ b/tests/detail/cmd/parser_predict.cpp
@@ -309,19 +309,19 @@ TEST_F(ParserPredictDeathTest, no_positional_argument) {
     this->CreateCMDArgs({ "./plssvm-predict" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_predict{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::StartsWith("Error missing test file!"));
+                ::testing::HasSubstr("ERROR: missing test file!"));
 }
 TEST_F(ParserPredictDeathTest, single_positional_argument) {
     this->CreateCMDArgs({ "./plssvm-predict", "data.libsvm" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_predict{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::StartsWith("Error missing model file!"));
+                ::testing::HasSubstr("ERROR: missing model file!"));
 }
 TEST_F(ParserPredictDeathTest, too_many_positional_arguments) {
     this->CreateCMDArgs({ "./plssvm-predict", "p1", "p2", "p3", "p4" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_predict{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::HasSubstr(R"(Only up to three positional options may be given, but 1 ("p4") additional option(s) where provided!)"));
+                ::testing::HasSubstr(R"(ERROR: only up to three positional options may be given, but 1 ("p4") additional option(s) where provided!)"));
 }
 
 // test whether nonsensical cmd arguments trigger the assertions

--- a/tests/detail/cmd/parser_scale.cpp
+++ b/tests/detail/cmd/parser_scale.cpp
@@ -10,8 +10,8 @@
 
 #include "plssvm/detail/cmd/parser_scale.hpp"
 
-#include "plssvm/constants.hpp"      // plssvm::real_type
-#include "plssvm/detail/logger.hpp"  // plssvm::verbosity
+#include "plssvm/constants.hpp"        // plssvm::real_type
+#include "plssvm/verbosity_levels.hpp"  // plssvm::verbosity
 
 #include "custom_test_macros.hpp"      // EXPECT_CONVERSION_TO_STRING
 #include "detail/cmd/cmd_utility.hpp"  // util::ParameterBase

--- a/tests/detail/cmd/parser_scale.cpp
+++ b/tests/detail/cmd/parser_scale.cpp
@@ -10,7 +10,7 @@
 
 #include "plssvm/detail/cmd/parser_scale.hpp"
 
-#include "plssvm/constants.hpp"        // plssvm::real_type
+#include "plssvm/constants.hpp"         // plssvm::real_type
 #include "plssvm/verbosity_levels.hpp"  // plssvm::verbosity
 
 #include "custom_test_macros.hpp"      // EXPECT_CONVERSION_TO_STRING
@@ -327,20 +327,27 @@ TEST_F(ParserScaleDeathTest, no_positional_argument) {
     this->CreateCMDArgs({ "./plssvm-scale" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_scale{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::StartsWith("Error missing input file!"));
+                ::testing::HasSubstr("ERROR: missing input file!"));
 }
 TEST_F(ParserScaleDeathTest, save_and_restore) {
     this->CreateCMDArgs({ "./plssvm-scale", "-s", "data.libsvm.save", "-r", "data.libsvm.restore", "data.libsvm" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_scale{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::StartsWith("Error cannot use -s (--save_filename) and -r (--restore_filename) simultaneously!"));
+                ::testing::HasSubstr("ERROR: cannot use -s (--save_filename) and -r (--restore_filename) simultaneously!"));
 }
 
 TEST_F(ParserScaleDeathTest, too_many_positional_arguments) {
     this->CreateCMDArgs({ "./plssvm-scale", "p1", "p2", "p3", "p4" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_scale{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::HasSubstr(R"(Only up to two positional options may be given, but 2 ("p3 p4") additional option(s) where provided!)"));
+                ::testing::HasSubstr(R"(ERROR: only up to two positional options may be given, but 2 ("p3 p4") additional option(s) where provided!)"));
+}
+TEST_F(ParserScaleDeathTest, illegal_scaling_range) {
+    // illegal [lower, upper] bound range
+    this->CreateCMDArgs({ "./plssvm-scale", "-l", "1.0", "-u", "-1.0", "data.libsvm" });
+    EXPECT_EXIT((plssvm::detail::cmd::parser_scale{ this->get_argc(), this->get_argv() }),
+                ::testing::ExitedWithCode(EXIT_FAILURE),
+                ::testing::HasSubstr("ERROR: invalid scaling range [lower, upper] with [1, -1]!"));
 }
 
 // test whether nonsensical cmd arguments trigger the assertions
@@ -351,12 +358,6 @@ TEST_F(ParserScaleDeathTest, too_few_argc) {
 TEST_F(ParserScaleDeathTest, nullptr_argv) {
     EXPECT_DEATH((plssvm::detail::cmd::parser_scale{ 1, nullptr }),
                  ::testing::HasSubstr("At least one argument is always given (the executable name), but argv is a nullptr!"));
-}
-TEST_F(ParserScaleDeathTest, illegal_scaling_range) {
-    // illegal [lower, upper] bound range
-    this->CreateCMDArgs({ "./plssvm-scale", "-l", "1.0", "-u", "-1.0", "data.libsvm" });
-    EXPECT_DEATH((plssvm::detail::cmd::parser_scale{ this->get_argc(), this->get_argv() }),
-                 ::testing::HasSubstr("Error invalid scaling range [lower, upper] with [1, -1]!"));
 }
 TEST_F(ParserScaleDeathTest, unrecognized_option) {
     this->CreateCMDArgs({ "./plssvm-scale", "--foo", "bar" });

--- a/tests/detail/cmd/parser_train.cpp
+++ b/tests/detail/cmd/parser_train.cpp
@@ -578,11 +578,11 @@ TEST_F(ParserTrainDeathTest, too_many_positional_arguments) {
 // test whether nonsensical cmd arguments trigger the assertions
 TEST_F(ParserTrainDeathTest, too_few_argc) {
     EXPECT_DEATH((plssvm::detail::cmd::parser_train{ 0, nullptr }),
-                 ::testing::HasSubstr("ERROR: at least one argument is always given (the executable name), but argc is 0!"));
+                 ::testing::HasSubstr("At least one argument is always given (the executable name), but argc is 0!"));
 }
 TEST_F(ParserTrainDeathTest, nullptr_argv) {
     EXPECT_DEATH((plssvm::detail::cmd::parser_train{ 1, nullptr }),
-                 ::testing::HasSubstr("ERROR: at least one argument is always given (the executable name), but argv is a nullptr!"));
+                 ::testing::HasSubstr("At least one argument is always given (the executable name), but argv is a nullptr!"));
 }
 TEST_F(ParserTrainDeathTest, unrecognized_option) {
     this->CreateCMDArgs({ "./plssvm-train", "--foo", "bar" });

--- a/tests/detail/cmd/parser_train.cpp
+++ b/tests/detail/cmd/parser_train.cpp
@@ -566,23 +566,23 @@ TEST_F(ParserTrainDeathTest, no_positional_argument) {
     this->CreateCMDArgs({ "./plssvm-train" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_train{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::StartsWith("Error missing input file!"));
+                ::testing::HasSubstr("ERROR: missing input file!"));
 }
 TEST_F(ParserTrainDeathTest, too_many_positional_arguments) {
     this->CreateCMDArgs({ "./plssvm-train", "p1", "p2", "p3", "p4" });
     EXPECT_EXIT((plssvm::detail::cmd::parser_train{ this->get_argc(), this->get_argv() }),
                 ::testing::ExitedWithCode(EXIT_FAILURE),
-                ::testing::HasSubstr(R"(Only up to two positional options may be given, but 2 ("p3 p4") additional option(s) where provided!)"));
+                ::testing::HasSubstr(R"(ERROR: only up to two positional options may be given, but 2 ("p3 p4") additional option(s) where provided!)"));
 }
 
 // test whether nonsensical cmd arguments trigger the assertions
 TEST_F(ParserTrainDeathTest, too_few_argc) {
     EXPECT_DEATH((plssvm::detail::cmd::parser_train{ 0, nullptr }),
-                 ::testing::HasSubstr("At least one argument is always given (the executable name), but argc is 0!"));
+                 ::testing::HasSubstr("ERROR: at least one argument is always given (the executable name), but argc is 0!"));
 }
 TEST_F(ParserTrainDeathTest, nullptr_argv) {
     EXPECT_DEATH((plssvm::detail::cmd::parser_train{ 1, nullptr }),
-                 ::testing::HasSubstr("At least one argument is always given (the executable name), but argv is a nullptr!"));
+                 ::testing::HasSubstr("ERROR: at least one argument is always given (the executable name), but argv is a nullptr!"));
 }
 TEST_F(ParserTrainDeathTest, unrecognized_option) {
     this->CreateCMDArgs({ "./plssvm-train", "--foo", "bar" });

--- a/tests/detail/cmd/parser_train.cpp
+++ b/tests/detail/cmd/parser_train.cpp
@@ -10,8 +10,8 @@
 
 #include "plssvm/detail/cmd/parser_train.hpp"
 
-#include "plssvm/constants.hpp"      // plssvm::real_type
-#include "plssvm/detail/logger.hpp"  // plssvm::verbosity
+#include "plssvm/constants.hpp"        // plssvm::real_type
+#include "plssvm/verbosity_levels.hpp"  // plssvm::verbosity
 
 #include "custom_test_macros.hpp"      // EXPECT_CONVERSION_TO_STRING
 #include "detail/cmd/cmd_utility.hpp"  // util::ParameterBase

--- a/tests/detail/logging.cpp
+++ b/tests/detail/logging.cpp
@@ -8,7 +8,7 @@
  * @brief Tests for the logging function.
  */
 
-#include "plssvm/detail/logging.hpp"
+#include "plssvm/detail/logging_without_performance_tracking.hpp"
 
 #include "utility.hpp"  // util::redirect_output
 

--- a/tests/detail/logging.cpp
+++ b/tests/detail/logging.cpp
@@ -1,0 +1,71 @@
+/**
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Tests for the logging function.
+ */
+
+#include "plssvm/detail/logging.hpp"
+
+#include "utility.hpp"  // util::redirect_output
+
+#include "gtest/gtest.h"  // TEST_F, EXPECT_EQ, EXPECT_TRUE, ::testing::Test
+
+class Logger : public ::testing::Test, public util::redirect_output<> {};
+
+TEST_F(Logger, enabled_logging) {
+    // explicitly enable logging
+    plssvm::verbosity = plssvm::verbosity_level::full;
+
+    // log a message
+    plssvm::detail::log(plssvm::verbosity_level::full, "Hello, World!");
+
+    // check captured output
+    EXPECT_EQ(this->get_capture(), "Hello, World!");
+}
+TEST_F(Logger, enabled_logging_with_args) {
+    // explicitly enable logging
+    plssvm::verbosity = plssvm::verbosity_level::full;
+
+    // log a message
+    plssvm::detail::log(plssvm::verbosity_level::full, "int: {}, float: {}, str: {}", 42, 1.5, "abc");
+
+    // check captured output
+    EXPECT_EQ(this->get_capture(), "int: 42, float: 1.5, str: abc");
+}
+
+TEST_F(Logger, disabled_logging) {
+    // explicitly disable logging
+    plssvm::verbosity = plssvm::verbosity_level::quiet;
+
+    // log message
+    plssvm::detail::log(plssvm::verbosity_level::full, "Hello, World!");
+
+    // since logging has been disabled, nothing should have been captured
+    EXPECT_TRUE(this->get_capture().empty());
+}
+TEST_F(Logger, disabled_logging_with_args) {
+    // explicitly disable logging
+    plssvm::verbosity = plssvm::verbosity_level::quiet;
+
+    // log message
+    plssvm::detail::log(plssvm::verbosity_level::full, "int: {}, float: {}, str: {}", 42, 1.5, "abc");
+
+    // since logging has been disabled, nothing should have been captured
+    EXPECT_TRUE(this->get_capture().empty());
+}
+
+TEST_F(Logger, mismatching_verbosity_level) {
+    // set verbosity_level to libsvm
+    plssvm::verbosity = plssvm::verbosity_level::libsvm;
+
+    // log message with full
+    plssvm::detail::log(plssvm::verbosity_level::full, "Hello, World!");
+    plssvm::detail::log(plssvm::verbosity_level::full, "int: {}, float: {}, str: {}", 42, 1.5, "abc");
+
+    // there should not be any output
+    EXPECT_TRUE(this->get_capture().empty());
+}

--- a/tests/verbosity_levels.cpp
+++ b/tests/verbosity_levels.cpp
@@ -21,10 +21,11 @@
 
 // check whether the plssvm::verbosity_level values are power of twos
 TEST(VerbosityLevel, values) {
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::quiet), 0b000);
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::libsvm), 0b001);
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::timing), 0b010);
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full), 0b100);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::quiet), 0b0000);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::libsvm), 0b0001);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::timing), 0b0010);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::warning), 0b0100);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full), 0b1000);
 }
 // check whether the plssvm::verbosity_level -> std::string conversions are correct
 TEST(VerbosityLevel, to_string) {
@@ -32,22 +33,27 @@ TEST(VerbosityLevel, to_string) {
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::quiet, "quiet");
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::libsvm, "libsvm");
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::timing, "timing");
+    EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::warning, "warning");
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::full, "full");
 }
 TEST(VerbosityLevel, to_string_concatenation) {
     // check conversion to std::string for multiple values
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::full | plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm,
                                 "libsvm | timing | full");
+    EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::full | plssvm::verbosity_level::warning | plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm,
+                                "libsvm | timing | warning | full");
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::full | plssvm::verbosity_level::timing,
                                 "timing | full");
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm,
                                 "libsvm | full");
     EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm,
                                 "libsvm | timing");
+    EXPECT_CONVERSION_TO_STRING(plssvm::verbosity_level::warning | plssvm::verbosity_level::libsvm,
+                                "libsvm | warning");
 }
 TEST(VerbosityLevel, to_string_unknown) {
     // check conversions to std::string from unknown backend_type
-    EXPECT_CONVERSION_TO_STRING(static_cast<plssvm::verbosity_level>(0b1000), "unknown");
+    EXPECT_CONVERSION_TO_STRING(static_cast<plssvm::verbosity_level>(0b10000), "unknown");
 }
 
 // check whether the std::string -> plssvm::verbosity_level conversions are correct
@@ -59,16 +65,20 @@ TEST(VerbosityLevel, from_string) {
     EXPECT_CONVERSION_FROM_STRING("LIBSVM", plssvm::verbosity_level::libsvm);
     EXPECT_CONVERSION_FROM_STRING("timing", plssvm::verbosity_level::timing);
     EXPECT_CONVERSION_FROM_STRING("TIMING", plssvm::verbosity_level::timing);
+    EXPECT_CONVERSION_FROM_STRING("warning", plssvm::verbosity_level::warning);
+    EXPECT_CONVERSION_FROM_STRING("WARNING", plssvm::verbosity_level::warning);
     EXPECT_CONVERSION_FROM_STRING("full", plssvm::verbosity_level::full);
     EXPECT_CONVERSION_FROM_STRING("FULL", plssvm::verbosity_level::full);
 }
 TEST(VerbosityLevel, from_string_concatenation) {
     // check conversion from std::string
     EXPECT_CONVERSION_FROM_STRING("quiet|libsvm|timing|full", plssvm::verbosity_level::quiet);
+    EXPECT_CONVERSION_FROM_STRING("libsvm|timing|warning|full", plssvm::verbosity_level::full | plssvm::verbosity_level::timing | plssvm::verbosity_level::warning | plssvm::verbosity_level::libsvm);
     EXPECT_CONVERSION_FROM_STRING("libsvm|timing|full", plssvm::verbosity_level::full | plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm);
     EXPECT_CONVERSION_FROM_STRING("timing|full", plssvm::verbosity_level::full | plssvm::verbosity_level::timing);
     EXPECT_CONVERSION_FROM_STRING("libsvm|full", plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm);
     EXPECT_CONVERSION_FROM_STRING("libsvm|timing", plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm);
+    EXPECT_CONVERSION_FROM_STRING("libsvm|warning", plssvm::verbosity_level::warning | plssvm::verbosity_level::libsvm);
 }
 TEST(VerbosityLevel, from_string_unknown) {
     // foo isn't a valid backend_type
@@ -79,26 +89,29 @@ TEST(VerbosityLevel, from_string_unknown) {
 }
 
 TEST(VerbosityLevel, bitwise_or) {
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm), 0b111);
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::timing), 0b110);
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm), 0b101);
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm), 0b011);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::warning | plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm), 0b1111);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm), 0b1011);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::timing), 0b1010);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm), 0b1001);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm), 0b0011);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::warning | plssvm::verbosity_level::libsvm), 0b0101);
 }
 TEST(VerbosityLevel, compound_bitwise_or) {
     plssvm::verbosity_level verb = plssvm::verbosity_level::full;
     verb |= plssvm::verbosity_level::timing | plssvm::verbosity_level::libsvm;
-    EXPECT_EQ(plssvm::detail::to_underlying(verb), 0b111);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb), 0b1011);
 }
 TEST(VerbosityLevel, bitwise_and) {
-    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full & plssvm::verbosity_level::full), 0b100);
+    EXPECT_EQ(plssvm::detail::to_underlying(plssvm::verbosity_level::full & plssvm::verbosity_level::full), 0b1000);
     const plssvm::verbosity_level verb = plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm;
-    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::quiet), 0b000);
-    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::libsvm), 0b001);
-    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::timing), 0b000);
-    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::full), 0b100);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::quiet), 0b0000);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::libsvm), 0b0001);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::timing), 0b0000);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::warning), 0b0000);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb & plssvm::verbosity_level::full), 0b1000);
 }
 TEST(VerbosityLevel, compound_bitwise_and) {
     plssvm::verbosity_level verb = plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm;
     verb &= plssvm::verbosity_level::full;
-    EXPECT_EQ(plssvm::detail::to_underlying(verb), 0b100);
+    EXPECT_EQ(plssvm::detail::to_underlying(verb), 0b1000);
 }

--- a/tests/verbosity_levels.cpp
+++ b/tests/verbosity_levels.cpp
@@ -5,17 +5,17 @@
  * @license This file is part of the PLSSVM project which is released under the MIT license.
  *          See the LICENSE.md file in the project root for full license information.
  *
- * @brief Tests for the logging function.
+ * @brief Tests for the verbosity level enumeration.
  */
 
-#include "plssvm/detail/logger.hpp"
+#include "plssvm/verbosity_levels.hpp"
 
 #include "plssvm/detail/utility.hpp"  // plssvm::detail::to_underlying
 
 #include "custom_test_macros.hpp"  // EXPECT_CONVERSION_TO_STRING, EXPECT_CONVERSION_FROM_STRING
 #include "utility.hpp"             // util::redirect_output
 
-#include "gtest/gtest.h"  // TEST_F, EXPECT_EQ, EXPECT_TRUE, ::testing::Test
+#include "gtest/gtest.h"  // TEST, EXPECT_EQ, EXPECT_TRUE
 
 #include <sstream>  // std::istringstream
 
@@ -101,60 +101,4 @@ TEST(VerbosityLevel, compound_bitwise_and) {
     plssvm::verbosity_level verb = plssvm::verbosity_level::full | plssvm::verbosity_level::libsvm;
     verb &= plssvm::verbosity_level::full;
     EXPECT_EQ(plssvm::detail::to_underlying(verb), 0b100);
-}
-
-class Logger : public ::testing::Test, public util::redirect_output<> {};
-
-TEST_F(Logger, enabled_logging) {
-    // explicitly enable logging
-    plssvm::verbosity = plssvm::verbosity_level::full;
-
-    // log a message
-    plssvm::detail::log(plssvm::verbosity_level::full, "Hello, World!");
-
-    // check captured output
-    EXPECT_EQ(this->get_capture(), "Hello, World!");
-}
-TEST_F(Logger, enabled_logging_with_args) {
-    // explicitly enable logging
-    plssvm::verbosity = plssvm::verbosity_level::full;
-
-    // log a message
-    plssvm::detail::log(plssvm::verbosity_level::full, "int: {}, float: {}, str: {}", 42, 1.5, "abc");
-
-    // check captured output
-    EXPECT_EQ(this->get_capture(), "int: 42, float: 1.5, str: abc");
-}
-
-TEST_F(Logger, disabled_logging) {
-    // explicitly disable logging
-    plssvm::verbosity = plssvm::verbosity_level::quiet;
-
-    // log message
-    plssvm::detail::log(plssvm::verbosity_level::full, "Hello, World!");
-
-    // since logging has been disabled, nothing should have been captured
-    EXPECT_TRUE(this->get_capture().empty());
-}
-TEST_F(Logger, disabled_logging_with_args) {
-    // explicitly disable logging
-    plssvm::verbosity = plssvm::verbosity_level::quiet;
-
-    // log message
-    plssvm::detail::log(plssvm::verbosity_level::full, "int: {}, float: {}, str: {}", 42, 1.5, "abc");
-
-    // since logging has been disabled, nothing should have been captured
-    EXPECT_TRUE(this->get_capture().empty());
-}
-
-TEST_F(Logger, mismatching_verbosity_level) {
-    // set verbosity_level to libsvm
-    plssvm::verbosity = plssvm::verbosity_level::libsvm;
-
-    // log message with full
-    plssvm::detail::log(plssvm::verbosity_level::full, "Hello, World!");
-    plssvm::detail::log(plssvm::verbosity_level::full, "int: {}, float: {}, str: {}", 42, 1.5, "abc");
-
-    // there should not be any output
-    EXPECT_TRUE(this->get_capture().empty());
 }


### PR DESCRIPTION
Add a new warning verbosity level and guard all warning outputs behind it. 
If the plssvm::verbosity is set to quiet (or libsvm or timing), these warnings are not printed to stderr anymore.