### PR TITLE
Fix vectorization warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,9 +536,9 @@ if (PLSSVM_ENABLE_ASSERTS)
 
     # disable vectorization warning in clang in Release mode
     # -> loops can't be vectorized due to the PLSSVM_ASSERTs in the matrix::operator() member function
-    target_compile_options(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC
-            $<$<AND:$<OR:$<CONFIG:RELEASE>,$<CONFIG:RELWITHDEBINFO>>,$<COMPILE_LANG_AND_ID:CXX,Clang>>:-Wno-pass-failed>
-    )
+    # target_compile_options(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC
+    #         $<$<AND:$<OR:$<CONFIG:RELEASE>,$<CONFIG:RELWITHDEBINFO>>,$<COMPILE_LANG_AND_ID:CXX,Clang>>:-Wno-pass-failed>
+    # )
 endif ()
 
 ## use float as real_type if requested

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,12 @@ option(PLSSVM_ENABLE_ASSERTS "Enables PLSSVM asserts even if NDEBUG is set." OFF
 if (PLSSVM_ENABLE_ASSERTS)
     message(STATUS "Enable additional debugging assertions.")
     target_compile_definitions(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC PLSSVM_ENABLE_ASSERTS)
+
+    # disable vectorization warning in clang in Release mode
+    # -> loops can't be vectorized due to the PLSSVM_ASSERTs in the matrix::operator() member function
+    target_compile_options(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC
+            $<$<AND:$<OR:$<CONFIG:RELEASE>,$<CONFIG:RELWITHDEBINFO>>,$<COMPILE_LANG_AND_ID:CXX,Clang>>:-Wno-pass-failed>
+    )
 endif ()
 
 ## use float as real_type if requested

--- a/include/plssvm/detail/operators.hpp
+++ b/include/plssvm/detail/operators.hpp
@@ -16,7 +16,6 @@
 #include "plssvm/detail/assert.hpp"  // PLSSVM_ASSERT
 #include "plssvm/matrix.hpp"         // plssvm::matrix
 
-#include <cmath>   // std::fma
 #include <vector>  // std::vector
 
 //*************************************************************************************************************************************//
@@ -127,7 +126,6 @@ transposed(const std::vector<T> &) -> transposed<T>;
 
 /**
  * @brief Calculate the dot product (\f$x^T \cdot y\f$) between both [`std::vector`](https://en.cppreference.com/w/cpp/container/vector).
- * @details Explicitly uses `std::fma` for better performance and accuracy.
  * @tparam T the value type
  * @param[in] lhs the first vector
  * @param[in] rhs the second vector
@@ -140,7 +138,7 @@ template <typename T>
     T val{};
     #pragma omp simd reduction(+ : val)
     for (typename std::vector<T>::size_type i = 0; i < lhs.vec.size(); ++i) {
-        val = std::fma(lhs.vec[i], rhs[i], val);
+        val += lhs.vec[i] * rhs[i];
     }
     return val;
 }
@@ -172,7 +170,6 @@ template <typename T>
 
 /**
  * @brief Calculates the squared Euclidean distance of both vectors: \f$d^2(x, y) = (x_1 - y_1)^2 + (x_2 - y_2)^2 + \dots + (x_n - y_n)^2\f$.
- * @details Explicitly uses `std::fma` for better performance and accuracy.
  * @tparam T the value type
  * @param[in] lhs the first vector
  * @param[in] rhs the second vector
@@ -186,7 +183,7 @@ template <typename T>
     #pragma omp simd reduction(+ : val)
     for (typename std::vector<T>::size_type i = 0; i < lhs.size(); ++i) {
         const T diff = lhs[i] - rhs[i];
-        val = std::fma(diff, diff, val);
+        val += diff * diff;
     }
     return val;
 }

--- a/include/plssvm/kernel_function_types.hpp
+++ b/include/plssvm/kernel_function_types.hpp
@@ -13,10 +13,10 @@
 #define PLSSVM_KERNEL_FUNCTION_TYPES_HPP_
 #pragma once
 
-#include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT
+#include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT, PLSSVM_ASSERT_ENABLED
 #include "plssvm/detail/operators.hpp"       // dot product, plssvm::squared_euclidean_dist
 #include "plssvm/detail/type_traits.hpp"     // plssvm::detail::always_false_v
-#include "plssvm/detail/utility.hpp"         // plssvm::detail::get
+#include "plssvm/detail/utility.hpp"         // plssvm::detail::get, PLSSVM_IS_DEFINED
 #include "plssvm/exceptions/exceptions.hpp"  // plssvm::unsupported_kernel_type_exception
 #include "plssvm/matrix.hpp"                 // plssvm::matrix, plssvm::layout_type
 
@@ -146,7 +146,7 @@ template <kernel_function_type kernel, typename T, layout_type layout, typename.
     if constexpr (kernel == kernel_function_type::linear) {
         static_assert(sizeof...(args) == 0, "Illegal number of additional parameters! Must be 0.");
         T temp{ 0.0 };
-        #pragma omp simd reduction(+ : temp)
+        #pragma omp simd reduction(+ : temp) if(!PLSSVM_IS_DEFINED(PLSSVM_ASSERT_ENABLED))
         for (size_type dim = 0; dim < x.num_cols(); ++dim) {
             temp += x(i, dim) * y(j, dim);
         }
@@ -157,7 +157,7 @@ template <kernel_function_type kernel, typename T, layout_type layout, typename.
         const auto gamma = static_cast<T>(detail::get<1>(args...));
         const auto coef0 = static_cast<T>(detail::get<2>(args...));
         T temp{ 0.0 };
-        #pragma omp simd reduction(+ : temp)
+        #pragma omp simd reduction(+ : temp) if(!PLSSVM_IS_DEFINED(PLSSVM_ASSERT_ENABLED))
         for (size_type dim = 0; dim < x.num_cols(); ++dim) {
             temp += x(i, dim) * y(j, dim);
         }
@@ -166,7 +166,7 @@ template <kernel_function_type kernel, typename T, layout_type layout, typename.
         static_assert(sizeof...(args) == 1, "Illegal number of additional parameters! Must be 1.");
         const auto gamma = static_cast<T>(detail::get<0>(args...));
         T temp{ 0.0 };
-        #pragma omp simd reduction(+ : temp)
+        #pragma omp simd reduction(+ : temp) if(!PLSSVM_IS_DEFINED(PLSSVM_ASSERT_ENABLED))
         for (size_type dim = 0; dim < x.num_cols(); ++dim) {
             const T diff = x(i, dim) - y(j, dim);
             temp += diff * diff;

--- a/include/plssvm/kernel_function_types.hpp
+++ b/include/plssvm/kernel_function_types.hpp
@@ -13,10 +13,10 @@
 #define PLSSVM_KERNEL_FUNCTION_TYPES_HPP_
 #pragma once
 
-#include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT, PLSSVM_ASSERT_ENABLED
+#include "plssvm/detail/assert.hpp"          // PLSSVM_ASSERT
 #include "plssvm/detail/operators.hpp"       // dot product, plssvm::squared_euclidean_dist
 #include "plssvm/detail/type_traits.hpp"     // plssvm::detail::always_false_v
-#include "plssvm/detail/utility.hpp"         // plssvm::detail::get, PLSSVM_IS_DEFINED
+#include "plssvm/detail/utility.hpp"         // plssvm::detail::get
 #include "plssvm/exceptions/exceptions.hpp"  // plssvm::unsupported_kernel_type_exception
 #include "plssvm/matrix.hpp"                 // plssvm::matrix, plssvm::layout_type
 
@@ -146,7 +146,7 @@ template <kernel_function_type kernel, typename T, layout_type layout, typename.
     if constexpr (kernel == kernel_function_type::linear) {
         static_assert(sizeof...(args) == 0, "Illegal number of additional parameters! Must be 0.");
         T temp{ 0.0 };
-        #pragma omp simd reduction(+ : temp) if(!PLSSVM_IS_DEFINED(PLSSVM_ASSERT_ENABLED))
+        #pragma omp simd reduction(+ : temp)
         for (size_type dim = 0; dim < x.num_cols(); ++dim) {
             temp += x(i, dim) * y(j, dim);
         }
@@ -157,7 +157,7 @@ template <kernel_function_type kernel, typename T, layout_type layout, typename.
         const auto gamma = static_cast<T>(detail::get<1>(args...));
         const auto coef0 = static_cast<T>(detail::get<2>(args...));
         T temp{ 0.0 };
-        #pragma omp simd reduction(+ : temp) if(!PLSSVM_IS_DEFINED(PLSSVM_ASSERT_ENABLED))
+        #pragma omp simd reduction(+ : temp)
         for (size_type dim = 0; dim < x.num_cols(); ++dim) {
             temp += x(i, dim) * y(j, dim);
         }
@@ -166,7 +166,7 @@ template <kernel_function_type kernel, typename T, layout_type layout, typename.
         static_assert(sizeof...(args) == 1, "Illegal number of additional parameters! Must be 1.");
         const auto gamma = static_cast<T>(detail::get<0>(args...));
         T temp{ 0.0 };
-        #pragma omp simd reduction(+ : temp) if(!PLSSVM_IS_DEFINED(PLSSVM_ASSERT_ENABLED))
+        #pragma omp simd reduction(+ : temp)
         for (size_type dim = 0; dim < x.num_cols(); ++dim) {
             const T diff = x(i, dim) - y(j, dim);
             temp += diff * diff;

--- a/src/plssvm/csvm.cpp
+++ b/src/plssvm/csvm.cpp
@@ -186,21 +186,21 @@ std::pair<std::vector<real_type>, real_type> csvm::perform_dimensional_reduction
 
     // create q_red vector and calculate QA_costs
     std::vector<real_type> q_red(num_rows_reduced);
-    switch (params.kernel_type) {
+    switch (params.kernel_type.value()) {
         case kernel_function_type::linear:
-#pragma omp parallel for default(none) shared(q_red, A) firstprivate(num_rows_reduced)
+            #pragma omp parallel for default(none) shared(q_red, A) firstprivate(num_rows_reduced)
             for (std::size_t i = 0; i < num_rows_reduced; ++i) {
                 q_red[i] = kernel_function<kernel_function_type::linear>(A, i, A, num_rows_reduced);
             }
             break;
         case kernel_function_type::polynomial:
-#pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
+            #pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
             for (std::size_t i = 0; i < num_rows_reduced; ++i) {
                 q_red[i] = kernel_function<kernel_function_type::polynomial>(A, i, A, num_rows_reduced, params.degree.value(), params.gamma.value(), params.coef0.value());
             }
             break;
         case kernel_function_type::rbf:
-#pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
+            #pragma omp parallel for default(none) shared(q_red, A, params) firstprivate(num_rows_reduced)
             for (std::size_t i = 0; i < num_rows_reduced; ++i) {
                 q_red[i] = kernel_function<kernel_function_type::rbf>(A, i, A, num_rows_reduced, params.gamma.value());
             }

--- a/tests/kernel_function_types.cpp
+++ b/tests/kernel_function_types.cpp
@@ -119,7 +119,7 @@ TYPED_TEST(KernelFunctionVector, linear_kernel_function_variadic) {
 
         for (const auto [degree, gamma, coef0, cost] : this->get_param_values()) {
             SCOPED_TRACE(fmt::format("parameter: [{}, {}, {}, {}]", degree, gamma, coef0, cost));
-            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::linear>(x1, x2), compare::detail::linear_kernel(x1, x2), real_type{ 512.0 });
+            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::linear>(x1, x2), compare::detail::linear_kernel(x1, x2), real_type{ 1e4 });
         }
     }
 }
@@ -135,7 +135,7 @@ TYPED_TEST(KernelFunctionVector, linear_kernel_function_parameter) {
         for (const auto [degree, gamma, coef0, cost] : this->get_param_values()) {
             SCOPED_TRACE(fmt::format("parameter: [{}, {}, {}, {}]", degree, gamma, coef0, cost));
             const plssvm::parameter params{ plssvm::kernel_function_type::linear, static_cast<int>(degree), gamma, coef0, cost };
-            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(x1, x2, params), compare::detail::linear_kernel(x1, x2), real_type{ 512.0 });
+            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(x1, x2, params), compare::detail::linear_kernel(x1, x2), real_type{ 1e5 });
         }
     }
 }
@@ -154,7 +154,7 @@ TYPED_TEST(KernelFunctionVector, polynomial_kernel_function_variadic) {
             const auto degree_p = static_cast<int>(degree);
             const auto gamma_p = static_cast<real_type>(gamma);
             const auto coef0_p = static_cast<real_type>(coef0);
-            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::polynomial>(x1, x2, degree_p, gamma_p, coef0_p), compare::detail::polynomial_kernel(x1, x2, degree_p, gamma_p, coef0_p), real_type{ 512.0 });
+            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::polynomial>(x1, x2, degree_p, gamma_p, coef0_p), compare::detail::polynomial_kernel(x1, x2, degree_p, gamma_p, coef0_p), real_type{ 1e5 });
         }
     }
 }
@@ -172,7 +172,7 @@ TYPED_TEST(KernelFunctionVector, polynomial_kernel_function_parameter) {
             const plssvm::parameter params{ plssvm::kernel_function_type::polynomial, static_cast<int>(degree), gamma, coef0, cost };
             EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(x1, x2, params),
                                            compare::detail::polynomial_kernel(x1, x2, params.degree.value(), static_cast<real_type>(params.gamma.value()), static_cast<real_type>(params.coef0.value())),
-                                           real_type{ 512.0 });
+                                           real_type{ 1e5 });
         }
     }
 }
@@ -189,7 +189,7 @@ TYPED_TEST(KernelFunctionVector, radial_basis_function_kernel_function_variadic)
         for (const auto [degree, gamma, coef0, cost] : this->get_param_values()) {
             SCOPED_TRACE(fmt::format("parameter: [{}, {}, {}, {}]", degree, gamma, coef0, cost));
             const auto gamma_p = static_cast<real_type>(gamma);
-            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::rbf>(x1, x2, gamma_p), compare::detail::rbf_kernel(x1, x2, gamma_p), real_type{ 512.0 });
+            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::rbf>(x1, x2, gamma_p), compare::detail::rbf_kernel(x1, x2, gamma_p), real_type{ 1e5 });
         }
     }
 }
@@ -205,7 +205,7 @@ TYPED_TEST(KernelFunctionVector, radial_basis_function_kernel_function_parameter
         for (const auto [degree, gamma, coef0, cost] : this->get_param_values()) {
             SCOPED_TRACE(fmt::format("parameter: [{}, {}, {}, {}]", degree, gamma, coef0, cost));
             const plssvm::parameter params{ plssvm::kernel_function_type::rbf, static_cast<int>(degree), gamma, coef0, cost };
-            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(x1, x2, params), compare::detail::rbf_kernel(x1, x2, static_cast<real_type>(params.gamma.value())), real_type{ 512.0 });
+            EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(x1, x2, params), compare::detail::rbf_kernel(x1, x2, static_cast<real_type>(params.gamma.value())), real_type{ 1e5 });
         }
     }
 }
@@ -306,7 +306,7 @@ TYPED_TEST(KernelFunctionMatrix, linear_kernel_function_variadic) {
                         x2[dim] = matr2(j, dim);
                     }
 
-                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::linear>(matr1, i, matr2, j), compare::detail::linear_kernel(x1, x2), real_type{ 512.0 });
+                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::linear>(matr1, i, matr2, j), compare::detail::linear_kernel(x1, x2), real_type{ 1e5 });
                 }
             }
         }
@@ -339,7 +339,7 @@ TYPED_TEST(KernelFunctionMatrix, linear_kernel_function_parameter) {
                     }
 
                     const plssvm::parameter params{ plssvm::kernel_function_type::linear, static_cast<int>(degree), gamma, coef0, cost };
-                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(matr1, i, matr2, j, params), compare::detail::linear_kernel(x1, x2), real_type{ 512.0 });
+                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(matr1, i, matr2, j, params), compare::detail::linear_kernel(x1, x2), real_type{ 1e5 });
                 }
             }
         }
@@ -375,7 +375,7 @@ TYPED_TEST(KernelFunctionMatrix, polynomial_kernel_function_variadic) {
                     const auto degree_p = static_cast<int>(degree);
                     const auto gamma_p = static_cast<real_type>(gamma);
                     const auto coef0_p = static_cast<real_type>(coef0);
-                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::polynomial>(matr1, i, matr2, j, degree_p, gamma_p, coef0_p), compare::detail::polynomial_kernel(x1, x2, degree_p, gamma_p, coef0_p), real_type{ 512.0 });
+                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::polynomial>(matr1, i, matr2, j, degree_p, gamma_p, coef0_p), compare::detail::polynomial_kernel(x1, x2, degree_p, gamma_p, coef0_p), real_type{ 1e5 });
                 }
             }
         }
@@ -410,7 +410,7 @@ TYPED_TEST(KernelFunctionMatrix, polynomial_kernel_function_parameter) {
                     const plssvm::parameter params{ plssvm::kernel_function_type::polynomial, static_cast<int>(degree), gamma, coef0, cost };
                     EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(matr1, i, matr2, j, params),
                                                    compare::detail::polynomial_kernel(x1, x2, params.degree.value(), static_cast<real_type>(params.gamma.value()), static_cast<real_type>(params.coef0.value())),
-                                                   real_type{ 512.0 });
+                                                   real_type{ 1e5 });
                 }
             }
         }
@@ -444,7 +444,7 @@ TYPED_TEST(KernelFunctionMatrix, rbf_kernel_function_variadic) {
                     }
 
                     const auto gamma_p = static_cast<real_type>(gamma);
-                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::rbf>(matr1, i, matr2, j, gamma_p), compare::detail::rbf_kernel(x1, x2, gamma_p), real_type{ 512.0 });
+                    EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function<plssvm::kernel_function_type::rbf>(matr1, i, matr2, j, gamma_p), compare::detail::rbf_kernel(x1, x2, gamma_p), real_type{ 1e5 });
                 }
             }
         }
@@ -479,7 +479,7 @@ TYPED_TEST(KernelFunctionMatrix, rbf_kernel_function_parameter) {
                     const plssvm::parameter params{ plssvm::kernel_function_type::rbf, static_cast<int>(degree), gamma, coef0, cost };
                     EXPECT_FLOATING_POINT_NEAR_EPS(plssvm::kernel_function(matr1, i, matr2, j, params),
                                                    compare::detail::rbf_kernel(x1, x2, static_cast<real_type>(params.gamma.value())),
-                                                   real_type{ 512.0 });
+                                                   real_type{ 1e5 });
                 }
             }
         }


### PR DESCRIPTION
Fix some warnings regarding (auto-)vectorization:
- remove std::fma
- conditional disable warning, if Release/RelWithDebInfo together with clang is used **and** assertions are enabled.