### PR TITLE
Correct index types in kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ target_compile_features(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC cxx_std_17)
 ## additional base library compile options
 target_compile_options(${PLSSVM_BASE_LIBRARY_NAME} PUBLIC
                        $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wdouble-promotion -fno-common -Wshadow -Wcast-qual
-                       -Wnull-dereference -Wctor-dtor-privacy -Wnon-virtual-dtor -Wextra-semi -Wunreachable-code -Wuninitialized -Wno-ctor-dtor-privacy
+                       -Wnull-dereference -Wnon-virtual-dtor -Wextra-semi -Wunreachable-code -Wuninitialized -Wno-ctor-dtor-privacy
                        -fPIC>
                        $<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wsuggest-override -Wstrict-null-sentinel -Wlogical-op -Wduplicated-branches -Wimplicit-fallthrough=5>
                        $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wdocumentation -Wmost>

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
@@ -31,42 +31,57 @@ namespace plssvm::cuda::detail {
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
 __global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
-    // compute: C = alpha * A * B + beta * C with A in m x k, B in n x k, and C in n x m, alpha, beta as scalar
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # rhs -> num_rhs
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # rows -> device_specific_num_rows
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # rhs -> num_rhs
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # rows -> device_specific_num_rows
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type A_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type B_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long dim = 0; dim < (num_rows - row_offset); dim += FEATURE_BLOCK_SIZE) {
+    // iterate over all features using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long dim = 0; dim < (num_rows - row_offset); dim += FEATURE_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_i = i_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_j = j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_i = i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_j = j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
             // determine on which side of the diagonal we are located
-            if (dim + threadIdx.y < global_j) {
-                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y) * (num_rows - row_offset + PADDING_SIZE) + global_j - (dim + threadIdx.y) * (dim + threadIdx.y + 1) / 2];
+            if (dim + threadIdx_y < global_j) {
+                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y) * (num_rows - row_offset + PADDING_SIZE_ull) + global_j - (dim + threadIdx_y) * (dim + threadIdx_y + 1ull) / 2ull];
             } else {
-                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE) + dim + threadIdx.y - global_j * (global_j + 1) / 2];
+                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ull) + dim + threadIdx_y - global_j * (global_j + 1ull) / 2ull];
             }
             // determine on which side of the diagonal we are located
             if (dim + threadIdx.y + THREAD_BLOCK_SIZE < global_j) {
-                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows - row_offset + PADDING_SIZE) + global_j - (dim + threadIdx.y + THREAD_BLOCK_SIZE) * (dim + threadIdx.y + THREAD_BLOCK_SIZE + 1) / 2];
+                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows - row_offset + PADDING_SIZE_ull) + global_j - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull + 1ull) / 2ull];
             } else {
-                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE - global_j * (global_j + 1) / 2];
+                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull - global_j * (global_j + 1ull) / 2ull];
             }
 
-            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx.y) * (num_rhs + PADDING_SIZE) + global_i];
-            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rhs + PADDING_SIZE) + global_i];
+            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx_y) * (num_rhs + PADDING_SIZE_ull) + global_i];
+            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rhs + PADDING_SIZE_ull) + global_i];
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -74,17 +89,19 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // apply the (partial) BLAS operation and update C
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long device_global_j = j + internal_j;
-            const unsigned long long global_j = row_offset + j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
+            const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
 
+            // be sure to not perform out of bounds accesses
             if (global_i < num_rhs && device_global_j < device_specific_num_rows) {
-                C[global_j * (num_rhs + PADDING_SIZE) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE) + global_i];
+                C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i];
             }
         }
     }
@@ -105,31 +122,47 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
 __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # rhs -> num_rhs
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # rows -> num_mirror_rows
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # rhs -> num_rhs
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # rows -> num_mirror_rows
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type A_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type B_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long dim = 0; dim < device_specific_num_rows; dim += FEATURE_BLOCK_SIZE) {
+    // iterate over the remaining features using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long dim = 0; dim < device_specific_num_rows; dim += FEATURE_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_i = i_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_j = j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_i = i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_j = j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y) * (num_rows - row_offset + PADDING_SIZE) - (dim + threadIdx.y - 1) * (dim + threadIdx.y) / 2 + device_specific_num_rows - (dim + threadIdx.y) + global_j];
-            A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows - row_offset + PADDING_SIZE) - (dim + threadIdx.y + THREAD_BLOCK_SIZE - 1) * (dim + threadIdx.y + THREAD_BLOCK_SIZE) / 2 + device_specific_num_rows - (dim + threadIdx.y + THREAD_BLOCK_SIZE) + global_j];
-
-            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx.y) * (num_rhs + PADDING_SIZE) + global_i];
-            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rhs + PADDING_SIZE) + global_i];
+            // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+            A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y) * (num_rows - row_offset + PADDING_SIZE_ull) - (dim + threadIdx_y - 1ull) * (dim + threadIdx_y) / 2ull + device_specific_num_rows - (dim + threadIdx_y) + global_j];
+            A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows - row_offset + PADDING_SIZE_ull) - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull - 1ull) * (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) / 2ull + device_specific_num_rows - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) + global_j];
+            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx_y) * (num_rhs + PADDING_SIZE_ull) + global_i];
+            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rhs + PADDING_SIZE_ull) + global_i];
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the feature reduction calculation
         for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -137,17 +170,19 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // apply the (remaining) BLAS operation and update C
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long partial_global_j = j + internal_j;
-            const unsigned long long global_j = row_offset + device_specific_num_rows + j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto partial_global_j = j + static_cast<unsigned long long>(internal_j);
+            const auto global_j = row_offset + device_specific_num_rows + j + static_cast<unsigned long long>(internal_j);
 
+            // be sure to not perform out of bounds accesses
             if (global_i < num_rhs && partial_global_j < num_mirror_rows) {
-                C[global_j * (num_rhs + PADDING_SIZE) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE) + global_i];
+                C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i];
             }
         }
     }
@@ -160,15 +195,26 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
  * @param[in] rhs the second matrix
  */
 __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # num_rows
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # num_rhs
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
+
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # num_rows
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # num_rhs
 
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long global_j = j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto global_j = j + static_cast<unsigned long long>(internal_j);
 
-            lhs[global_i * (num_cols + PADDING_SIZE) + global_j] += rhs[global_i * (num_cols + PADDING_SIZE) + global_j];
+            lhs[global_i * (num_cols + PADDING_SIZE_ull) + global_j] += rhs[global_i * (num_cols + PADDING_SIZE_ull) + global_j];
         }
     }
 }
@@ -180,15 +226,26 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
  * @param[in] scale the value to scale
  */
 __global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # num_rows
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # num_rhs
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
+
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # num_rows
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # num_rhs
 
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long global_j = j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto global_j = j + static_cast<unsigned long long>(internal_j);
 
-            lhs[global_i * (num_cols + PADDING_SIZE) + global_j] *= scale;
+            lhs[global_i * (num_cols + PADDING_SIZE_ull) + global_j] *= scale;
         }
     }
 }

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
@@ -1,13 +1,13 @@
 /**
- * @file
- * @author Alexander Van Craen
- * @author Marcel Breyer
- * @copyright 2018-today The PLSSVM project - All Rights Reserved
- * @license This file is part of the PLSSVM project which is released under the MIT license.
- *          See the LICENSE.md file in the project root for full license information.
- *
- * @brief Functions for explicitly assembling the kernel matrix using the CUDA backend.
- */
+* @file
+* @author Alexander Van Craen
+* @author Marcel Breyer
+* @copyright 2018-today The PLSSVM project - All Rights Reserved
+* @license This file is part of the PLSSVM project which is released under the MIT license.
+*          See the LICENSE.md file in the project root for full license information.
+*
+* @brief Functions for explicitly assembling the kernel matrix using the CUDA backend.
+*/
 
 #ifndef PLSSVM_BACKENDS_CUDA_KERNEL_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLY_CUH_
 #define PLSSVM_BACKENDS_CUDA_KERNEL_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLY_CUH_
@@ -20,76 +20,99 @@
 namespace plssvm::cuda::detail {
 
 /**
- * @brief Create the explicit kernel matrix using the @p kernel_function.
- * @tparam kernel_function the type of the used kernel function
- * @tparam Args the types of the parameters necessary for the specific kernel function
- * @param[out] ret the calculated kernel matrix
- * @param[in] data_d the data points to calculate the kernel matrix from
- * @param[in] num_rows the total number of data points (= total number of rows)
- * @param[in] device_num_rows the number of rows the current device is responsible for
- * @param[in] row_offset the first row in @p data_d the current device is responsible for
- * @param[in] num_features the number of features per data point
- * @param[in] q the vector used in the dimensional reduction
- * @param[in] QA_cost the scalar used in the dimensional reduction
- * @param[in] cost the cost factor the diagonal is scaled with
- * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
- */
+* @brief Create the explicit kernel matrix using the @p kernel_function.
+* @tparam kernel_function the type of the used kernel function
+* @tparam Args the types of the parameters necessary for the specific kernel function
+* @param[out] kernel_matrix_d the calculated kernel matrix
+* @param[in] data_d the data points to calculate the kernel matrix from
+* @param[in] num_rows the total number of data points (= total number of rows)
+* @param[in] device_num_rows the number of rows the current device is responsible for
+* @param[in] row_offset the first row in @p data_d the current device is responsible for
+* @param[in] num_features the number of features per data point
+* @param[in] q the vector used in the dimensional reduction
+* @param[in] QA_cost the scalar used in the dimensional reduction
+* @param[in] cost the cost factor the diagonal is scaled with
+* @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
+*/
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_assembly(real_type *ret, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+__global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) {
+   // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+   const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+   const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+   const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+   const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+   const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+   const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+   const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+   const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+   const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+   const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
-    __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
-    __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
+   // calculate the indices used in the current thread
+   const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+   const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+   const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+   const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
-    if (blockIdx.x >= blockIdx.y) {
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+   // create the shared memory arrays used for caching data point features
+   __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
+   __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
-            // load data into shared memory
-            for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+   // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
+   if (blockIdx.x >= blockIdx.y) {
+       // create a thread private array used for internal caching
+       real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-                data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_j];
-                data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_j];
-            }
-            __syncthreads();
+       // iterate over all features using blocking to be able to cache them for faster memory accesses
+       for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
+           // load data into shared memory
+           for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
+               const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+               const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            // calculation
-            for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
-                for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
-                    for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                        temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i[block_dim][threadIdx.x * INTERNAL_BLOCK_SIZE + internal_i],
-                                                                                                data_cache_j[block_dim][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_j]);
-                    }
-                }
-            }
-            __syncthreads();
-        }
+               // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+               data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+               data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+               data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+               data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+           }
+           __syncthreads();  // wait until all threads loaded their part of the data
 
-        for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
-            for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long device_global_i = i + internal_i;
-                const unsigned long long global_i = row_offset + i + internal_i;
-                const unsigned long long device_global_j = j + internal_j;
-                const unsigned long long global_j = row_offset + j + internal_j;
+           // perform the feature reduction calculation
+           for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
+               for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
+                   for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
+                       temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i[block_dim][threadIdx.x * INTERNAL_BLOCK_SIZE + internal_i],
+                                                                                               data_cache_j[block_dim][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_j]);
+                   }
+               }
+           }
+           __syncthreads();  // wait until all threads performed their part of the calculations
+       }
 
-                if (device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j) {
-                    real_type temp_ij = temp[internal_i][internal_j];
-                    temp_ij = detail::apply_kernel_function<kernel_function>(temp_ij, kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
-                    if (global_i == global_j) {
-                        temp_ij += cost;
-                    }
-                    ret[device_global_j * (num_rows - row_offset + PADDING_SIZE) - device_global_j * (device_global_j + 1) / 2 + device_global_i] = temp_ij;
-                }
-            }
-        }
-    }
+       // apply the remaining part of the kernel function and store the value in the output kernel matrix
+       for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
+           for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
+               // calculate the indices to access the kernel matrix (the part stored on the current device)
+               const auto device_global_i = i + static_cast<unsigned long long>(internal_i);
+               const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+               const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
+               const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
+
+               // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
+               if (device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j) {
+                   real_type temp_ij = temp[internal_i][internal_j];
+                   temp_ij = detail::apply_kernel_function<kernel_function>(temp_ij, kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
+                   // apply the cost on the diagonal
+                   if (global_i == global_j) {
+                       temp_ij += cost;
+                   }
+                   // update the kernel matrix
+                   kernel_matrix_d[device_global_j * (num_rows - row_offset + PADDING_SIZE_ull) - device_global_j * (device_global_j + 1ull) / 2ull + device_global_i] = temp_ij;
+               }
+           }
+       }
+   }
 }
 
 }  // namespace plssvm::cuda::detail

--- a/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
@@ -40,32 +40,50 @@ namespace plssvm::cuda::detail {
  */
 template <kernel_function_type kernel_function, typename... Args>
 __global__ void device_kernel_assembly_symm(const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, Args... kernel_function_parameter) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
     if (blockIdx.x >= blockIdx.y) {
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+        // create a thread private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
         {
+            // create the shared memory arrays used for caching data point features
             __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
             __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-            for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+            // iterate over all features using blocking to be able to cache them for faster memory accesses
+            for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
                 // load data into shared memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
-                    const unsigned long long global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+                    const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                    data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                    data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                    data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_j];
-                    data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_j];
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                    data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                    data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+                    data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads loaded their part of the data
 
-                // calculation
+                // perform the feature reduction calculation
                 for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -74,46 +92,51 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                         }
                     }
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads performed their part of the calculations
             }
         }
 
-        // update temp using the rbf kernel function taking the dimensional reduction into account and apply the cost to the diagonal
+        // apply the remaining part of the kernel function and store the value in the output kernel matrix
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = row_offset + i + internal_i;
-                const unsigned long long device_global_i = i + internal_i;
-                const unsigned long long global_j = row_offset + j + internal_j;
-                const unsigned long long device_global_j = j + internal_j;
+                const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+                const auto device_global_i = i + static_cast<unsigned long long>(internal_i);
+                const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
+                const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
 
+                // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                 if ((device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j)) {
                     temp[internal_i][internal_j] = detail::apply_kernel_function<kernel_function>(temp[internal_i][internal_j], kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
+                    // apply the cost on the diagonal
                     if (global_i == global_j) {
                         temp[internal_i][internal_j] += cost;
                     }
                 } else {
-                    temp[internal_i][internal_j] = 0.0;
+                    // be sure to set the value to zero otherwise
+                    temp[internal_i][internal_j] = real_type{ 0.0 };
                 }
             }
         }
 
         // calculate C += alpha * temp * B for the UPPER triangular matrix
         {
+            // same shared memory size but with different dimensions
             __shared__ real_type B_cache[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE][FEATURE_BLOCK_SIZE];
             __shared__ real_type C_out_cache[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE][FEATURE_BLOCK_SIZE];
 
-            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
+            // iterate over all classes using blocking to be able to cache them for faster memory accesses
+            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
                 // load data into shared memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = alpha * B[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y];
-                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE];
-
-                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = 0.0;
-                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = 0.0;
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = alpha * B[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y];
+                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
+                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = real_type{ 0.0 };
+                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = real_type{ 0.0 };
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads loaded their part of the data
 
                 // calculate intermediate results and store them in shared memory
                 for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
@@ -123,48 +146,50 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                                 temp[internal_i][internal_j] * B_cache[threadIdx.x * INTERNAL_BLOCK_SIZE + internal_i][(class_idx + threadIdx.x) % FEATURE_BLOCK_SIZE];
                         }
                     }
-                    __syncthreads();
+                    __syncthreads();  // wait until all threads performed their part of the calculations
                 }
 
                 // add intermediate cached results to C
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_j = row_offset + j + internal;
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.x], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x]);
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.x + THREAD_BLOCK_SIZE], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x + THREAD_BLOCK_SIZE]);
+                    const auto global_j = row_offset + j + static_cast<unsigned long long>(internal);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_x], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x]);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_x + THREAD_BLOCK_SIZE_ull], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x + THREAD_BLOCK_SIZE]);
                 }
-                __syncthreads();
+                __syncthreads();  // wai until all threads updated C with their values
             }
         }
 
         // set potential diagonal entries in temp to 0.0 such that we don't apply the main diagonal twice to C
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = row_offset + i + internal_i;
-                const unsigned long long global_j = row_offset + j + internal_j;
+                const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+                const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
 
                 if (global_i == global_j) {
-                    temp[internal_i][internal_j] = 0.0;
+                    temp[internal_i][internal_j] = real_type{ 0.0 };
                 }
             }
         }
 
         // calculate C += alpha * temp * B for the LOWER triangular matrix
         {
+            // same shared memory size but with different dimensions
             __shared__ real_type B_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
             __shared__ real_type C_out_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
+            // iterate over all classes using blocking to be able to cache them for faster memory accesses
+            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
                 // load data into shared memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                    B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.y];
-                    B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE];
-
-                    C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
-                    C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y];
+                    B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
+                    C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
+                    C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads loaded their part of the data
 
                 // calculate intermediate results and store them in shared memory
                 for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
@@ -174,16 +199,16 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                                 temp[internal_i][internal_j] * B_cache[(class_idx + threadIdx.y) % FEATURE_BLOCK_SIZE][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_j];
                         }
                     }
-                    __syncthreads();
+                    __syncthreads();  // wait until all threads performed their part of the calculations
                 }
 
                 // add intermediate cached results to C
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset + i + internal;
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y], C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE], C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                    const auto global_i = row_offset + i + static_cast<unsigned long long>(internal);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y], C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull], C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
                 }
-                __syncthreads();
+                __syncthreads();  // wai until all threads updated C with their values
             }
         }
     }

--- a/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
@@ -208,7 +208,7 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                     atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y], C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
                     atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull], C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
                 }
-                __syncthreads();  // wai until all threads updated C with their values
+                __syncthreads();  // wait until all threads updated C with their values
             }
         }
     }

--- a/include/plssvm/backends/CUDA/kernel/detail/fill_kernel.cuh
+++ b/include/plssvm/backends/CUDA/kernel/detail/fill_kernel.cuh
@@ -26,7 +26,7 @@ namespace plssvm::cuda::detail {
  */
 template <typename value_type, typename size_type>
 __global__ void fill_array(value_type *data, const value_type value, const size_type start_pos, const size_type count) {
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const auto idx = static_cast<size_type>(blockIdx.x) * static_cast<size_type>(blockDim.x) + static_cast<size_type>(threadIdx.x);
     // fill the array
     if (idx < count) {
         data[start_pos + idx] = value;

--- a/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
+++ b/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
@@ -31,28 +31,43 @@ namespace plssvm::cuda::detail {
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
  */
 __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset) {
-    const unsigned long long feature_idx = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long feature_idx_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long class_idx = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long class_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto feature_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto feature_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto class_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_feature[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type data_cache_alpha[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long sv = 0; sv < device_specific_num_sv; sv += THREAD_BLOCK_SIZE) {
+    // iterate over all support vectors using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long sv = 0; sv < device_specific_num_sv; sv += THREAD_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_feature_idx = feature_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_feature_idx = feature_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_class_idx = class_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            data_cache_feature[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE) + sv + threadIdx.y];  // SoA
-            data_cache_alpha[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE) + sv + sv_offset + threadIdx.y];       // AoS
+            data_cache_feature[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE_ull) + sv + threadIdx_y];  // SoA
+            data_cache_alpha[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE_ull) + sv + sv_offset + threadIdx_y];       // AoS
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (unsigned block_dim = 0; block_dim < THREAD_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
                 for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
@@ -60,22 +75,23 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // update global array with local one
     for (unsigned internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
         for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-            const unsigned long long global_feature_idx = feature_idx + internal_feature;
-            const unsigned long long global_class_idx = class_idx + internal_class;
+            const auto global_feature_idx = feature_idx + static_cast<unsigned long long>(internal_feature);
+            const auto global_class_idx = class_idx + static_cast<unsigned long long>(internal_class);
 
-            w_d[global_feature_idx * (num_classes + PADDING_SIZE) + global_class_idx] = temp[internal_feature][internal_class];
+            w_d[global_feature_idx * (num_classes + PADDING_SIZE_ull) + global_class_idx] = temp[internal_feature][internal_class];
         }
     }
 }
 
 /**
  * @brief Predict the @p predict_points_d using the linear kernel speeding up the calculation using the @p w_d vector.
- * @param[out] out_d the predicted values
+ * @param[out] prediction_d the predicted values
  * @param[in] w_d the vector to speedup the calculations
  * @param[in] rho_d the previously learned bias
  * @param[in] predict_points_d the data points to predict
@@ -83,31 +99,48 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
  */
-__global__ void device_kernel_predict_linear(real_type *out_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) {
-    const unsigned long long pp_idx = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long pp_idx_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long class_idx = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long class_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+__global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto class_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type data_cache_w[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+    // iterate over all features using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_pp_idx = pp_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_class_idx = class_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_w[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx.y) * (num_classes + PADDING_SIZE) + global_class_idx];
-            data_cache_w[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_classes + PADDING_SIZE) + global_class_idx];
+            // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+            data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+            data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+            data_cache_w[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx_y) * (num_classes + PADDING_SIZE_ull) + global_class_idx];
+            data_cache_w[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_classes + PADDING_SIZE_ull) + global_class_idx];
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                 for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
@@ -115,15 +148,16 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // update global array with local one
     for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
         for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-            const unsigned long long global_pp_idx = pp_idx + internal_pd;
-            const unsigned long long global_class_idx = class_idx + internal_class;
+            const auto global_pp_idx = pp_idx + static_cast<unsigned long long>(internal_pd);
+            const auto global_class_idx = class_idx + static_cast<unsigned long long>(internal_class);
 
-            out_d[global_pp_idx * (num_classes + PADDING_SIZE) + global_class_idx] = temp[internal_pd][internal_class] - rho_d[global_class_idx];
+            prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ull) + global_class_idx] = temp[internal_pd][internal_class] - rho_d[global_class_idx];
         }
     }
 }
@@ -132,7 +166,7 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
  * @brief Predict the @p predict_points_d using the @p kernel_function.
  * @tparam kernel_function the type of the used kernel function
  * @tparam Args the types of the parameters necessary for the specific kernel function
- * @param[in] out_d the predicted values
+ * @param[in] prediction_d the predicted values
  * @param[in] alpha_d the previously learned weights
  * @param[in] rho_d the previously learned biases
  * @param[in] sv_d the support vectors
@@ -144,31 +178,48 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) {
-    const unsigned long long pp_idx = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long pp_idx_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long sv_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+__global__ void device_kernel_predict(real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // calculate the indices used in the current thread
+    const auto pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto sv_cached_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
     {
+        // create the shared memory arrays used for caching data point features
         __shared__ real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
         __shared__ real_type data_cache_sv[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const auto global_pp_idx = pp_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
+                const auto global_sv_idx = sv_cached_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
 
-                data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-                data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-                data_cache_sv[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx.y) * (num_sv + PADDING_SIZE) + global_sv_idx];
-                data_cache_sv[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_sv + PADDING_SIZE) + global_sv_idx];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+                data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+                data_cache_sv[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
+                data_cache_sv[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads loaded their part of the data
 
-            // calculation
+            // perform the feature reduction calculation
             for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                     for (unsigned internal_sv = 0; internal_sv < INTERNAL_BLOCK_SIZE; ++internal_sv) {
@@ -177,7 +228,7 @@ __global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d
                     }
                 }
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads performed their part of the calculations
         }
     }
 
@@ -189,27 +240,30 @@ __global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d
     }
 
     {
+        // same shared memory size but with different dimensions
         __shared__ real_type alpha_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
         __shared__ real_type out_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-        for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                 const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
 
-                alpha_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx.y) * (num_sv + PADDING_SIZE) + global_sv_idx];
-                alpha_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_sv + PADDING_SIZE) + global_sv_idx];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                alpha_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
+                alpha_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
-                if (blockIdx.y == 0) {
-                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx.y];
-                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx.y + THREAD_BLOCK_SIZE];
+                if (blockIdx.y == 0u) {
+                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y];
+                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
                 } else {
-                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
-                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
+                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
+                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
                 }
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads loaded their part of the data
 
             // calculate intermediate results and store them in shared memory
             for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
@@ -219,15 +273,15 @@ __global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d
                             temp[internal_pd][internal_sv] * alpha_cache[(class_idx + threadIdx.y) % FEATURE_BLOCK_SIZE][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_sv];
                     }
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads performed their part of the calculations
             }
 
             // add intermediate cached results to out_d
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_pp_idx = pp_idx + internal;
+                const auto global_pp_idx = pp_idx + static_cast<unsigned long long>(internal);
 
-                atomicAdd(&out_d[global_pp_idx * (num_classes + PADDING_SIZE) + dim + threadIdx.y], out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
-                atomicAdd(&out_d[global_pp_idx * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE], out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y], out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull], out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
             }
             __syncthreads();
         }

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
@@ -34,42 +34,57 @@ namespace plssvm::hip::detail {
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
 __global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
-    // compute: C = alpha * A * B + beta * C with A in m x k, B in n x k, and C in n x m, alpha, beta as scalar
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # rhs -> num_rhs
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # rows -> device_specific_num_rows
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # rhs -> num_rhs
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # rows -> device_specific_num_rows
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type A_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type B_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long dim = 0; dim < (num_rows - row_offset); dim += FEATURE_BLOCK_SIZE) {
+    // iterate over all features using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long dim = 0; dim < (num_rows - row_offset); dim += FEATURE_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_i = i_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_j = j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_i = i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_j = j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
             // determine on which side of the diagonal we are located
-            if (dim + threadIdx.y < global_j) {
-                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y) * (num_rows - row_offset + PADDING_SIZE) + global_j - (dim + threadIdx.y) * (dim + threadIdx.y + 1) / 2];
+            if (dim + threadIdx_y < global_j) {
+                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y) * (num_rows - row_offset + PADDING_SIZE_ull) + global_j - (dim + threadIdx_y) * (dim + threadIdx_y + 1ull) / 2ull];
             } else {
-                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE) + dim + threadIdx.y - global_j * (global_j + 1) / 2];
+                A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ull) + dim + threadIdx_y - global_j * (global_j + 1ull) / 2ull];
             }
             // determine on which side of the diagonal we are located
             if (dim + threadIdx.y + THREAD_BLOCK_SIZE < global_j) {
-                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows - row_offset + PADDING_SIZE) + global_j - (dim + threadIdx.y + THREAD_BLOCK_SIZE) * (dim + threadIdx.y + THREAD_BLOCK_SIZE + 1) / 2];
+                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows - row_offset + PADDING_SIZE_ull) + global_j - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull + 1ull) / 2ull];
             } else {
-                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE - global_j * (global_j + 1) / 2];
+                A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull - global_j * (global_j + 1ull) / 2ull];
             }
 
-            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx.y) * (num_rhs + PADDING_SIZE) + global_i];
-            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rhs + PADDING_SIZE) + global_i];
+            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx_y) * (num_rhs + PADDING_SIZE_ull) + global_i];
+            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(dim + row_offset + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rhs + PADDING_SIZE_ull) + global_i];
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -77,17 +92,19 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // apply the (partial) BLAS operation and update C
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long device_global_j = j + internal_j;
-            const unsigned long long global_j = row_offset + j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
+            const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
 
+            // be sure to not perform out of bounds accesses
             if (global_i < num_rhs && device_global_j < device_specific_num_rows) {
-                C[global_j * (num_rhs + PADDING_SIZE) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE) + global_i];
+                C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i];
             }
         }
     }
@@ -108,31 +125,47 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
 __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # rhs -> num_rhs
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # rows -> num_mirror_rows
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # rhs -> num_rhs
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # rows -> num_mirror_rows
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type A_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type B_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long dim = 0; dim < device_specific_num_rows; dim += FEATURE_BLOCK_SIZE) {
+    // iterate over the remaining features using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long dim = 0; dim < device_specific_num_rows; dim += FEATURE_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_i = i_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_j = j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_i = i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_j = j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y) * (num_rows - row_offset + PADDING_SIZE) - (dim + threadIdx.y - 1) * (dim + threadIdx.y) / 2 + device_specific_num_rows - (dim + threadIdx.y) + global_j];
-            A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows - row_offset + PADDING_SIZE) - (dim + threadIdx.y + THREAD_BLOCK_SIZE - 1) * (dim + threadIdx.y + THREAD_BLOCK_SIZE) / 2 + device_specific_num_rows - (dim + threadIdx.y + THREAD_BLOCK_SIZE) + global_j];
-
-            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx.y) * (num_rhs + PADDING_SIZE) + global_i];
-            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rhs + PADDING_SIZE) + global_i];
+            // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+            A_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y) * (num_rows - row_offset + PADDING_SIZE_ull) - (dim + threadIdx_y - 1ull) * (dim + threadIdx_y) / 2ull + device_specific_num_rows - (dim + threadIdx_y) + global_j];
+            A_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = A[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows - row_offset + PADDING_SIZE_ull) - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull - 1ull) * (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) / 2ull + device_specific_num_rows - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) + global_j];
+            B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx_y) * (num_rhs + PADDING_SIZE_ull) + global_i];
+            B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = B[(row_offset + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rhs + PADDING_SIZE_ull) + global_i];
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the feature reduction calculation
         for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -140,17 +173,19 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // apply the (remaining) BLAS operation and update C
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long partial_global_j = j + internal_j;
-            const unsigned long long global_j = row_offset + device_specific_num_rows + j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto partial_global_j = j + static_cast<unsigned long long>(internal_j);
+            const auto global_j = row_offset + device_specific_num_rows + j + static_cast<unsigned long long>(internal_j);
 
+            // be sure to not perform out of bounds accesses
             if (global_i < num_rhs && partial_global_j < num_mirror_rows) {
-                C[global_j * (num_rhs + PADDING_SIZE) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE) + global_i];
+                C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i] = alpha * temp[internal_i][internal_j] + beta * C[global_j * (num_rhs + PADDING_SIZE_ull) + global_i];
             }
         }
     }
@@ -163,15 +198,26 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
  * @param[in] rhs the second matrix
  */
 __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # num_rows
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # num_rhs
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
+
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # num_rows
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # num_rhs
 
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long global_j = j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto global_j = j + static_cast<unsigned long long>(internal_j);
 
-            lhs[global_i * (num_cols + PADDING_SIZE) + global_j] += rhs[global_i * (num_cols + PADDING_SIZE) + global_j];
+            lhs[global_i * (num_cols + PADDING_SIZE_ull) + global_j] += rhs[global_i * (num_cols + PADDING_SIZE_ull) + global_j];
         }
     }
 }
@@ -183,15 +229,26 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
  * @param[in] scale the value to scale
  */
 __global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;  // # num_rows
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;  // # num_rhs
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
+
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;  // # num_rows
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;  // # num_rhs
 
     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-            const unsigned long long global_i = i + internal_i;
-            const unsigned long long global_j = j + internal_j;
+            const auto global_i = i + static_cast<unsigned long long>(internal_i);
+            const auto global_j = j + static_cast<unsigned long long>(internal_j);
 
-            lhs[global_i * (num_cols + PADDING_SIZE) + global_j] *= scale;
+            lhs[global_i * (num_cols + PADDING_SIZE_ull) + global_j] *= scale;
         }
     }
 }

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
@@ -23,47 +23,65 @@
 namespace plssvm::hip::detail {
 
 /**
- * @brief Create the explicit kernel matrix using the @p kernel_function.
- * @tparam kernel_function the type of the used kernel function
- * @tparam Args the types of the parameters necessary for the specific kernel function
- * @param[out] ret the calculated kernel matrix
- * @param[in] data_d the data points to calculate the kernel matrix from
- * @param[in] num_rows the total number of data points (= total number of rows)
- * @param[in] device_num_rows the number of rows the current device is responsible for
- * @param[in] row_offset the first row in @p data_d the current device is responsible for
- * @param[in] num_features the number of features per data point
- * @param[in] q the vector used in the dimensional reduction
- * @param[in] QA_cost the scalar used in the dimensional reduction
- * @param[in] cost the cost factor the diagonal is scaled with
- * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
+* @brief Create the explicit kernel matrix using the @p kernel_function.
+* @tparam kernel_function the type of the used kernel function
+* @tparam Args the types of the parameters necessary for the specific kernel function
+* @param[out] kernel_matrix_d the calculated kernel matrix
+* @param[in] data_d the data points to calculate the kernel matrix from
+* @param[in] num_rows the total number of data points (= total number of rows)
+* @param[in] device_num_rows the number of rows the current device is responsible for
+* @param[in] row_offset the first row in @p data_d the current device is responsible for
+* @param[in] num_features the number of features per data point
+* @param[in] q the vector used in the dimensional reduction
+* @param[in] QA_cost the scalar used in the dimensional reduction
+* @param[in] cost the cost factor the diagonal is scaled with
+* @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_assembly(real_type *ret, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+__global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
+    // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a wavefront must progress further
     if (blockIdx.x >= blockIdx.y) {
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // create a thread private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+                const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_j];
-                data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_j];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+                data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads loaded their part of the data
 
-            // calculation
+            // perform the feature reduction calculation
             for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                     for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -72,23 +90,28 @@ __global__ void device_kernel_assembly(real_type *ret, const real_type *data_d, 
                     }
                 }
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads performed their part of the calculations
         }
 
+        // apply the remaining part of the kernel function and store the value in the output kernel matrix
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long device_global_i = i + internal_i;
-                const unsigned long long global_i = row_offset + i + internal_i;
-                const unsigned long long device_global_j = j + internal_j;
-                const unsigned long long global_j = row_offset + j + internal_j;
+                // calculate the indices to access the kernel matrix (the part stored on the current device)
+                const auto device_global_i = i + static_cast<unsigned long long>(internal_i);
+                const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+                const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
+                const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
 
+                // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                 if (device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j) {
                     real_type temp_ij = temp[internal_i][internal_j];
                     temp_ij = detail::apply_kernel_function<kernel_function>(temp_ij, kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
+                    // apply the cost on the diagonal
                     if (global_i == global_j) {
                         temp_ij += cost;
                     }
-                    ret[device_global_j * (num_rows - row_offset + PADDING_SIZE) - device_global_j * (device_global_j + 1) / 2 + device_global_i] = temp_ij;
+                    // update the kernel matrix
+                    kernel_matrix_d[device_global_j * (num_rows - row_offset + PADDING_SIZE_ull) - device_global_j * (device_global_j + 1ull) / 2ull + device_global_i] = temp_ij;
                 }
             }
         }

--- a/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
@@ -42,32 +42,50 @@ namespace plssvm::hip::detail {
  */
 template <kernel_function_type kernel_function, typename... Args>
 __global__ void device_kernel_assembly_symm(const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, Args... kernel_function_parameter) {
-    const unsigned long long i = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long i_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long j = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long j_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a wavefront must progress further
     if (blockIdx.x >= blockIdx.y) {
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // create a thread private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
         {
+            // create the shared memory arrays used for caching data point features
             __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
             __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-            for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+            // iterate over all features using blocking to be able to cache them for faster memory accesses
+            for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
                 // load data into shared memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
-                    const unsigned long long global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+                    const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                    data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                    data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                    data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y) * (num_rows + 1 + PADDING_SIZE) + global_j];
-                    data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_j];
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                    data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                    data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+                    data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads loaded their part of the data
 
-                // calculation
+                // perform the feature reduction calculation
                 for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -76,46 +94,51 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                         }
                     }
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads performed their part of the calculations
             }
         }
 
-        // update temp using the rbf kernel function taking the dimensional reduction into account and apply the cost to the diagonal
+        // apply the remaining part of the kernel function and store the value in the output kernel matrix
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = row_offset + i + internal_i;
-                const unsigned long long device_global_i = i + internal_i;
-                const unsigned long long global_j = row_offset + j + internal_j;
-                const unsigned long long device_global_j = j + internal_j;
+                const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+                const auto device_global_i = i + static_cast<unsigned long long>(internal_i);
+                const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
+                const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
 
+                // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                 if ((device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j)) {
                     temp[internal_i][internal_j] = detail::apply_kernel_function<kernel_function>(temp[internal_i][internal_j], kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
+                    // apply the cost on the diagonal
                     if (global_i == global_j) {
                         temp[internal_i][internal_j] += cost;
                     }
                 } else {
-                    temp[internal_i][internal_j] = 0.0;
+                    // be sure to set the value to zero otherwise
+                    temp[internal_i][internal_j] = real_type{ 0.0 };
                 }
             }
         }
 
         // calculate C += alpha * temp * B for the UPPER triangular matrix
         {
+            // same shared memory size but with different dimensions
             __shared__ real_type B_cache[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE][FEATURE_BLOCK_SIZE];
             __shared__ real_type C_out_cache[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE][FEATURE_BLOCK_SIZE];
 
-            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
+            // iterate over all classes using blocking to be able to cache them for faster memory accesses
+            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
                 // load data into shared memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = alpha * B[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y];
-                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE];
-
-                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = 0.0;
-                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = 0.0;
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = alpha * B[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y];
+                    B_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
+                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y] = real_type{ 0.0 };
+                    C_out_cache[internal * THREAD_BLOCK_SIZE + threadIdx.x][threadIdx.y + THREAD_BLOCK_SIZE] = real_type{ 0.0 };
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads loaded their part of the data
 
                 // calculate intermediate results and store them in shared memory
                 for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
@@ -125,48 +148,50 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                                 temp[internal_i][internal_j] * B_cache[threadIdx.x * INTERNAL_BLOCK_SIZE + internal_i][(class_idx + threadIdx.x) % FEATURE_BLOCK_SIZE];
                         }
                     }
-                    __syncthreads();
+                    __syncthreads();  // wait until all threads performed their part of the calculations
                 }
 
                 // add intermediate cached results to C
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_j = row_offset + j + internal;
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.x], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x]);
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.x + THREAD_BLOCK_SIZE], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x + THREAD_BLOCK_SIZE]);
+                    const auto global_j = row_offset + j + static_cast<unsigned long long>(internal);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_x], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x]);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_x + THREAD_BLOCK_SIZE_ull], C_out_cache[threadIdx.y * INTERNAL_BLOCK_SIZE + internal][threadIdx.x + THREAD_BLOCK_SIZE]);
                 }
-                __syncthreads();
+                __syncthreads();  // wai until all threads updated C with their values
             }
         }
 
         // set potential diagonal entries in temp to 0.0 such that we don't apply the main diagonal twice to C
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = row_offset + i + internal_i;
-                const unsigned long long global_j = row_offset + j + internal_j;
+                const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+                const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
 
                 if (global_i == global_j) {
-                    temp[internal_i][internal_j] = 0.0;
+                    temp[internal_i][internal_j] = real_type{ 0.0 };
                 }
             }
         }
 
         // calculate C += alpha * temp * B for the LOWER triangular matrix
         {
+            // same shared memory size but with different dimensions
             __shared__ real_type B_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
             __shared__ real_type C_out_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
+            // iterate over all classes using blocking to be able to cache them for faster memory accesses
+            for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
                 // load data into shared memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-                    B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.y];
-                    B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE];
-
-                    C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
-                    C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    B_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y];
+                    B_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha * B[global_j * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
+                    C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
+                    C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads loaded their part of the data
 
                 // calculate intermediate results and store them in shared memory
                 for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
@@ -176,16 +201,16 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                                 temp[internal_i][internal_j] * B_cache[(class_idx + threadIdx.y) % FEATURE_BLOCK_SIZE][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_j];
                         }
                     }
-                    __syncthreads();
+                    __syncthreads();  // wait until all threads performed their part of the calculations
                 }
 
                 // add intermediate cached results to C
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset + i + internal;
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y], C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE], C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                    const auto global_i = row_offset + i + static_cast<unsigned long long>(internal);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y], C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull], C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
                 }
-                __syncthreads();
+                __syncthreads();  // wai until all threads updated C with their values
             }
         }
     }

--- a/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
@@ -210,7 +210,7 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
                     atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y], C_out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
                     atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull], C_out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
                 }
-                __syncthreads();  // wai until all threads updated C with their values
+                __syncthreads();  // wait until all threads updated C with their values
             }
         }
     }

--- a/include/plssvm/backends/HIP/kernel/detail/fill_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/detail/fill_kernel.hip.hpp
@@ -19,20 +19,20 @@
 namespace plssvm::hip::detail {
 
 /**
- * @brief Fill the array @p data with @p count values @p value starting at position @p pos.
- * @tparam value_type the type of the array
- * @tparam size_type  the unsigned size_type
- * @param[in,out] data the array to fill
+ * @brief Fill @p count values of the array @p data with the @p value starting at position @p start_pos.
+ * @tparam value_type the type of the array and fill value
+ * @tparam size_type the size type
+ * @param[out] data the array to fill
  * @param[in] value the value to fill the array with
- * @param[in] pos the position at which to start te filling
- * @param[in] count the number of values to fill in the array starting at @p pos
+ * @param[in] start_pos the position to start filling the array
+ * @param[in] count the number of values to fill
  */
 template <typename value_type, typename size_type>
-__global__ void fill_array(value_type *data, value_type value, size_type pos, size_type count) {
-    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+__global__ void fill_array(value_type *data, const value_type value, const size_type start_pos, const size_type count) {
+    const auto idx = static_cast<size_type>(blockIdx.x) * static_cast<size_type>(blockDim.x) + static_cast<size_type>(threadIdx.x);
     // fill the array
     if (idx < count) {
-        data[pos + idx] = value;
+        data[start_pos + idx] = value;
     }
 }
 

--- a/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
@@ -33,28 +33,43 @@ namespace plssvm::hip::detail {
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
  */
 __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset) {
-    const unsigned long long feature_idx = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long feature_idx_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long class_idx = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long class_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto feature_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto feature_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto class_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_feature[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type data_cache_alpha[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long sv = 0; sv < device_specific_num_sv; sv += THREAD_BLOCK_SIZE) {
+    // iterate over all support vectors using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long sv = 0; sv < device_specific_num_sv; sv += THREAD_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_feature_idx = feature_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_feature_idx = feature_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_class_idx = class_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            data_cache_feature[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE) + sv + threadIdx.y];  // SoA
-            data_cache_alpha[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE) + sv + sv_offset + threadIdx.y];       // AoS
+            data_cache_feature[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE_ull) + sv + threadIdx_y];  // SoA
+            data_cache_alpha[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE_ull) + sv + sv_offset + threadIdx_y];       // AoS
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (unsigned block_dim = 0; block_dim < THREAD_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
                 for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
@@ -62,22 +77,23 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // update global array with local one
     for (unsigned internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
         for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-            const unsigned long long global_feature_idx = feature_idx + internal_feature;
-            const unsigned long long global_class_idx = class_idx + internal_class;
+            const auto global_feature_idx = feature_idx + static_cast<unsigned long long>(internal_feature);
+            const auto global_class_idx = class_idx + static_cast<unsigned long long>(internal_class);
 
-            w_d[global_feature_idx * (num_classes + PADDING_SIZE) + global_class_idx] = temp[internal_feature][internal_class];
+            w_d[global_feature_idx * (num_classes + PADDING_SIZE_ull) + global_class_idx] = temp[internal_feature][internal_class];
         }
     }
 }
 
 /**
  * @brief Predict the @p predict_points_d using the linear kernel speeding up the calculation using the @p w_d vector.
- * @param[out] out_d the predicted values
+ * @param[out] prediction_d the predicted values
  * @param[in] w_d the vector to speedup the calculations
  * @param[in] rho_d the previously learned bias
  * @param[in] predict_points_d the data points to predict
@@ -85,31 +101,48 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
  */
-__global__ void device_kernel_predict_linear(real_type *out_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) {
-    const unsigned long long pp_idx = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long pp_idx_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long class_idx = (blockIdx.y * blockDim.y + threadIdx.y) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long class_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+__global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
+    // calculate the indices used in the current thread
+    const auto pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto class_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __shared__ real_type data_cache_w[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-    for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+    // iterate over all features using blocking to be able to cache them for faster memory accesses
+    for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const unsigned long long global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const unsigned long long global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const auto global_pp_idx = pp_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_class_idx = class_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-            data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_w[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx.y) * (num_classes + PADDING_SIZE) + global_class_idx];
-            data_cache_w[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_classes + PADDING_SIZE) + global_class_idx];
+            // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+            data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+            data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+            data_cache_w[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx_y) * (num_classes + PADDING_SIZE_ull) + global_class_idx];
+            data_cache_w[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = w_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_classes + PADDING_SIZE_ull) + global_class_idx];
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                 for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
@@ -117,15 +150,16 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
                 }
             }
         }
-        __syncthreads();
+        __syncthreads();  // wait until all threads performed their part of the calculations
     }
 
+    // update global array with local one
     for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
         for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-            const unsigned long long global_pp_idx = pp_idx + internal_pd;
-            const unsigned long long global_class_idx = class_idx + internal_class;
+            const auto global_pp_idx = pp_idx + static_cast<unsigned long long>(internal_pd);
+            const auto global_class_idx = class_idx + static_cast<unsigned long long>(internal_class);
 
-            out_d[global_pp_idx * (num_classes + PADDING_SIZE) + global_class_idx] = temp[internal_pd][internal_class] - rho_d[global_class_idx];
+            prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ull) + global_class_idx] = temp[internal_pd][internal_class] - rho_d[global_class_idx];
         }
     }
 }
@@ -134,7 +168,7 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
  * @brief Predict the @p predict_points_d using the @p kernel_function.
  * @tparam kernel_function the type of the used kernel function
  * @tparam Args the types of the parameters necessary for the specific kernel function
- * @param[in] out_d the predicted values
+ * @param[in] prediction_d the predicted values
  * @param[in] alpha_d the previously learned weights
  * @param[in] rho_d the previously learned biases
  * @param[in] sv_d the support vectors
@@ -146,31 +180,48 @@ __global__ void device_kernel_predict_linear(real_type *out_d, const real_type *
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) {
-    const unsigned long long pp_idx = (blockIdx.x * blockDim.x + threadIdx.x) * INTERNAL_BLOCK_SIZE;
-    const unsigned long long pp_idx_linear = blockIdx.x * blockDim.x * INTERNAL_BLOCK_SIZE + threadIdx.x;
-    const unsigned long long sv_cached_idx_linear = blockIdx.y * blockDim.y * INTERNAL_BLOCK_SIZE + threadIdx.x;
+__global__ void device_kernel_predict(real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+    // calculate the indices used in the current thread
+    const auto pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto sv_cached_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
     {
+        // create the shared memory arrays used for caching data point features
         __shared__ real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
         __shared__ real_type data_cache_sv[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const auto global_pp_idx = pp_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
+                const auto global_sv_idx = sv_cached_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
 
-                data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-                data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-                data_cache_sv[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx.y) * (num_sv + PADDING_SIZE) + global_sv_idx];
-                data_cache_sv[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_sv + PADDING_SIZE) + global_sv_idx];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+                data_cache_pp[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
+                data_cache_sv[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
+                data_cache_sv[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads loaded their part of the data
 
-            // calculation
+            // perform the feature reduction calculation
             for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                     for (unsigned internal_sv = 0; internal_sv < INTERNAL_BLOCK_SIZE; ++internal_sv) {
@@ -179,7 +230,7 @@ __global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d
                     }
                 }
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads performed their part of the calculations
         }
     }
 
@@ -191,27 +242,30 @@ __global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d
     }
 
     {
+        // same shared memory size but with different dimensions
         __shared__ real_type alpha_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
         __shared__ real_type out_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-        for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                 const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
 
-                alpha_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx.y) * (num_sv + PADDING_SIZE) + global_sv_idx];
-                alpha_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx.y + THREAD_BLOCK_SIZE) * (num_sv + PADDING_SIZE) + global_sv_idx];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                alpha_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
+                alpha_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
-                if (blockIdx.y == 0) {
-                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx.y];
-                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx.y + THREAD_BLOCK_SIZE];
+                if (blockIdx.y == 0u) {
+                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y];
+                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
                 } else {
-                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
-                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = 0.0;
+                    out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
+                    out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = real_type{ 0.0 };
                 }
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads loaded their part of the data
 
             // calculate intermediate results and store them in shared memory
             for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
@@ -221,17 +275,17 @@ __global__ void device_kernel_predict(real_type *out_d, const real_type *alpha_d
                             temp[internal_pd][internal_sv] * alpha_cache[(class_idx + threadIdx.y) % FEATURE_BLOCK_SIZE][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_sv];
                     }
                 }
-                __syncthreads();
+                __syncthreads();  // wait until all threads performed their part of the calculations
             }
 
-            // add intermediate cached results to out_d
+            // add intermediate cached results to prediction_d
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_pp_idx = pp_idx + internal;
+                const auto global_pp_idx = pp_idx + static_cast<unsigned long long>(internal);
 
-                atomicAdd(&out_d[global_pp_idx * (num_classes + PADDING_SIZE) + dim + threadIdx.y], out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
-                atomicAdd(&out_d[global_pp_idx * (num_classes + PADDING_SIZE) + dim + threadIdx.y + THREAD_BLOCK_SIZE], out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y], out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ull) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ull], out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x]);
             }
-            __syncthreads();
+            __syncthreads();  // wait until all threads updated their part of the prediction
         }
     }
 }

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
@@ -6,7 +6,7 @@
  * @license This file is part of the PLSSVM project which is released under the MIT license.
  *          See the LICENSE.md file in the project root for full license information.
  *
- * @brief Functions for explicitly assemblying the kernel matrix using the OpenCL backend.
+ * @brief Functions for explicitly assembling the kernel matrix using the OpenCL backend.
  */
 
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
@@ -14,7 +14,7 @@
 /**
  * @brief Create the explicit kernel matrix using the kernel function determined at runtime.
  * @details The `PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST`, `PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER`, `PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION`, and `PLSSVM_OPENCL_APPLY_KERNEL_FUNCTION` placeholder will be replaced by the correct values upon kernel construction.
- * @param[out] ret the calculated kernel matrix
+ * @param[out] kernel_matrix_d the calculated kernel matrix
  * @param[in] data_d the data points to calculate the kernel matrix from
  * @param[in] num_rows the total number of data points (= total number of rows)
  * @param[in] device_num_rows the number of rows the current device is responsible for
@@ -25,56 +25,70 @@
  * @param[in] cost the cost factor the diagonal is scaled with
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
  */
-__kernel void device_kernel_assembly(__global real_type *ret, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const __global real_type *q, const real_type QA_cost, const real_type cost PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE;
-    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE + get_local_id(0);
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE;
-    const ulong j_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE + get_local_id(0);
+__kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const __global real_type *q, const real_type QA_cost, const real_type cost PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
+    // cast values to 32-bit unsigned int values to prevent implicit conversions
+    const uint local_id_0 = get_local_id(0);
+    const uint local_id_1 = get_local_id(1);
 
+    // calculate the indices used in the current thread
+    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong j_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+
+    // create the local memory arrays used for caching data point features
     __local real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __local real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
+    // only calculate the upper triangular matrix -> can't use get_local_id() since all work-items in a work-group must progress further
     if (get_group_id(0) >= get_group_id(1)) {
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+        // create a thread private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 
-        for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
-            // load data into shared memory
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ul) {
+            // load data into local memory
             for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const ulong global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
-                const ulong global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const ulong global_i = row_offset + i_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
+                const ulong global_j = row_offset + j_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-                data_cache_i[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1)) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_i[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_j[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1)) * (num_rows + 1 + PADDING_SIZE) + global_j];
-                data_cache_j[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_j];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
+                data_cache_i[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_i[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_j[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
+                data_cache_j[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
             }
-            barrier(CLK_LOCAL_MEM_FENCE);
+            barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
-            // calculation
+            // perform the feature reduction calculation
             for (uint block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                     for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                        temp[internal_i][internal_j] += PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION(data_cache_i[block_dim][get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_i], data_cache_j[block_dim][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_j]);
+                        temp[internal_i][internal_j] += PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION(data_cache_i[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_i], data_cache_j[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_j]);
                     }
                 }
             }
-            barrier(CLK_LOCAL_MEM_FENCE);
+            barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
         }
 
+        // apply the remaining part of the kernel function and store the value in the output kernel matrix
         for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const ulong device_global_i = i + internal_i;
-                const ulong global_i = row_offset + i + internal_i;
-                const ulong device_global_j = j + internal_j;
-                const ulong global_j = row_offset + j + internal_j;
+                const ulong device_global_i = i + (ulong) internal_i;
+                const ulong global_i = row_offset + i + (ulong) internal_i;
+                const ulong device_global_j = j + (ulong) internal_j;
+                const ulong global_j = row_offset + j + (ulong) internal_j;
 
+                // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                 if (device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j) {
                     real_type temp_ij = temp[internal_i][internal_j];
                     temp_ij = PLSSVM_OPENCL_APPLY_KERNEL_FUNCTION(temp_ij PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER) + QA_cost - q[global_i] - q[global_j];
+                    // apply the cost on the diagonal
                     if (global_i == global_j) {
                         temp_ij += cost;
                     }
-                    ret[device_global_j * (num_rows - row_offset + PADDING_SIZE) - device_global_j * (device_global_j + 1) / 2 + device_global_i] = temp_ij;
+                    // update the kernel matrix
+                    kernel_matrix_d[device_global_j * (num_rows - row_offset + PADDING_SIZE_ul) - device_global_j * (device_global_j + (ulong) 1) / (ulong) 2 + device_global_i] = temp_ij;
                 }
             }
         }

--- a/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
@@ -30,147 +30,163 @@
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
  */
 __kernel void device_kernel_assembly_symm(const real_type alpha, const __global real_type *q, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const real_type QA_cost, const real_type cost, const __global real_type *B, __global real_type *C, const ulong num_classes PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE;
-    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE + get_local_id(0);
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE;
-    const ulong j_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE + get_local_id(0);
+    // cast values to 32-bit unsigned int values to prevent implicit conversions
+    const uint local_id_0 = get_local_id(0);
+    const uint local_id_1 = get_local_id(1);
 
+    // calculate the indices used in the current thread
+    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong j_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+
+    // create the local memory arrays used for caching data point features
     __local real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __local real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
+    // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
     if (get_group_id(0) >= get_group_id(1)) {
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+        // create a thread private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 
-        for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
-            // load data into shared memory
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ul) {
+            // load data into local memory
             for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const ulong global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
-                const ulong global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const ulong global_i = row_offset + i_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
+                const ulong global_j = row_offset + j_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-                data_cache_i[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1)) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_i[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_i];
-                data_cache_j[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1)) * (num_rows + 1 + PADDING_SIZE) + global_j];
-                data_cache_j[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_rows + 1 + PADDING_SIZE) + global_j];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                data_cache_i[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_i[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_j[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
+                data_cache_j[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
             }
-            barrier(CLK_LOCAL_MEM_FENCE);
+            barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
-            // calculation
+            // perform the feature reduction calculation
             for (uint block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                     for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                        temp[internal_i][internal_j] += PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION(data_cache_i[block_dim][get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_i], data_cache_j[block_dim][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_j]);
+                        temp[internal_i][internal_j] += PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION(data_cache_i[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_i], data_cache_j[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_j]);
                     }
                 }
             }
-            barrier(CLK_LOCAL_MEM_FENCE);
+            barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
         }
 
-        // update temp using the kernel function taking the dimensional reduction into account and apply the cost to the diagonal
+        // apply the remaining part of the kernel function and store the value in the output kernel matrix
         for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const ulong global_i = row_offset + i + internal_i;
-                const ulong device_global_i = i + internal_i;
-                const ulong global_j = row_offset + j + internal_j;
-                const ulong device_global_j = j + internal_j;
+                const ulong global_i = row_offset + i + (ulong) internal_i;
+                const ulong device_global_i = i + (ulong) internal_i;
+                const ulong global_j = row_offset + j + (ulong) internal_j;
+                const ulong device_global_j = j + (ulong) internal_j;
 
+                // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                 if ((device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j)) {
                     temp[internal_i][internal_j] = PLSSVM_OPENCL_APPLY_KERNEL_FUNCTION(temp[internal_i][internal_j] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER) + QA_cost - q[global_i] - q[global_j];
+                    // apply the cost on the diagonal
                     if (global_i == global_j) {
                         temp[internal_i][internal_j] += cost;
                     }
                 } else {
-                    temp[internal_i][internal_j] = 0.0;
+                    temp[internal_i][internal_j] = (real_type) 0.0;
                 }
             }
         }
 
         // calculate C += alpha * temp * B for the UPPER triangular matrix
         {
+            // reinterpret cache arrays with interchanged dimensions
             real_type (*B_cache)[FEATURE_BLOCK_SIZE] = (real_type (*)[FEATURE_BLOCK_SIZE]) data_cache_i;
             real_type (*C_out_cache)[FEATURE_BLOCK_SIZE] = (real_type (*)[FEATURE_BLOCK_SIZE]) data_cache_j;
 
-            for (ulong dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
-                // load data into shared memory
+            // iterate over all classes using blocking to be able to cache them for faster memory accesses
+            for (ulong dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ul) {
+                // load data into local memory
                 for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const ulong global_i = row_offset + i_linear + internal * THREAD_BLOCK_SIZE;
+                    const ulong global_i = row_offset + i_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-                    B_cache[internal * THREAD_BLOCK_SIZE + get_local_id(0)][get_local_id(1)] = alpha * B[global_i * (num_classes + PADDING_SIZE) + dim + get_local_id(1)];
-                    B_cache[internal * THREAD_BLOCK_SIZE + get_local_id(0)][get_local_id(1) + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE) + dim + get_local_id(1) + THREAD_BLOCK_SIZE];
-
-                    C_out_cache[internal * THREAD_BLOCK_SIZE + get_local_id(0)][get_local_id(1)] = 0.0;
-                    C_out_cache[internal * THREAD_BLOCK_SIZE + get_local_id(0)][get_local_id(1) + THREAD_BLOCK_SIZE] = 0.0;
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    B_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1] = alpha * B[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)];
+                    B_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1 + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul];
+                    C_out_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1] = (real_type) 0.0;
+                    C_out_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1 + THREAD_BLOCK_SIZE] = (real_type) 0.0;
                 }
-                barrier(CLK_LOCAL_MEM_FENCE);
+                barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
-                // calculate intermediate results and store them in shared memory
+                // calculate intermediate results and store them in local memory
                 for (uint class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
                     for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                         for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                            C_out_cache[get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_j][(class_idx + get_local_id(0)) % FEATURE_BLOCK_SIZE] +=
-                                temp[internal_i][internal_j] * B_cache[get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_i][(class_idx + get_local_id(0)) % FEATURE_BLOCK_SIZE];
+                            C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal_j][(class_idx + local_id_0) % FEATURE_BLOCK_SIZE] +=
+                                temp[internal_i][internal_j] * B_cache[local_id_0 * INTERNAL_BLOCK_SIZE + internal_i][(class_idx + local_id_0) % FEATURE_BLOCK_SIZE];
                         }
                     }
-                    barrier(CLK_LOCAL_MEM_FENCE);
+                    barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
                 }
 
                 // add intermediate cached results to C
                 for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const ulong global_j = row_offset + j + internal;
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE) + dim + get_local_id(0)], C_out_cache[get_local_id(1) * INTERNAL_BLOCK_SIZE + internal][get_local_id(0)]);
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE) + dim + get_local_id(0) + THREAD_BLOCK_SIZE], C_out_cache[get_local_id(1) * INTERNAL_BLOCK_SIZE + internal][get_local_id(0) + THREAD_BLOCK_SIZE]);
+                    const ulong global_j = row_offset + j + (ulong) internal;
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(0)], C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal][local_id_0]);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(0) + THREAD_BLOCK_SIZE_ul], C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal][local_id_0 + THREAD_BLOCK_SIZE]);
                 }
-                barrier(CLK_LOCAL_MEM_FENCE);
+                barrier(CLK_LOCAL_MEM_FENCE);  // wai until all threads updated C with their values
             }
         }
 
         // set potential diagonal entries in temp to 0.0 such that we don't apply the main diagonal twice to C
         for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const ulong global_i = row_offset + i + internal_i;
-                const ulong global_j = row_offset + j + internal_j;
+                const ulong global_i = row_offset + i + (ulong) internal_i;
+                const ulong global_j = row_offset + j + (ulong) internal_j;
 
                 if (global_i == global_j) {
-                    temp[internal_i][internal_j] = 0.0;
+                    temp[internal_i][internal_j] = (real_type) 0.0;
                 }
             }
         }
 
         // calculate C += alpha * temp * B for the LOWER triangular matrix
         {
+            // reinterpret cache arrays with interchanged dimensions
             real_type (*B_cache)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE] = (real_type (*)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]) data_cache_i;
             real_type (*C_out_cache)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE] = (real_type (*)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]) data_cache_j;
 
-            for (ulong dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
-                // load data into shared memory
+            // iterate over all classes using blocking to be able to cache them for faster memory accesses
+            for (ulong dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ul) {
+                // load data into local memory
                 for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const ulong global_j = row_offset + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const ulong global_j = row_offset + j_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-                    B_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = alpha * B[global_j * (num_classes + PADDING_SIZE) + dim + get_local_id(1)];
-                    B_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = alpha * B[global_j * (num_classes + PADDING_SIZE) + dim + get_local_id(1) + THREAD_BLOCK_SIZE];
-
-                    C_out_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = 0.0;
-                    C_out_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = 0.0;
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha * B[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)];
+                    B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha * B[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul];
+                    C_out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
+                    C_out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
                 }
-                barrier(CLK_LOCAL_MEM_FENCE);
+                barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
                 // calculate intermediate results and store them in shared memory
                 for (uint class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
                     for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                         for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                            C_out_cache[(class_idx + get_local_id(1)) % FEATURE_BLOCK_SIZE][internal_i * THREAD_BLOCK_SIZE + get_local_id(0)] +=
-                                temp[internal_i][internal_j] * B_cache[(class_idx + get_local_id(1)) % FEATURE_BLOCK_SIZE][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_j];
+                            C_out_cache[(class_idx + local_id_1) % FEATURE_BLOCK_SIZE][internal_i * THREAD_BLOCK_SIZE + local_id_0] +=
+                                temp[internal_i][internal_j] * B_cache[(class_idx + local_id_1) % FEATURE_BLOCK_SIZE][local_id_1 * INTERNAL_BLOCK_SIZE + internal_j];
                         }
                     }
-                    barrier(CLK_LOCAL_MEM_FENCE);
+                    barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
                 }
 
                 // add intermediate cached results to C
                 for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const ulong global_i = row_offset + i + internal;
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE) + dim + get_local_id(1)], C_out_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)]);
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE) + dim + get_local_id(1) + THREAD_BLOCK_SIZE], C_out_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)]);
+                    const ulong global_i = row_offset + i + (ulong) internal;
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)], C_out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0]);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul], C_out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0]);
                 }
-                barrier(CLK_LOCAL_MEM_FENCE);
+                barrier(CLK_LOCAL_MEM_FENCE);   // wait until all threads updated C with their values
             }
         }
     }

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
@@ -16,7 +16,7 @@
 /**
  * @brief Predict the @p predict_points_d using the kernel function determined at runtime.
  * @details The `PLSSVM_DEVICE_KERNEL_PREDICT_NAME`, `PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST`, `PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER`, `PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION`, and `PLSSVM_OPENCL_APPLY_KERNEL_FUNCTION` placeholder will be replaced by the correct values upon kernel construction.
- * @param[in] out_d the predicted values
+ * @param[in] prediction_d the predicted values
  * @param[in] alpha_d the previously learned weights
  * @param[in] rho_d the previously learned biases
  * @param[in] sv_d the support vectors
@@ -27,38 +27,47 @@
  * @param[in] num_features the number of features per data point
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
  */
-__kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *out_d, const __global real_type *alpha_d, const __global real_type *rho_d, const __global real_type *sv_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_sv, const ulong num_predict_points, const ulong num_features PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
-    const ulong pp_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE;
-    const ulong pp_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE + get_local_id(0);
-    const ulong sv_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE + get_local_id(0);
+__kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d, const __global real_type *alpha_d, const __global real_type *rho_d, const __global real_type *sv_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_sv, const ulong num_predict_points, const ulong num_features PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
+    // cast values to 32-bit unsigned int values to prevent implicit conversions
+    const uint local_id_0 = get_local_id(0);
+    const uint local_id_1 = get_local_id(1);
 
+    // calculate the indices used in the current thread
+    const ulong pp_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong pp_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong sv_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+
+    // create the local memory arrays used for caching data point features
     __local real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __local real_type data_cache_sv[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 
-    for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
-        // load data into shared memory
+    // iterate over all features using blocking to be able to cache them for faster memory accesses
+    for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ul) {
+        // load data into local memory
         for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const ulong global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const ulong global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const ulong global_pp_idx = pp_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
+            const ulong global_sv_idx = sv_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-            data_cache_pp[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = predict_points_d[(dim + get_local_id(1)) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_pp[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = predict_points_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_sv[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = sv_d[(dim + get_local_id(1)) * (num_sv + PADDING_SIZE) + global_sv_idx];
-            data_cache_sv[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = sv_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_sv + PADDING_SIZE) + global_sv_idx];
+            // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+            data_cache_pp[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1)) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_pp[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_sv[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[(dim + get_local_id(1)) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
+            data_cache_sv[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
+        barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
-        // calculation
+        // perform the feature reduction calculation
         for (uint block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (uint internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                 for (uint internal_sv = 0; internal_sv < INTERNAL_BLOCK_SIZE; ++internal_sv) {
-                    temp[internal_pd][internal_sv] += PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION(data_cache_sv[block_dim][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_sv], data_cache_pp[block_dim][get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_pd]);
+                    temp[internal_pd][internal_sv] += PLSSVM_OPENCL_FEATURE_REDUCE_FUNCTION(data_cache_sv[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_sv], data_cache_pp[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_pd]);
                 }
             }
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
+        barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
     }
 
     // update temp using the respective kernel function
@@ -69,47 +78,50 @@ __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *out_d, const
     }
 
     {
-        real_type (*alpha_cache)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE] = (real_type (*)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]) data_cache_pp;
-        real_type (*out_cache)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE] = (real_type (*)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]) data_cache_sv;
+        // reinterpret cache arrays with interchanged dimensions
+        real_type(*alpha_cache)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE] = (real_type(*)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]) data_cache_pp;
+        real_type(*out_cache)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE] = (real_type(*)[INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]) data_cache_sv;
 
-        for (ulong dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE) {
-            // load data into shared memory
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (ulong dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ul) {
+            // load data into local memory
             for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const ulong global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const ulong global_sv_idx = sv_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-                alpha_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = alpha_d[(dim + get_local_id(1)) * (num_sv + PADDING_SIZE) + global_sv_idx];
-                alpha_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = alpha_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_sv + PADDING_SIZE) + global_sv_idx];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                alpha_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + get_local_id(1)) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
+                alpha_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
-                if (get_group_id(1) == 0) {
-                    out_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = -rho_d[dim + get_local_id(1)];
-                    out_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = -rho_d[dim + get_local_id(1) + THREAD_BLOCK_SIZE];
+                if (get_group_id(1) == (ulong) 0) {
+                    out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + get_local_id(1)];
+                    out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul];
                 } else {
-                    out_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = 0.0;
-                    out_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = 0.0;
+                    out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
+                    out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
                 }
             }
-            barrier(CLK_LOCAL_MEM_FENCE);
+            barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
             // calculate intermediate results and store them in shared memory
             for (uint class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
                 for (uint internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                     for (uint internal_sv = 0; internal_sv < INTERNAL_BLOCK_SIZE; ++internal_sv) {
-                        out_cache[(class_idx + get_local_id(1)) % FEATURE_BLOCK_SIZE][internal_pd * THREAD_BLOCK_SIZE + get_local_id(0)] +=
-                            temp[internal_pd][internal_sv] * alpha_cache[(class_idx + get_local_id(1)) % FEATURE_BLOCK_SIZE][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_sv];
+                        out_cache[(class_idx + local_id_1) % FEATURE_BLOCK_SIZE][internal_pd * THREAD_BLOCK_SIZE + local_id_0] +=
+                            temp[internal_pd][internal_sv] * alpha_cache[(class_idx + local_id_1) % FEATURE_BLOCK_SIZE][local_id_1 * INTERNAL_BLOCK_SIZE + internal_sv];
                     }
                 }
-                barrier(CLK_LOCAL_MEM_FENCE);
+                barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
             }
 
-            // add intermediate cached results to out_d
+            // add intermediate cached results to prediction_d
             for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const ulong global_pp_idx = pp_idx + internal;
+                const ulong global_pp_idx = pp_idx + (ulong) internal;
 
-                atomicAdd(&out_d[global_pp_idx * (num_classes + PADDING_SIZE) + dim + get_local_id(1)], out_cache[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)]);
-                atomicAdd(&out_d[global_pp_idx * (num_classes + PADDING_SIZE) + dim + get_local_id(1) + THREAD_BLOCK_SIZE], out_cache[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)], out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul], out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0]);
             }
-            barrier(CLK_LOCAL_MEM_FENCE);
+            barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items updated their part of the prediction
         }
     }
 }

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
@@ -24,51 +24,60 @@
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
  */
 __kernel void device_kernel_w_linear(__global real_type *w_d, const __global real_type *alpha_d, const __global real_type *sv_d, const ulong num_classes, const ulong num_sv, const ulong device_specific_num_sv, const ulong sv_offset) {
-    const ulong feature_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE;
-    const ulong feature_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE + get_local_id(0);
-    const ulong class_idx = get_global_id(1) * INTERNAL_BLOCK_SIZE;
-    const ulong class_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE + get_local_id(0);
+    // cast values to 32-bit unsigned int values to prevent implicit conversions
+    const uint local_id_0 = get_local_id(0);
+    const uint local_id_1 = get_local_id(1);
 
+    // calculate the indices used in the current thread
+    const ulong feature_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong feature_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong class_idx = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong class_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+
+    // create the local memory arrays used for caching data point features
     __local real_type data_cache_feature[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __local real_type data_cache_alpha[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 
-    for (ulong sv = 0; sv < device_specific_num_sv; sv += THREAD_BLOCK_SIZE) {
-        // load data into shared memory
+    // iterate over all support vectors using blocking to be able to cache them for faster memory accesses
+    for (ulong sv = 0; sv < device_specific_num_sv; sv += THREAD_BLOCK_SIZE_ul) {
+        // load data into local memory
         for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-            const ulong global_feature_idx = feature_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const ulong global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const ulong global_feature_idx = feature_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
+            const ulong global_class_idx = class_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-            data_cache_feature[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE) + sv + get_local_id(1)];  // SoA
-            data_cache_alpha[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE) + sv + sv_offset + get_local_id(1)];       // AoS
+            data_cache_feature[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE_ul) + sv + get_local_id(1)];  // SoA
+            data_cache_alpha[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE_ul) + sv + sv_offset + get_local_id(1)];       // AoS
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
+        barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (uint block_dim = 0; block_dim < THREAD_BLOCK_SIZE; ++block_dim) {
             for (uint internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
                 for (uint internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-                    temp[internal_feature][internal_class] += data_cache_alpha[block_dim][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_feature[block_dim][get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_feature];
+                    temp[internal_feature][internal_class] += data_cache_alpha[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_feature[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_feature];
                 }
             }
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
+        barrier(CLK_LOCAL_MEM_FENCE);  // wait until all threads performed their part of the calculations
     }
 
+    // update global array with local one
     for (uint internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
         for (uint internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-            const ulong global_feature_idx = feature_idx + internal_feature;
-            const ulong global_class_idx = class_idx + internal_class;
+            const ulong global_feature_idx = feature_idx + (ulong) internal_feature;
+            const ulong global_class_idx = class_idx + (ulong) internal_class;
 
-            w_d[global_feature_idx * (num_classes + PADDING_SIZE) + global_class_idx] = temp[internal_feature][internal_class];
+            w_d[global_feature_idx * (num_classes + PADDING_SIZE_ul) + global_class_idx] = temp[internal_feature][internal_class];
         }
     }
 }
 
 /**
  * @brief Predict the @p predict_points_d using the linear kernel speeding up the calculation using the @p w_d vector.
- * @param[out] out_d the predicted values
+ * @param[out] prediction_d the predicted values
  * @param[in] w_d the vector to speedup the calculations
  * @param[in] rho_d the previously learned bias
  * @param[in] predict_points_d the data points to predict
@@ -76,47 +85,57 @@ __kernel void device_kernel_w_linear(__global real_type *w_d, const __global rea
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
  */
-__kernel void device_kernel_predict_linear(__global real_type *out_d, const __global real_type *w_d, const __global real_type *rho_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_predict_points, const ulong num_features) {
-    const ulong pp_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE;
-    const ulong pp_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE + get_local_id(0);
-    const ulong class_idx = get_global_id(1) * INTERNAL_BLOCK_SIZE;
-    const ulong class_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE + get_local_id(0);
+__kernel void device_kernel_predict_linear(__global real_type *prediction_d, const __global real_type *w_d, const __global real_type *rho_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_predict_points, const ulong num_features) {
+    // cast values to 32-bit unsigned int values to prevent implicit conversions
+    const uint local_id_0 = get_local_id(0);
+    const uint local_id_1 = get_local_id(1);
 
+    // calculate the indices used in the current thread
+    const ulong pp_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong pp_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong class_idx = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong class_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+
+    // create the local memory arrays used for caching data point features
     __local real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __local real_type data_cache_w[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { 0.0 };
+    // create a thread private array used for internal caching
+    real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 
-    for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE) {
-        // load data into shared memory
+    // iterate over all features using blocking to be able to cache them for faster memory accesses
+    for (ulong dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ul) {
+        // load data into local memory
         for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
             const ulong global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
             const ulong global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
 
-            data_cache_pp[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = predict_points_d[(dim + get_local_id(1)) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_pp[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = predict_points_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_predict_points + PADDING_SIZE) + global_pp_idx];
-            data_cache_w[get_local_id(1)][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = w_d[(dim + get_local_id(1)) * (num_classes + PADDING_SIZE) + global_class_idx];
-            data_cache_w[get_local_id(1) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + get_local_id(0)] = w_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE) * (num_classes + PADDING_SIZE) + global_class_idx];
+            // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+            data_cache_pp[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1)) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_pp[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_w[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = w_d[(dim + get_local_id(1)) * (num_classes + PADDING_SIZE_ul) + global_class_idx];
+            data_cache_w[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = w_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_classes + PADDING_SIZE_ul) + global_class_idx];
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
+        barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
-        // calculation
+        // perform the dot product calculation
         for (uint block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
             for (uint internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                 for (uint internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-                    temp[internal_pd][internal_class] += data_cache_w[block_dim][get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_pp[block_dim][get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_pd];
+                    temp[internal_pd][internal_class] += data_cache_w[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_pp[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_pd];
                 }
             }
         }
-        barrier(CLK_LOCAL_MEM_FENCE);
+        barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items performed their part of the calculations
     }
 
+    // update global array with local one
     for (uint internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
         for (uint internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-            const ulong global_pp_idx = pp_idx + internal_pd;
-            const ulong global_class_idx = class_idx + internal_class;
+            const ulong global_pp_idx = pp_idx + (ulong) internal_pd;
+            const ulong global_class_idx = class_idx + (ulong) internal_class;
 
-            out_d[global_pp_idx * (num_classes + PADDING_SIZE) + global_class_idx] = temp[internal_pd][internal_class] - rho_d[global_class_idx];
+            prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + global_class_idx] = temp[internal_pd][internal_class] - rho_d[global_class_idx];
         }
     }
 }

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
@@ -17,6 +17,8 @@
 
 #include "sycl/sycl.hpp"  // sycl::nd_item
 
+#include <cstddef>  // std::size_t
+
 namespace plssvm::sycl::detail {
 
 /**
@@ -37,9 +39,9 @@ class device_kernel_symm {
      * @param[in] beta the scalar beta value
      * @param[in,out] C the matrix @p C, also used as result matrix
      */
-    device_kernel_symm(::sycl::handler &cgh, const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) :
-        A_cache_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        B_cache_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
+    device_kernel_symm(::sycl::handler &cgh, const std::size_t num_rows, const std::size_t num_rhs, const std::size_t device_specific_num_rows, const std::size_t row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) :
+        A_cache_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        B_cache_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         num_rows_{ num_rows },
         num_rhs_{ num_rhs },
         device_specific_num_rows_{ device_specific_num_rows },
@@ -55,56 +57,71 @@ class device_kernel_symm {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long j_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
-        for (unsigned long long dim = 0; dim < (num_rows_ - row_offset_); dim += FEATURE_BLOCK_SIZE) {
-            // load data into shared memory
+        // calculate the indices used in the current work-item
+        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
+        const auto j_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // create a work-item private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
+
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < (num_rows_ - row_offset_); dim += FEATURE_BLOCK_SIZE_uz) {
+            // load data into local memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_i = i_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_j = j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const auto global_i = i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                const auto global_j = j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                 // determine on which side of the diagonal we are located
                 if (dim + nd_idx.get_local_id(0) < global_j) {
-                    A_cache_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = A_[(dim + nd_idx.get_local_id(0)) * (num_rows_ - row_offset_ + PADDING_SIZE) + global_j - (dim + nd_idx.get_local_id(0)) * (dim + nd_idx.get_local_id(0) + 1) / 2];
+                    A_cache_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[(dim + nd_idx.get_local_id(0)) * (num_rows_ - row_offset_ + PADDING_SIZE_uz) + global_j - (dim + nd_idx.get_local_id(0)) * (dim + nd_idx.get_local_id(0) + std::size_t{ 1 }) / std::size_t{ 2 }];
                 } else {
-                    A_cache_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = A_[global_j * (num_rows_ - row_offset_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0) - global_j * (global_j + 1) / 2];
+                    A_cache_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[global_j * (num_rows_ - row_offset_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) - global_j * (global_j + std::size_t{ 1 }) / std::size_t{ 2 }];
                 }
                 // determine on which side of the diagonal we are located
                 if (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE < global_j) {
-                    A_cache_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = A_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rows_ - row_offset_ + PADDING_SIZE) + global_j - (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE + 1) / 2];
+                    A_cache_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ - row_offset_ + PADDING_SIZE_uz) + global_j - (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz + std::size_t{ 1 }) / std::size_t{ 2 }];
                 } else {
-                    A_cache_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = A_[global_j * (num_rows_ - row_offset_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE - global_j * (global_j + 1) / 2];
+                    A_cache_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[global_j * (num_rows_ - row_offset_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz - global_j * (global_j + std::size_t{ 1 }) / std::size_t{ 2 }];
                 }
 
-                B_cache_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = B_[(dim + row_offset_ + nd_idx.get_local_id(0)) * (num_rhs_ + PADDING_SIZE) + global_i];
-                B_cache_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = B_[(dim + row_offset_ + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rhs_ + PADDING_SIZE) + global_i];
+                B_cache_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = B_[(dim + row_offset_ + nd_idx.get_local_id(0)) * (num_rhs_ + PADDING_SIZE_uz) + global_i];
+                B_cache_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = B_[(dim + row_offset_ + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rhs_ + PADDING_SIZE_uz) + global_i];
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-            // calculation
+            // perform the dot product calculation
             for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                     for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                        temp[internal_i][internal_j] += A_cache_[block_dim][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_j] * B_cache_[block_dim][nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_i];
+                        temp[internal_i][internal_j] += A_cache_[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_j] * B_cache_[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_i];
                     }
                 }
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all work-items performed their part of the calculations
         }
 
+        // apply the (partial) BLAS operation and update C
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = i + internal_i;
-                const unsigned long long device_global_j = j + internal_j;
-                const unsigned long long global_j = row_offset_ + j + internal_j;
+                const auto global_i = i + static_cast<std::size_t>(internal_i);
+                const auto device_global_j = j + static_cast<std::size_t>(internal_j);
+                const auto global_j = row_offset_ + j + static_cast<std::size_t>(internal_j);
 
+                // be sure to not perform out of bounds accesses
                 if (global_i < num_rhs_ && device_global_j < device_specific_num_rows_) {
-                    C_[global_j * (num_rhs_ + PADDING_SIZE) + global_i] = alpha_ * temp[internal_i][internal_j] + beta_ * C_[global_j * (num_rhs_ + PADDING_SIZE) + global_i];
+                    C_[global_j * (num_rhs_ + PADDING_SIZE_uz) + global_i] = alpha_ * temp[internal_i][internal_j] + beta_ * C_[global_j * (num_rhs_ + PADDING_SIZE_uz) + global_i];
                 }
             }
         }
@@ -117,10 +134,10 @@ class device_kernel_symm {
     ::sycl::local_accessor<real_type, 2> B_cache_;
 
     /// @cond Doxygen_suppress
-    const unsigned long long num_rows_;
-    const unsigned long long num_rhs_;
-    const unsigned long long device_specific_num_rows_;
-    const unsigned long long row_offset_;
+    const std::size_t num_rows_;
+    const std::size_t num_rhs_;
+    const std::size_t device_specific_num_rows_;
+    const std::size_t row_offset_;
     const real_type alpha_;
     const real_type *A_;
     const real_type *B_;
@@ -149,9 +166,9 @@ class device_kernel_symm_mirror {
      * @param[in] beta the scalar beta value
      * @param[in,out] C the matrix @p C, also used as result matrix
      */
-    device_kernel_symm_mirror(::sycl::handler &cgh, const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) :
-        A_cache_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        B_cache_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
+    device_kernel_symm_mirror(::sycl::handler &cgh, const std::size_t num_rows, const std::size_t num_rhs, const std::size_t num_mirror_rows, const std::size_t device_specific_num_rows, const std::size_t row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) :
+        A_cache_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        B_cache_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         num_rows_{ num_rows },
         num_rhs_{ num_rhs },
         num_mirror_rows_{ num_mirror_rows },
@@ -168,47 +185,62 @@ class device_kernel_symm_mirror {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long j_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
-        for (unsigned long long dim = 0; dim < device_specific_num_rows_; dim += FEATURE_BLOCK_SIZE) {
+        // calculate the indices used in the current work-item
+        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
+        const auto j_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // create a work-item private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
+
+        // iterate over the remaining features using blocking to be able to cache them for faster memory accesses
+        for (std::size_t dim = 0; dim < device_specific_num_rows_; dim += FEATURE_BLOCK_SIZE_uz) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_i = i_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_j = j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const unsigned long long global_i = i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                const unsigned long long global_j = j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                // determine on which side of the diagonal we are located
-                A_cache_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = A_[(dim + nd_idx.get_local_id(0)) * (num_rows_ - row_offset_ + PADDING_SIZE) - (dim + nd_idx.get_local_id(0) - 1) * (dim + nd_idx.get_local_id(0)) / 2 + device_specific_num_rows_ - (dim + nd_idx.get_local_id(0)) + global_j];
-                A_cache_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = A_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rows_ - row_offset_ + PADDING_SIZE) - (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE - 1) * (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) / 2 + device_specific_num_rows_ - (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) + global_j];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
+                A_cache_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[(dim + nd_idx.get_local_id(0)) * (num_rows_ - row_offset_ + PADDING_SIZE_uz) - (dim + nd_idx.get_local_id(0) - std::size_t{ 1 }) * (dim + nd_idx.get_local_id(0)) / std::size_t{ 2 } + device_specific_num_rows_ - (dim + nd_idx.get_local_id(0)) + global_j];
+                A_cache_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ - row_offset_ + PADDING_SIZE_uz) - (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz - std::size_t{ 1 }) * (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) / std::size_t{ 2 } + device_specific_num_rows_ - (dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) + global_j];
 
-                B_cache_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = B_[(dim + row_offset_ + nd_idx.get_local_id(0)) * (num_rhs_ + PADDING_SIZE) + global_i];
-                B_cache_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = B_[(dim + row_offset_ + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rhs_ + PADDING_SIZE) + global_i];
+                B_cache_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = B_[(dim + row_offset_ + nd_idx.get_local_id(0)) * (num_rhs_ + PADDING_SIZE_uz) + global_i];
+                B_cache_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = B_[(dim + row_offset_ + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rhs_ + PADDING_SIZE_uz) + global_i];
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all threads loaded their part of the data
 
-            // calculation
+            // perform the feature reduction calculation
             for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                     for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                        temp[internal_i][internal_j] += A_cache_[block_dim][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_j] * B_cache_[block_dim][nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_i];
+                        temp[internal_i][internal_j] += A_cache_[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_j] * B_cache_[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_i];
                     }
                 }
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all threads performed their part of the calculations
         }
 
+        // apply the (remaining) BLAS operation and update C
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = i + internal_i;
-                const unsigned long long partial_global_j = j + internal_j;
-                const unsigned long long global_j = row_offset_ + device_specific_num_rows_ + j + internal_j;
+                const auto global_i = i + static_cast<std::size_t>(internal_i);
+                const auto partial_global_j = j + static_cast<std::size_t>(internal_j);
+                const auto global_j = row_offset_ + device_specific_num_rows_ + j + static_cast<std::size_t>(internal_j);
 
+                // be sure to not perform out of bounds accesses
                 if (global_i < num_rhs_ && partial_global_j < num_mirror_rows_) {
-                    C_[global_j * (num_rhs_ + PADDING_SIZE) + global_i] = alpha_ * temp[internal_i][internal_j] + beta_ * C_[global_j * (num_rhs_ + PADDING_SIZE) + global_i];
+                    C_[global_j * (num_rhs_ + PADDING_SIZE_uz) + global_i] = alpha_ * temp[internal_i][internal_j] + beta_ * C_[global_j * (num_rhs_ + PADDING_SIZE_uz) + global_i];
                 }
             }
         }
@@ -221,11 +253,11 @@ class device_kernel_symm_mirror {
     ::sycl::local_accessor<real_type, 2> B_cache_;
 
     /// @cond Doxygen_suppress
-    const unsigned long long num_rows_;
-    const unsigned long long num_rhs_;
-    const unsigned long long num_mirror_rows_;
-    const unsigned long long device_specific_num_rows_;
-    const unsigned long long row_offset_;
+    const std::size_t num_rows_;
+    const std::size_t num_rhs_;
+    const std::size_t num_mirror_rows_;
+    const std::size_t device_specific_num_rows_;
+    const std::size_t row_offset_;
     const real_type alpha_;
     const real_type *A_;
     const real_type *B_;
@@ -245,7 +277,7 @@ class device_kernel_inplace_matrix_add {
      * @param[in,out] lhs the first matrix (updated inplace)
      * @param[in] rhs the second matrix
      */
-    device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs) :
+    device_kernel_inplace_matrix_add(const std::size_t num_cols, real_type *lhs, const real_type *rhs) :
         num_cols_{ num_cols },
         lhs_{ lhs },
         rhs_{ rhs } { }
@@ -255,22 +287,27 @@ class device_kernel_inplace_matrix_add {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;  // # num_rows
-        const unsigned long long j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;  // # num_rhs
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
+
+        // calculate the indices used in the current work-item
+        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;  // # num_rows
+        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;  // # num_rhs
 
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = i + internal_i;
-                const unsigned long long global_j = j + internal_j;
+                const auto global_i = i + static_cast<std::size_t>(internal_i);
+                const auto global_j = j + static_cast<std::size_t>(internal_j);
 
-                lhs_[global_i * (num_cols_ + PADDING_SIZE) + global_j] += rhs_[global_i * (num_cols_ + PADDING_SIZE) + global_j];
+                lhs_[global_i * (num_cols_ + PADDING_SIZE_uz) + global_j] += rhs_[global_i * (num_cols_ + PADDING_SIZE_uz) + global_j];
             }
         }
     }
 
   private:
     /// @cond Doxygen_suppress
-    const unsigned long long num_cols_;
+    const std::size_t num_cols_;
     real_type *lhs_;
     const real_type *rhs_;
     /// @endcond
@@ -287,7 +324,7 @@ class device_kernel_inplace_matrix_scale {
      * @param[in,out] lhs the first matrix (updated inplace)
      * @param[in] scale the value to scale
      */
-    device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale) :
+    device_kernel_inplace_matrix_scale(const std::size_t num_cols, real_type *lhs, const real_type scale) :
         num_cols_{ num_cols },
         lhs_{ lhs },
         scale_{ scale } { }
@@ -297,22 +334,27 @@ class device_kernel_inplace_matrix_scale {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;  // # num_rows
-        const unsigned long long j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;  // # num_rhs
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
+
+        // calculate the indices used in the current work-item
+        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;  // # num_rows
+        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;  // # num_rhs
 
         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                const unsigned long long global_i = i + internal_i;
-                const unsigned long long global_j = j + internal_j;
+                const auto global_i = i + static_cast<std::size_t>(internal_i);
+                const auto global_j = j + static_cast<std::size_t>(internal_j);
 
-                lhs_[global_i * (num_cols_ + PADDING_SIZE) + global_j] *= scale_;
+                lhs_[global_i * (num_cols_ + PADDING_SIZE_uz) + global_j] *= scale_;
             }
         }
     }
 
   private:
     /// @cond Doxygen_suppress
-    const unsigned long long num_cols_;
+    const std::size_t num_cols_;
     real_type *lhs_;
     const real_type scale_;
     /// @endcond

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
@@ -58,8 +58,8 @@ class device_kernel_symm {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
@@ -186,8 +186,8 @@ class device_kernel_symm_mirror {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
@@ -208,8 +208,8 @@ class device_kernel_symm_mirror {
         for (std::size_t dim = 0; dim < device_specific_num_rows_; dim += FEATURE_BLOCK_SIZE_uz) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_i = i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
-                const unsigned long long global_j = j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                const auto global_i = i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                const auto global_j = j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
                 A_cache_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = A_[(dim + nd_idx.get_local_id(0)) * (num_rows_ - row_offset_ + PADDING_SIZE_uz) - (dim + nd_idx.get_local_id(0) - std::size_t{ 1 }) * (dim + nd_idx.get_local_id(0)) / std::size_t{ 2 } + device_specific_num_rows_ - (dim + nd_idx.get_local_id(0)) + global_j];

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
@@ -67,8 +67,8 @@ class device_kernel_assembly {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
@@ -20,6 +20,8 @@
 
 #include "sycl/sycl.hpp"  // sycl::nd_item
 
+#include <cstddef>  // std::size_t
+
 namespace plssvm::sycl::detail {
 
 /**
@@ -33,7 +35,7 @@ class device_kernel_assembly {
     /**
      * @brief Initialize the SYCL kernel function object.
      * @param[in] cgh the SYCL handler used to allocate the local memory
-     * @param[out] ret the calculated kernel matrix
+     * @param[out] kernel_matrix_d the calculated kernel matrix
      * @param[in] data_d the data points to calculate the kernel matrix from
      * @param[in] num_rows the number of data points
      * @param[in] device_num_rows the number of rows the current device is responsible for
@@ -44,10 +46,10 @@ class device_kernel_assembly {
      * @param[in] cost the cost factor the diagonal is scaled with
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
-    device_kernel_assembly(::sycl::handler &cgh, real_type *ret, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) :
-        data_cache_i_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        data_cache_j_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        ret_{ ret },
+    device_kernel_assembly(::sycl::handler &cgh, real_type *kernel_matrix_d, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) :
+        data_cache_i_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        data_cache_j_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        kernel_matrix_d_{ kernel_matrix_d },
         data_d_{ data_d },
         num_rows_{ num_rows },
         device_num_rows_{ device_num_rows },
@@ -64,53 +66,73 @@ class device_kernel_assembly {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long j_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
+
+        // calculate the indices used in the current work-item
+        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
+        const auto j_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // only calculate the upper triangular matrix -> can't use get_local_id() since all work-items in a work-group must progress further
         if (nd_idx.get_group(1) >= nd_idx.get_group(0)) {
-            real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+            // create a work-item private array used for internal caching
+            real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-            for (unsigned long long dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE) {
-                // load data into shared memory
+            // iterate over all features using blocking to be able to cache them for faster memory accesses
+            for (std::size_t dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE_uz) {
+                // load data into local memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_i = row_offset_ + i_linear + internal * THREAD_BLOCK_SIZE;
-                    const unsigned long long global_j = row_offset_ + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_i = row_offset_ + i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                    const auto global_j = row_offset_ + j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                    data_cache_i_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + 1 + PADDING_SIZE) + global_i];
-                    data_cache_i_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rows_ + 1 + PADDING_SIZE) + global_i];
-                    data_cache_j_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + 1 + PADDING_SIZE) + global_j];
-                    data_cache_j_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rows_ + 1 + PADDING_SIZE) + global_j];
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
+                    data_cache_i_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                    data_cache_i_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                    data_cache_j_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
+                    data_cache_j_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
                 }
-                nd_idx.barrier();
+                nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-                // calculation
+                // perform the feature reduction calculation
                 for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                     for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                         for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                            temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i_[block_dim][nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_i],
-                                                                                                    data_cache_j_[block_dim][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_j]);
+                            temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i_[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_i],
+                                                                                                    data_cache_j_[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_j]);
                         }
                     }
                 }
-                nd_idx.barrier();
+                nd_idx.barrier();  // wait until all work-items performed their part of the calculations
             }
 
+            // apply the remaining part of the kernel function and store the value in the output kernel matrix
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                    const unsigned long long device_global_i = i + internal_i;
-                    const unsigned long long global_i = row_offset_ + i + internal_i;
-                    const unsigned long long device_global_j = j + internal_j;
-                    const unsigned long long global_j = row_offset_ + j + internal_j;
+                    // calculate the indices to access the kernel matrix (the part stored on the current device)
+                    const auto device_global_i = i + static_cast<std::size_t>(internal_i);
+                    const auto global_i = row_offset_ + i + static_cast<std::size_t>(internal_i);
+                    const auto device_global_j = j + static_cast<std::size_t>(internal_j);
+                    const auto global_j = row_offset_ + j + static_cast<std::size_t>(internal_j);
 
+                    // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                     if (device_global_i < (num_rows_ - row_offset_) && device_global_j < device_num_rows_ && global_i >= global_j) {
                         real_type temp_ij = temp[internal_i][internal_j];
                         temp_ij = detail::apply_kernel_function<kernel_function>(temp_ij, kernel_function_parameter_) + QA_cost_ - q_[global_i] - q_[global_j];
+                        // apply the cost on the diagonal
                         if (global_i == global_j) {
                             temp_ij += cost_;
                         }
-                        ret_[device_global_j * (num_rows_ - row_offset_ + PADDING_SIZE) - device_global_j * (device_global_j + 1) / 2 + device_global_i] = temp_ij;
+                        // update the kernel matrix
+                        kernel_matrix_d_[device_global_j * (num_rows_ - row_offset_ + PADDING_SIZE_uz) - device_global_j * (device_global_j + std::size_t{ 1 }) / std::size_t{ 2 } + device_global_i] = temp_ij;
                     }
                 }
             }
@@ -124,12 +146,12 @@ class device_kernel_assembly {
     ::sycl::local_accessor<real_type, 2> data_cache_j_;
 
     /// @cond Doxygen_suppress
-    real_type *ret_;
+    real_type *kernel_matrix_d_;
     const real_type *data_d_;
-    const unsigned long long num_rows_;
-    const unsigned long long device_num_rows_;
-    const unsigned long long row_offset_;
-    const unsigned long long num_features_;
+    const std::size_t num_rows_;
+    const std::size_t device_num_rows_;
+    const std::size_t row_offset_;
+    const std::size_t num_features_;
     const real_type *q_;
     const real_type QA_cost_;
     const real_type cost_;

--- a/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
@@ -21,6 +21,8 @@
 
 #include "sycl/sycl.hpp"  // sycl::nd_item
 
+#include <cstddef>  // std::size_t
+
 namespace plssvm::sycl::detail {
 
 /**
@@ -48,9 +50,9 @@ class device_kernel_assembly_symm {
      * @param[in] num_classes the number of classes in the data set
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
-    device_kernel_assembly_symm(::sycl::handler &cgh, const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, Args... kernel_function_parameter) :
-        data_cache_i_{ ::sycl::range<1>{ FEATURE_BLOCK_SIZE * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
-        data_cache_j_{ ::sycl::range<1>{ FEATURE_BLOCK_SIZE * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
+    device_kernel_assembly_symm(::sycl::handler &cgh, const real_type alpha, const real_type *q, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const std::size_t num_classes, Args... kernel_function_parameter) :
+        data_cache_i_{ ::sycl::range<1>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE) * static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
+        data_cache_j_{ ::sycl::range<1>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE) * static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
         alpha_{ alpha },
         q_{ q },
         data_d_{ data_d },
@@ -70,147 +72,169 @@ class device_kernel_assembly_symm {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long j_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
+
+        // calculate the indices used in the current work-item
+        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
+        const auto j_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // only calculate the upper triangular matrix -> can't use get_local_id() since all work-items in a work-group must progress further
         if (nd_idx.get_group(1) >= nd_idx.get_group(0)) {
-            real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+            // create a work-item private array used for internal caching
+            real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
             {
-                for (unsigned long long dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE) {
-                    // load data into shared memory
+                // iterate over all features using blocking to be able to cache them for faster memory accesses
+                for (std::size_t dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE_uz) {
+                    // load data into local memory
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                        const unsigned long long global_i = row_offset_ + i_linear + internal * THREAD_BLOCK_SIZE;
-                        const unsigned long long global_j = row_offset_ + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                        const auto global_i = row_offset_ + i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                        const auto global_j = row_offset_ + j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                        data_cache_i_[nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + 1 + PADDING_SIZE) + global_i];
-                        data_cache_i_[(nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rows_ + 1 + PADDING_SIZE) + global_i];
-                        data_cache_j_[nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + 1 + PADDING_SIZE) + global_j];
-                        data_cache_j_[(nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_rows_ + 1 + PADDING_SIZE) + global_j];
+                        // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
+                        data_cache_i_[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                        data_cache_i_[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                        data_cache_j_[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
+                        data_cache_j_[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-                    // calculation
+                    // perform the feature reduction calculation
                     for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                                temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i_[block_dim * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_i],
-                                                                                                        data_cache_j_[block_dim * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_j]);
+                                temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i_[block_dim * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + local_id_1 * INTERNAL_BLOCK_SIZE + internal_i],
+                                                                                                        data_cache_j_[block_dim * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + local_id_0 * INTERNAL_BLOCK_SIZE + internal_j]);
                             }
                         }
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wait until all work-items performed their part of the calculations
                 }
             }
 
-            // update temp using the rbf kernel function taking the dimensional reduction into account and apply the cost to the diagonal
+            // apply the remaining part of the kernel function and store the value in the output kernel matrix
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                    const unsigned long long global_i = row_offset_ + i + internal_i;
-                    const unsigned long long device_global_i = i + internal_i;
-                    const unsigned long long global_j = row_offset_ + j + internal_j;
-                    const unsigned long long device_global_j = j + internal_j;
+                    const auto global_i = row_offset_ + i + static_cast<std::size_t>(internal_i);
+                    const auto device_global_i = i + static_cast<std::size_t>(internal_i);
+                    const auto global_j = row_offset_ + j + static_cast<std::size_t>(internal_j);
+                    const auto device_global_j = j + static_cast<std::size_t>(internal_j);
 
+                    // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
                     if (device_global_i < (num_rows_ - row_offset_) && device_global_j < device_num_rows_ && global_i >= global_j) {
                         temp[internal_i][internal_j] = detail::apply_kernel_function<kernel_function>(temp[internal_i][internal_j], kernel_function_parameter_) + QA_cost_ - q_[global_i] - q_[global_j];
+                        // apply the cost on the diagonal
                         if (global_i == global_j) {
                             temp[internal_i][internal_j] += cost_;
                         }
                     } else {
-                        temp[internal_i][internal_j] = 0.0;
+                        // be sure to set the value to zero otherwise
+                        temp[internal_i][internal_j] = real_type{ 0.0 };
                     }
                 }
             }
 
             // calculate C += alpha * temp * B for the UPPER triangular matrix
             {
+                // rename cached arrays
                 auto &B_cache = data_cache_i_;      // [INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE][FEATURE_BLOCK_SIZE]
                 auto &C_out_cache = data_cache_j_;  // [INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE][FEATURE_BLOCK_SIZE]
 
-                for (unsigned long long dim = 0; dim < num_classes_; dim += FEATURE_BLOCK_SIZE) {
-                    // load data into shared memory
+                // iterate over all classes using blocking to be able to cache them for faster memory accesses
+                for (std::size_t dim = 0; dim < num_classes_; dim += FEATURE_BLOCK_SIZE_uz) {
+                    // load data into local memory
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                        const unsigned long long global_i = row_offset_ + i_linear + internal * THREAD_BLOCK_SIZE;
+                        const std::size_t global_i = row_offset_ + i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                        B_cache[(internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)) * FEATURE_BLOCK_SIZE + nd_idx.get_local_id(0)] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0)];
-                        B_cache[(internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)) * FEATURE_BLOCK_SIZE + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE];
-
-                        C_out_cache[(internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)) * FEATURE_BLOCK_SIZE + nd_idx.get_local_id(0)] = 0.0;
-                        C_out_cache[(internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)) * FEATURE_BLOCK_SIZE + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE] = 0.0;
+                        // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
+                        B_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)];
+                        B_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0 + THREAD_BLOCK_SIZE] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz];
+                        C_out_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0] = real_type{ 0.0 };
+                        C_out_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0 + THREAD_BLOCK_SIZE] = real_type{ 0.0 };
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
                     // calculate intermediate results and store them in shared memory
                     for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
                         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                                C_out_cache[(nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_j) * FEATURE_BLOCK_SIZE + (class_idx + nd_idx.get_local_id(1)) % FEATURE_BLOCK_SIZE] +=
-                                    temp[internal_i][internal_j] * B_cache[(nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_i) * FEATURE_BLOCK_SIZE + (class_idx + nd_idx.get_local_id(1)) % FEATURE_BLOCK_SIZE];
+                                C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal_j) * FEATURE_BLOCK_SIZE + (class_idx + local_id_1) % FEATURE_BLOCK_SIZE] +=
+                                    temp[internal_i][internal_j] * B_cache[(local_id_1 * INTERNAL_BLOCK_SIZE + internal_i) * FEATURE_BLOCK_SIZE + (class_idx + local_id_1) % FEATURE_BLOCK_SIZE];
                             }
                         }
-                        nd_idx.barrier();
+                        nd_idx.barrier();  // wait until all work-items performed their part of the calculations
                     }
 
                     // add intermediate cached results to C
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                        const unsigned long long global_j = row_offset_ + j + internal;
-                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(1)] } += C_out_cache[(nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + nd_idx.get_local_id(1)];
-                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(1) + THREAD_BLOCK_SIZE] } += C_out_cache[(nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + nd_idx.get_local_id(1) + THREAD_BLOCK_SIZE];
+                        const auto global_j = row_offset_ + j + static_cast<std::size_t>(internal);
+                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(1)] } += C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + local_id_1];
+                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(1) + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + local_id_1 + THREAD_BLOCK_SIZE];
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wai until all work-items updated C with their values
                 }
             }
 
             // set potential diagonal entries in temp to 0.0 such that we don't apply the main diagonal twice to C
             for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                 for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                    const unsigned long long global_i = row_offset_ + i + internal_i;
-                    const unsigned long long global_j = row_offset_ + j + internal_j;
+                    const auto global_i = row_offset_ + i + static_cast<std::size_t>(internal_i);
+                    const auto global_j = row_offset_ + j + static_cast<std::size_t>(internal_j);
 
                     if (global_i == global_j) {
-                        temp[internal_i][internal_j] = 0.0;
+                        temp[internal_i][internal_j] = real_type{ 0.0 };
                     }
                 }
             }
 
             // calculate C += alpha * temp * B for the LOWER triangular matrix
             {
+                // rename cached arrays
                 auto &B_cache = data_cache_i_;      // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
                 auto &C_out_cache = data_cache_j_;  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
 
-                for (unsigned long long dim = 0; dim < num_classes_; dim += FEATURE_BLOCK_SIZE) {
-                    // load data into shared memory
+                // iterate over all classes using blocking to be able to cache them for faster memory accesses
+                for (std::size_t dim = 0; dim < num_classes_; dim += FEATURE_BLOCK_SIZE_uz) {
+                    // load data into local memory
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                        const unsigned long long global_j = row_offset_ + j_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                        const auto global_j = row_offset_ + j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                        B_cache[nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0)];
-                        B_cache[(nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE];
-
-                        C_out_cache[nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = 0.0;
-                        C_out_cache[(nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = 0.0;
+                        // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                        B_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)];
+                        B_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz];
+                        C_out_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
+                        C_out_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
                     // calculate intermediate results and store them in shared memory
                     for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
                         for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
                             for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                                C_out_cache[((class_idx + nd_idx.get_local_id(0)) % FEATURE_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal_i * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] +=
-                                    temp[internal_i][internal_j] * B_cache[((class_idx + nd_idx.get_local_id(0)) % FEATURE_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_j];
+                                C_out_cache[((class_idx + local_id_0) % FEATURE_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal_i * THREAD_BLOCK_SIZE + local_id_1] +=
+                                    temp[internal_i][internal_j] * B_cache[((class_idx + local_id_0) % FEATURE_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + local_id_0 * INTERNAL_BLOCK_SIZE + internal_j];
                             }
                         }
-                        nd_idx.barrier();
+                        nd_idx.barrier();  // wait until all work-items performed their part of the calculations
                     }
 
                     // add intermediate cached results to C
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                        const unsigned long long global_i = row_offset_ + i + internal;
-                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0)] } += C_out_cache[nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)];
-                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE] } += C_out_cache[(nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)];
+                        const auto global_i = row_offset_ + i + static_cast<std::size_t>(internal);
+                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)] } += C_out_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
+                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wai until all threads updated C with their values
                 }
             }
         }
@@ -226,15 +250,15 @@ class device_kernel_assembly_symm {
     const real_type alpha_;
     const real_type *q_;
     const real_type *data_d_;
-    const unsigned long long num_rows_;
-    const unsigned long long device_num_rows_;
-    const unsigned long long row_offset_;
-    const unsigned long long num_features_;
+    const std::size_t num_rows_;
+    const std::size_t device_num_rows_;
+    const std::size_t row_offset_;
+    const std::size_t num_features_;
     const real_type QA_cost_;
     const real_type cost_;
     const real_type *B_;
     real_type *C_;
-    const unsigned long long num_classes_;
+    const std::size_t num_classes_;
     const detail::standard_layout_tuple<Args...> kernel_function_parameter_;
     /// @endcond
 };

--- a/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
@@ -234,7 +234,7 @@ class device_kernel_assembly_symm {
                         detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)] } += C_out_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
                         detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
                     }
-                    nd_idx.barrier();  // wai until all threads updated C with their values
+                    nd_idx.barrier();  // wait until all threads updated C with their values
                 }
             }
         }

--- a/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
@@ -73,8 +73,8 @@ class device_kernel_assembly_symm {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);

--- a/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
+++ b/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
@@ -21,6 +21,8 @@
 
 #include "sycl/sycl.hpp"  // sycl::item
 
+#include <cstddef>  // std::size_t
+
 namespace plssvm::sycl::detail {
 
 /**
@@ -39,9 +41,9 @@ class device_kernel_w_linear {
      * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
      * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
      */
-    device_kernel_w_linear(::sycl::handler &cgh, real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset) :
-        data_cache_feature_{ ::sycl::range<2>{ THREAD_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        data_cache_alpha_{ ::sycl::range<2>{ THREAD_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
+    device_kernel_w_linear(::sycl::handler &cgh, real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t device_specific_num_sv, const std::size_t sv_offset) :
+        data_cache_feature_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        data_cache_alpha_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         w_d_{ w_d },
         alpha_d_{ alpha_d },
         sv_d_{ sv_d },
@@ -55,41 +57,54 @@ class device_kernel_w_linear {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long feature_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long feature_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long class_idx = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long class_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
-        for (unsigned long long sv = 0; sv < device_specific_num_sv_; sv += THREAD_BLOCK_SIZE) {
-            // load data into shared memory
+        // calculate the indices used in the current work-item
+        const auto feature_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto feature_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto class_idx = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
+        const auto class_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // create a work-item private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
+
+        // iterate over all support vectors using blocking to be able to cache them for faster memory accesses
+        for (std::size_t sv = 0; sv < device_specific_num_sv_; sv += THREAD_BLOCK_SIZE) {
+            // load data into local memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_feature_idx = feature_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const auto global_class_idx = class_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                const auto global_feature_idx = feature_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                data_cache_feature_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = sv_d_[global_feature_idx * (device_specific_num_sv_ + PADDING_SIZE) + sv + sv_offset_ + nd_idx.get_local_id(0)];  // SoA
-                data_cache_alpha_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = alpha_d_[global_class_idx * (num_sv_ + PADDING_SIZE) + sv + nd_idx.get_local_id(0)];                                // AoS
+                data_cache_feature_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[global_feature_idx * (device_specific_num_sv_ + PADDING_SIZE_uz) + sv + sv_offset_ + nd_idx.get_local_id(0)];  // SoA
+                data_cache_alpha_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[global_class_idx * (num_sv_ + PADDING_SIZE_uz) + sv + nd_idx.get_local_id(0)];                                // AoS
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-            // calculation
+            // perform the dot product calculation
             for (unsigned block_dim = 0; block_dim < THREAD_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
                     for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-                        temp[internal_feature][internal_class] += data_cache_alpha_[block_dim][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_feature_[block_dim][nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_feature];
+                        temp[internal_feature][internal_class] += data_cache_alpha_[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_feature_[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_feature];
                     }
                 }
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all work-items performed their part of the calculations
         }
 
+        // update global array with local one
         for (unsigned internal_feature = 0; internal_feature < INTERNAL_BLOCK_SIZE; ++internal_feature) {
             for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-                const unsigned long long global_class_idx = class_idx + internal_class;
-                const unsigned long long global_feature_idx = feature_idx + internal_feature;
+                const auto global_class_idx = class_idx + static_cast<std::size_t>(internal_class);
+                const auto global_feature_idx = feature_idx + static_cast<std::size_t>(internal_feature);
 
-                w_d_[global_feature_idx * (num_classes_ + PADDING_SIZE) + global_class_idx] = temp[internal_feature][internal_class];
+                w_d_[global_feature_idx * (num_classes_ + PADDING_SIZE_uz) + global_class_idx] = temp[internal_feature][internal_class];
             }
         }
     }
@@ -104,10 +119,10 @@ class device_kernel_w_linear {
     real_type *w_d_;
     const real_type *alpha_d_;
     const real_type *sv_d_;
-    const unsigned long long num_classes_;
-    const unsigned long long num_sv_;
-    const unsigned long long device_specific_num_sv_;
-    const unsigned long long sv_offset_;
+    const std::size_t num_classes_;
+    const std::size_t num_sv_;
+    const std::size_t device_specific_num_sv_;
+    const std::size_t sv_offset_;
     /// @endcond
 };
 
@@ -119,7 +134,7 @@ class device_kernel_predict_linear {
     /**
      * @brief Initialize the SYCL kernel function object.
      * @param[in] cgh the SYCL handler used to allocate the local memory
-     * @param[out] out_d the predicted values
+     * @param[out] prediction_d the predicted values
      * @param[in] w_d the vector to speedup the calculations
      * @param[in] rho_d the previously learned bias
      * @param[in] predict_points_d the data points to predict
@@ -127,10 +142,10 @@ class device_kernel_predict_linear {
      * @param[in] num_predict_points the number of data points to predict
      * @param[in] num_features the number of features per data point
      */
-    device_kernel_predict_linear(::sycl::handler &cgh, real_type *out_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) :
-        data_cache_pp_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        data_cache_w_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        out_d_{ out_d },
+    device_kernel_predict_linear(::sycl::handler &cgh, real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_predict_points, const std::size_t num_features) :
+        data_cache_pp_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        data_cache_w_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        prediction_d_{ prediction_d },
         w_d_{ w_d },
         rho_d_{ rho_d },
         predict_points_d_{ predict_points_d },
@@ -143,43 +158,58 @@ class device_kernel_predict_linear {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long pp_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long pp_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long class_idx = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long class_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
-        for (unsigned long long dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE) {
+        // calculate the indices used in the current work-item
+        const auto pp_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto pp_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto class_idx = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
+        const auto class_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // create a work-item private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
+
+        // iterate over all support vectors using blocking to be able to cache them for faster memory accesses
+        for (std::size_t dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE_uz) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-                const unsigned long long global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const auto global_pp_idx = pp_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                const auto global_class_idx = class_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                data_cache_pp_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = predict_points_d_[(dim + nd_idx.get_local_id(0)) * (num_predict_points_ + PADDING_SIZE) + global_pp_idx];
-                data_cache_pp_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = predict_points_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_predict_points_ + PADDING_SIZE) + global_pp_idx];
-                data_cache_w_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = w_d_[(dim + nd_idx.get_local_id(0)) * (num_classes_ + PADDING_SIZE) + global_class_idx];
-                data_cache_w_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = w_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_classes_ + PADDING_SIZE) + global_class_idx];
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
+                data_cache_pp_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0)) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                data_cache_pp_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                data_cache_w_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = w_d_[(dim + nd_idx.get_local_id(0)) * (num_classes_ + PADDING_SIZE_uz) + global_class_idx];
+                data_cache_w_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = w_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_classes_ + PADDING_SIZE_uz) + global_class_idx];
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-            // calculation
+            // perform the dot product calculation
             for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                 for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                     for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-                        temp[internal_pd][internal_class] += data_cache_w_[block_dim][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_pp_[block_dim][nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_pd];
+                        temp[internal_pd][internal_class] += data_cache_w_[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_class] * data_cache_pp_[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_pd];
                     }
                 }
             }
-            nd_idx.barrier();
+            nd_idx.barrier();  // wait until all work-items performed their part of the calculations
         }
 
+        // update global array with local one
         for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
             for (unsigned internal_class = 0; internal_class < INTERNAL_BLOCK_SIZE; ++internal_class) {
-                const unsigned long long global_class_idx = class_idx + internal_class;
-                const unsigned long long global_pp_idx = pp_idx + internal_pd;
+                const auto global_class_idx = class_idx + static_cast<std::size_t>(internal_class);
+                const auto global_pp_idx = pp_idx + static_cast<std::size_t>(internal_pd);
 
-                out_d_[global_pp_idx * (num_classes_ + PADDING_SIZE) + global_class_idx] = temp[internal_pd][internal_class] - rho_d_[global_class_idx];
+                prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + global_class_idx] = temp[internal_pd][internal_class] - rho_d_[global_class_idx];
             }
         }
     }
@@ -191,13 +221,13 @@ class device_kernel_predict_linear {
     ::sycl::local_accessor<real_type, 2> data_cache_w_;
 
     /// @cond Doxygen_suppress
-    real_type *out_d_;
+    real_type *prediction_d_;
     const real_type *w_d_;
     const real_type *rho_d_;
     const real_type *predict_points_d_;
-    const unsigned long long num_classes_;
-    const unsigned long long num_predict_points_;
-    const unsigned long long num_features_;
+    const std::size_t num_classes_;
+    const std::size_t num_predict_points_;
+    const std::size_t num_features_;
     /// @endcond
 };
 
@@ -212,7 +242,7 @@ class device_kernel_predict {
     /**
      * @brief Initialize the SYCL kernel function object.
      * @param[in] cgh the SYCL handler used to allocate the local memory
-     * @param[in] out_d the predicted values
+     * @param[in] prediction_d the predicted values
      * @param[in] alpha_d the previously learned weights
      * @param[in] rho_d the previously learned biases
      * @param[in] sv_d the support vectors
@@ -223,10 +253,10 @@ class device_kernel_predict {
      * @param[in] num_features the number of features per data point
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
-    device_kernel_predict(::sycl::handler &cgh, real_type *out_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) :
-        data_cache_pp_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        data_cache_sv_{ ::sycl::range<2>{ FEATURE_BLOCK_SIZE, INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE }, cgh },
-        out_d_{ out_d },
+    device_kernel_predict(::sycl::handler &cgh, real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t num_predict_points, const std::size_t num_features, Args... kernel_function_parameter) :
+        data_cache_pp_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        data_cache_sv_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
+        prediction_d_{ prediction_d },
         alpha_d_{ alpha_d },
         rho_d_{ rho_d },
         sv_d_{ sv_d },
@@ -242,36 +272,50 @@ class device_kernel_predict {
      * @param[in] nd_idx indices representing the current point in the execution space
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
-        const unsigned long long pp_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE;
-        const unsigned long long pp_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
-        const unsigned long long sv_cached_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE + nd_idx.get_local_id(1);
+        // cast values to 32-bit unsigned int values to prevent implicit conversions
+        const unsigned local_id_0 = nd_idx.get_local_id(0);
+        const unsigned local_id_1 = nd_idx.get_local_id(1);
 
-        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { { 0.0 } };
+        // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
+        const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
+        const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
+        const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
+
+        // calculate the indices used in the current work-item
+        const auto pp_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
+        const auto pp_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto sv_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+
+        // create a work-item private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
         {
-            for (unsigned long long dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE) {
-                // load data into shared memory
+            // iterate over all features using blocking to be able to cache them for faster memory accesses
+            for (std::size_t dim = 0; dim < num_features_; dim += FEATURE_BLOCK_SIZE_uz) {
+                // load data into local memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-                    const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const auto global_pp_idx = pp_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
+                    const auto global_sv_idx = sv_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                    data_cache_pp_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = predict_points_d_[(dim + nd_idx.get_local_id(0)) * (num_predict_points_ + PADDING_SIZE) + global_pp_idx];
-                    data_cache_pp_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = predict_points_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_predict_points_ + PADDING_SIZE) + global_pp_idx];
-                    data_cache_sv_[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = sv_d_[(dim + nd_idx.get_local_id(0)) * (num_sv_ + PADDING_SIZE) + global_sv_idx];
-                    data_cache_sv_[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = sv_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_sv_ + PADDING_SIZE) + global_sv_idx];
+                    // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                    data_cache_pp_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0)) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                    data_cache_pp_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                    data_cache_sv_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[(dim + nd_idx.get_local_id(0)) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
+                    data_cache_sv_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
                 }
-                nd_idx.barrier();
+                nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-                // calculation
+                // perform the feature reduction calculation
                 for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
                     for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                         for (unsigned internal_sv = 0; internal_sv < INTERNAL_BLOCK_SIZE; ++internal_sv) {
-                            temp[internal_pd][internal_sv] += detail::feature_reduce<kernel_function>(data_cache_sv_[block_dim][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_sv],
-                                                                                                      data_cache_pp_[block_dim][nd_idx.get_local_id(1) * INTERNAL_BLOCK_SIZE + internal_pd]);
+                            temp[internal_pd][internal_sv] += detail::feature_reduce<kernel_function>(data_cache_sv_[block_dim][local_id_0 * INTERNAL_BLOCK_SIZE + internal_sv],
+                                                                                                      data_cache_pp_[block_dim][local_id_1 * INTERNAL_BLOCK_SIZE + internal_pd]);
                         }
                     }
                 }
-                nd_idx.barrier();
+                nd_idx.barrier();  // wait until all work-items performed their part of the calculations
             }
         }
 
@@ -283,47 +327,49 @@ class device_kernel_predict {
         }
 
         {
+            // rename cached arrays
             auto &alpha_cache = data_cache_pp_;
             auto &out_cache = data_cache_sv_;
 
-            for (unsigned long long dim = 0; dim < num_classes_; dim += FEATURE_BLOCK_SIZE) {
-                // load data into shared memory
+            // iterate over all features using blocking to be able to cache them for faster memory accesses
+            for (std::size_t dim = 0; dim < num_classes_; dim += FEATURE_BLOCK_SIZE_uz) {
+                // load data into local memory
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                    const std::size_t global_sv_idx = sv_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                    alpha_cache[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = alpha_d_[(dim + nd_idx.get_local_id(0)) * (num_sv_ + PADDING_SIZE) + global_sv_idx];
-                    alpha_cache[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = alpha_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_sv_ + PADDING_SIZE) + global_sv_idx];
+                    alpha_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + nd_idx.get_local_id(0)) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
+                    alpha_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
 
                     // the bias (rho) must only be applied once for all support vectors
-                    if (nd_idx.get_group(0) == 0) {
-                        out_cache[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = -rho_d_[dim + nd_idx.get_local_id(0)];
-                        out_cache[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = -rho_d_[dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE];
+                    if (nd_idx.get_group(0) == std::size_t{ 0 }) {
+                        out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + nd_idx.get_local_id(0)];
+                        out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz];
                     } else {
-                        out_cache[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = 0.0;
-                        out_cache[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] = 0.0;
+                        out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
+                        out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
                     }
                 }
-                nd_idx.barrier();
+                nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
-                // calculate intermediate results and store them in shared memory
+                // calculate intermediate results and store them in local memory
                 for (unsigned class_idx = 0; class_idx < FEATURE_BLOCK_SIZE; ++class_idx) {
                     for (unsigned internal_pd = 0; internal_pd < INTERNAL_BLOCK_SIZE; ++internal_pd) {
                         for (unsigned internal_sv = 0; internal_sv < INTERNAL_BLOCK_SIZE; ++internal_sv) {
-                            out_cache[(class_idx + nd_idx.get_local_id(0)) % FEATURE_BLOCK_SIZE][internal_pd * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)] +=
-                                temp[internal_pd][internal_sv] * alpha_cache[(class_idx + nd_idx.get_local_id(0)) % FEATURE_BLOCK_SIZE][nd_idx.get_local_id(0) * INTERNAL_BLOCK_SIZE + internal_sv];
+                            out_cache[(class_idx + local_id_0) % FEATURE_BLOCK_SIZE][internal_pd * THREAD_BLOCK_SIZE + local_id_1] +=
+                                temp[internal_pd][internal_sv] * alpha_cache[(class_idx + local_id_0) % FEATURE_BLOCK_SIZE][local_id_0 * INTERNAL_BLOCK_SIZE + internal_sv];
                         }
                     }
-                    nd_idx.barrier();
+                    nd_idx.barrier();  // wait until all work-items performed their part of the calculations
                 }
 
-                // add intermediate cached results to out_d
+                // add intermediate cached results to prediction_d
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                    const unsigned long long global_pp_idx = pp_idx + internal;
+                    const auto global_pp_idx = pp_idx + static_cast<std::size_t>(internal);
 
-                    detail::atomic_op<real_type>{ out_d_[global_pp_idx * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0)] } += out_cache[nd_idx.get_local_id(0)][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)];
-                    detail::atomic_op<real_type>{ out_d_[global_pp_idx * (num_classes_ + PADDING_SIZE) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE] } += out_cache[nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + nd_idx.get_local_id(1)];
+                    detail::atomic_op<real_type>{ prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)] } += out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1];
+                    detail::atomic_op<real_type>{ prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz] } += out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1];
                 }
-                nd_idx.barrier();
+                nd_idx.barrier();  // wait until all work-items updated their part of the prediction
             }
         }
     }
@@ -335,15 +381,15 @@ class device_kernel_predict {
     ::sycl::local_accessor<real_type, 2> data_cache_sv_;
 
     /// @cond Doxygen_suppress
-    real_type *out_d_;
+    real_type *prediction_d_;
     const real_type *alpha_d_;
     const real_type *rho_d_;
     const real_type *sv_d_;
     const real_type *predict_points_d_;
-    const unsigned long long num_classes_;
-    const unsigned long long num_sv_;
-    const unsigned long long num_predict_points_;
-    const unsigned long long num_features_;
+    const std::size_t num_classes_;
+    const std::size_t num_sv_;
+    const std::size_t num_predict_points_;
+    const std::size_t num_features_;
     const detail::standard_layout_tuple<Args...> kernel_function_parameter_;
     /// @endcond
 };

--- a/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
+++ b/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
@@ -58,8 +58,8 @@ class device_kernel_w_linear {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
@@ -159,8 +159,8 @@ class device_kernel_predict_linear {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
@@ -273,8 +273,8 @@ class device_kernel_predict {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast values to 32-bit unsigned int values to prevent implicit conversions
-        const unsigned local_id_0 = nd_idx.get_local_id(0);
-        const unsigned local_id_1 = nd_idx.get_local_id(1);
+        const auto local_id_0 = static_cast<unsigned>(nd_idx.get_local_id(0));
+        const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);

--- a/include/plssvm/csvm.hpp
+++ b/include/plssvm/csvm.hpp
@@ -393,7 +393,7 @@ model<label_type> csvm::fit(const data_set<label_type> &data, Args &&...named_ar
     parameter params{ params_ };
     if (params.gamma.is_default()) {
         // no gamma provided -> use default value which depends on the number of features in the data set
-        params.gamma = real_type{ 1.0 } / data.num_features();
+        params.gamma = real_type{ 1.0 } / static_cast<real_type>(data.num_features());
     }
 
     // create model
@@ -658,11 +658,11 @@ std::vector<label_type> csvm::predict(const model<label_type> &model, const data
 #pragma omp parallel for default(none) shared(predicted_labels, class_votes, model) if (!std::is_same_v<label_type, bool>)
         for (typename std::vector<label_type>::size_type i = 0; i < predicted_labels.size(); ++i) {
             std::size_t argmax = 0;
-            real_type max = std::numeric_limits<real_type>::lowest();
+            std::size_t max = 0;
             for (std::size_t v = 0; v < class_votes.num_cols(); ++v) {
                 if (max < class_votes(i, v)) {
                     argmax = v;
-                    max = static_cast<real_type>(class_votes(i, v));
+                    max = class_votes(i, v);
                 }
             }
             predicted_labels[i] = model.data_.mapping_->get_label_by_mapped_index(argmax);

--- a/include/plssvm/detail/io/libsvm_model_parsing.hpp
+++ b/include/plssvm/detail/io/libsvm_model_parsing.hpp
@@ -111,7 +111,7 @@ namespace plssvm::detail::io {
 
     const auto i_it = std::lower_bound(index_sets[i].cbegin(), index_sets[i].cend(), idx_to_find);
     const auto j_it = std::lower_bound(index_sets[j].cbegin(), index_sets[j].cend(), idx_to_find);
-    const std::size_t global_idx = std::distance(index_sets[i].cbegin(), i_it) + std::distance(index_sets[j].cbegin(), j_it);
+    const auto global_idx = static_cast<std::size_t>(std::distance(index_sets[i].cbegin(), i_it) + std::distance(index_sets[j].cbegin(), j_it));
 
     PLSSVM_ASSERT(global_idx < index_sets[i].size() + index_sets[j].size(), "The global index ({}) for the provided index to find ({}) must be smaller than the combined size of both index sets ({} + {})!", global_idx, idx_to_find, index_sets[i].size(), index_sets[j].size());
 
@@ -749,7 +749,7 @@ inline void write_libsvm_model_data(const std::string &filename, const plssvm::p
                     ptr = fmt::format_to(ptr, FMT_COMPILE("{}:{:.10e} "), j + i + 1, d(point, j + i));
                 }
             }
-            output.append(buffer.data(), ptr - buffer.data());
+            output.append(buffer.data(), static_cast<std::string::size_type>(ptr - buffer.data()));
         }
         output.push_back('\n');
     };

--- a/include/plssvm/detail/io/libsvm_parsing.hpp
+++ b/include/plssvm/detail/io/libsvm_parsing.hpp
@@ -287,7 +287,7 @@ inline void write_libsvm_data_impl(const std::string &filename, const soa_matrix
 #endif
                 }
             }
-            output.append(buffer.data(), ptr - buffer.data());
+            output.append(buffer.data(), static_cast<std::string::size_type>(ptr - buffer.data()));
         }
         output.push_back('\n');
     };

--- a/include/plssvm/detail/memory_size.hpp
+++ b/include/plssvm/detail/memory_size.hpp
@@ -128,7 +128,7 @@ constexpr memory_size &operator-=(memory_size &lhs, const memory_size rhs) {
  * @return a reference to the modified memory size @p mem
  */
 constexpr memory_size &operator*=(memory_size &mem, const long double factor) {
-    mem = memory_size{ static_cast<unsigned long long>(mem.num_bytes() * factor) };
+    mem = memory_size{ static_cast<unsigned long long>(static_cast<long double>(mem.num_bytes()) * factor) };
     return mem;
 }
 
@@ -155,7 +155,7 @@ constexpr memory_size &operator*=(memory_size &mem, const long double factor) {
  * @copydoc plssvm::detail::operator*=(memory_size &, const long double)
  */
 constexpr memory_size &operator/=(memory_size &mem, const long double factor) {
-    mem = memory_size{ static_cast<unsigned long long>(mem.num_bytes() / factor) };
+    mem = memory_size{ static_cast<unsigned long long>(static_cast<long double>(mem.num_bytes()) / factor) };
     return mem;
 }
 

--- a/include/plssvm/exceptions/source_location.hpp
+++ b/include/plssvm/exceptions/source_location.hpp
@@ -41,8 +41,8 @@ class source_location {
 
         loc.file_name_ = file_name;
         loc.function_name_ = function_name;
-        loc.line_ = line;
-        loc.column_ = column;
+        loc.line_ = static_cast<std::uint_least32_t>(line);
+        loc.column_ = static_cast<uint_least32_t>(column);
 
         return loc;
     }

--- a/src/plssvm/backends/CUDA/CMakeLists.txt
+++ b/src/plssvm/backends/CUDA/CMakeLists.txt
@@ -57,6 +57,7 @@ if (CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
 elseif (CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
     # use clang to compile CUDA code
     # build type specific flags
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Wall -Wextra -Wdouble-promotion -Wshadow -Wcast-qual -Wnull-dereference -Wextra-semi -Wunreachable-code -Wuninitialized -Wmost -Wconversion")
     set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO} -O2")
     set(CMAKE_CUDA_FLAGS_RELEASE "${CMAKE_CUDA_FLAGS} -O3")
     # set fast-math if requested

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -85,7 +85,7 @@ void csvm::init(const target_platform target) {
     target_ = plssvm::target_platform::gpu_nvidia;
 
     // get all available devices wrt the requested target platform
-    devices_.resize(detail::get_device_count());
+    devices_.resize(static_cast<std::vector<queue_type>::size_type>(detail::get_device_count()));
     std::iota(devices_.begin(), devices_.end(), 0);
 
     // throw exception if no CUDA devices could be found
@@ -157,8 +157,8 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
@@ -213,8 +213,8 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     detail::set_device(device);
     {
         const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-        const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                        static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
         detail::device_kernel_symm<<<grid, block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
     }
@@ -224,8 +224,8 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
 
         if (num_mirror_rows > 0) {
             const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-            const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                            static_cast<int>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+            const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                            static_cast<unsigned int>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
             detail::device_kernel_symm_mirror<<<grid, block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
         }
@@ -245,8 +245,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_t
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     detail::set_device(device);
     detail::device_kernel_inplace_matrix_add<<<grid, block>>>(num_rhs, lhs_d.get(), rhs_d.get());
@@ -265,8 +265,8 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     detail::set_device(device);
     detail::device_kernel_inplace_matrix_scale<<<grid, block>>>(num_rhs, lhs_d.get(), scale);
@@ -291,8 +291,8 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     detail::set_device(device);
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
@@ -341,8 +341,8 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
@@ -372,16 +372,16 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &para
     detail::set_device(device);
     if (params.kernel_type == kernel_function_type::linear) {
         // define the grid sizes
-        const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
         detail::device_kernel_predict_linear<<<grid, block>>>(out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features);
     } else {
         const unsigned long long num_sv = sv_or_w_d.shape().x;
 
         // define the grid sizes
-        const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<int>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
         switch (params.kernel_type.value()) {
             case kernel_function_type::linear:

--- a/src/plssvm/backends/CUDA/detail/device_ptr.cu
+++ b/src/plssvm/backends/CUDA/detail/device_ptr.cu
@@ -80,8 +80,8 @@ void device_ptr<T>::fill(const value_type value, const size_type pos, const size
 
     // run GPU kernel
     const size_type rcount = std::min(count, this->size_padded() - pos);
-    constexpr int block_size = 512;
-    const int grid_size = (rcount + block_size - 1) / block_size;
+    constexpr unsigned int block_size = 512;
+    const unsigned int grid_size = (static_cast<unsigned int>(rcount) + block_size - 1) / block_size;
     detail::fill_array<<<grid_size, block_size>>>(data_, value, pos, rcount);
 
     detail::peek_at_last_error();

--- a/src/plssvm/backends/HIP/CMakeLists.txt
+++ b/src/plssvm/backends/HIP/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(HIP REQUIRED)
 set(CMAKE_HIP_STANDARD 17)
 set(CMAKE_HIP_STANDARD_REQUIRED ON)
 
-set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -std=c++17")
+set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -std=c++17 -Wall -Wextra -Wdouble-promotion -Wshadow -Wcast-qual -Wnull-dereference -Wextra-semi -Wunreachable-code -Wuninitialized -Wmost -Wconversion")
 # set fast-math if requested
 if (PLSSVM_ENABLE_FAST_MATH)
     set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -ffast-math")

--- a/src/plssvm/backends/HIP/csvm.hip
+++ b/src/plssvm/backends/HIP/csvm.hip
@@ -72,7 +72,7 @@ void csvm::init(const target_platform target) {
     target_ = plssvm::target_platform::gpu_amd;
 
     // get all available devices wrt the requested target platform
-    devices_.resize(detail::get_device_count());
+    devices_.resize(static_cast<std::vector<queue_type>::size_type>(detail::get_device_count()));
     std::iota(devices_.begin(), devices_.end(), 0);
 
     // throw exception if no HIP devices could be found

--- a/src/plssvm/backends/HIP/csvm.hip
+++ b/src/plssvm/backends/HIP/csvm.hip
@@ -156,8 +156,8 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
@@ -212,8 +212,8 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     detail::set_device(device);
     {
         const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-        const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                        static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
         detail::device_kernel_symm<<<grid, block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
     }
@@ -223,8 +223,8 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
 
         if (num_mirror_rows > 0) {
             const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-            const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                            static_cast<int>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+            const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                            static_cast<unsigned int>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
             detail::device_kernel_symm_mirror<<<grid, block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
         }
@@ -244,8 +244,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_t
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     detail::set_device(device);
     detail::device_kernel_inplace_matrix_add<<<grid, block>>>(num_rhs, lhs_d.get(), rhs_d.get());
@@ -264,8 +264,8 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     detail::set_device(device);
     detail::device_kernel_inplace_matrix_scale<<<grid, block>>>(num_rhs, lhs_d.get(), scale);
@@ -290,8 +290,8 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     detail::set_device(device);
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
@@ -340,8 +340,8 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
         throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
     }
     const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
@@ -371,16 +371,16 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &para
     detail::set_device(device);
     if (params.kernel_type == kernel_function_type::linear) {
         // define the grid sizes
-        const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
         detail::device_kernel_predict_linear<<<grid, block>>>(out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features);
     } else {
         const unsigned long long num_sv = sv_or_w_d.shape().x;
 
         // define the grid sizes
-        const dim3 grid(static_cast<int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<int>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
+                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
 
         switch (params.kernel_type.value()) {
             case kernel_function_type::linear:

--- a/src/plssvm/backends/HIP/detail/device_ptr.hip
+++ b/src/plssvm/backends/HIP/detail/device_ptr.hip
@@ -84,8 +84,8 @@ void device_ptr<T>::fill(const value_type value, const size_type pos, const size
 
     // run GPU kernel
     const size_type rcount = std::min(count, this->size_padded() - pos);
-    constexpr int block_size = 512;
-    const int grid_size = (rcount + block_size - 1) / block_size;
+    constexpr unsigned int block_size = 512;
+    const unsigned int grid_size = (static_cast<unsigned int>(rcount) + block_size - 1) / block_size;
     detail::fill_array<<<grid_size, block_size>>>(data_, value, pos, rcount);
 
     detail::peek_at_last_error();

--- a/src/plssvm/backends/OpenCL/detail/utility.cpp
+++ b/src/plssvm/backends/OpenCL/detail/utility.cpp
@@ -344,6 +344,12 @@ std::vector<command_queue> create_command_queues(const std::vector<context> &con
     ::plssvm::detail::replace_all(kernel_src_string, "real_type", ::plssvm::detail::arithmetic_type_name<real_type>());
 
     // replace constants in kernel_src_string
+    // replace the size_t variants -> BEFORE replacing the "normal" values
+    ::plssvm::detail::replace_all(kernel_src_string, "THREAD_BLOCK_SIZE_ul", fmt::format("(ulong) {}", THREAD_BLOCK_SIZE));
+    ::plssvm::detail::replace_all(kernel_src_string, "FEATURE_BLOCK_SIZE_ul", fmt::format("(ulong) {}", FEATURE_BLOCK_SIZE));
+    ::plssvm::detail::replace_all(kernel_src_string, "INTERNAL_BLOCK_SIZE_ul", fmt::format("(ulong) {}", INTERNAL_BLOCK_SIZE));
+    ::plssvm::detail::replace_all(kernel_src_string, "PADDING_SIZE_ul", fmt::format("(ulong) {}", PADDING_SIZE));
+    // replace the normal variants
     ::plssvm::detail::replace_all(kernel_src_string, "THREAD_BLOCK_SIZE", fmt::format("{}", THREAD_BLOCK_SIZE));
     ::plssvm::detail::replace_all(kernel_src_string, "FEATURE_BLOCK_SIZE", fmt::format("{}", FEATURE_BLOCK_SIZE));
     ::plssvm::detail::replace_all(kernel_src_string, "INTERNAL_BLOCK_SIZE", fmt::format("{}", INTERNAL_BLOCK_SIZE));

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/CMakeLists.txt
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/CMakeLists.txt
@@ -77,7 +77,7 @@ if (AdaptiveCpp_FOUND)
     endif ()
     
     # silence unknown options warnings
-    target_compile_options(${PLSSVM_SYCL_BACKEND_ADAPTIVECPP_LIBRARY_NAME} PRIVATE -Wno-unknown-warning-option
+    target_compile_options(${PLSSVM_SYCL_BACKEND_ADAPTIVECPP_LIBRARY_NAME} PRIVATE -Wno-unknown-warning-option -Wconversion
                            $<$<CXX_COMPILER_ID:GNU>:-Wno-unknown-pragmas>
     )
     

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -181,15 +181,15 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
 //***************************************************//
 
 auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
-    const unsigned long long num_rows_reduced = data_d.shape().x - 1;
-    const unsigned long long num_features = data_d.shape().y;
+    const std::size_t num_rows_reduced = data_d.shape().x - 1;
+    const std::size_t num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // calculate the number of data points this device is responsible for
-    const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
+    const std::size_t device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
 
     // get the offset of the data points this device is responsible for
-    const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
     // define grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -251,14 +251,14 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
 }
 
 void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
-    const unsigned long long num_rhs = B_d.shape().x;
-    const unsigned long long num_rows = B_d.shape().y;
+    const std::size_t num_rhs = B_d.shape().x;
+    const std::size_t num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // calculate the number of data points this device is responsible for
-    const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
+    const std::size_t device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
     // get the offset of the data points this device is responsible for
-    const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
     // define grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -278,7 +278,7 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     }
 
     {
-        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+        const std::size_t num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
         if (num_mirror_rows > 0) {
             const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
@@ -295,8 +295,8 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
 }
 
 void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
-    const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
+    const std::size_t num_rhs = lhs_d.shape().x;
+    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // define the grid and block sizes
@@ -314,8 +314,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_t
 }
 
 void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
-    const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
+    const std::size_t num_rhs = lhs_d.shape().x;
+    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // define the grid and block sizes
@@ -333,15 +333,15 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type
 }
 
 void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
-    const unsigned long long num_rows_reduced = A_d.shape().x - 1;
-    const unsigned long long num_features = A_d.shape().y;
-    const unsigned long long num_classes = B_d.shape().x;
+    const std::size_t num_rows_reduced = A_d.shape().x - 1;
+    const std::size_t num_features = A_d.shape().y;
+    const std::size_t num_classes = B_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     // calculate the number of data points this device is responsible for
-    const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
+    const std::size_t device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
     // get the offset of the data points this device is responsible for
-    const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
     // define the grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -400,14 +400,14 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //***************************************************//
 
 auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
-    const unsigned long long num_classes = alpha_d.shape().x;
-    const unsigned long long num_sv = alpha_d.shape().y;
-    const unsigned long long device_specific_num_sv = sv_d.shape().x;
-    const unsigned long long num_features = sv_d.shape().y;
+    const std::size_t num_classes = alpha_d.shape().x;
+    const std::size_t num_sv = alpha_d.shape().y;
+    const std::size_t device_specific_num_sv = sv_d.shape().x;
+    const std::size_t num_features = sv_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // get the offset of the data points this device is responsible for
-    const unsigned long long sv_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t sv_offset = data_distribution_->place_row_offset(device_id);
 
     // define grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -430,9 +430,9 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
 }
 
 auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
-    const unsigned long long num_classes = alpha_d.shape().x;
-    const unsigned long long num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
-    const unsigned long long num_features = predict_points_d.shape().y;
+    const std::size_t num_classes = alpha_d.shape().x;
+    const std::size_t num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
+    const std::size_t num_features = predict_points_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
@@ -453,7 +453,7 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &para
             cgh.parallel_for(execution_range, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features });
         });
     } else {
-        const unsigned long long num_sv = sv_or_w_d.shape().x;
+        const std::size_t num_sv = sv_or_w_d.shape().x;
 
         const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
                                      static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };

--- a/src/plssvm/backends/SYCL/DPCPP/CMakeLists.txt
+++ b/src/plssvm/backends/SYCL/DPCPP/CMakeLists.txt
@@ -64,6 +64,10 @@ if (PLSSVM_SYCL_BACKEND_CHECK_FOR_DPCPP_COMPILER)
     # enable DPC++ SYCL support
     target_compile_options(${PLSSVM_SYCL_BACKEND_DPCPP_LIBRARY_NAME} PRIVATE -sycl-std=2020 -fsycl -fno-sycl-id-queries-fit-in-int)
     target_link_options(${PLSSVM_SYCL_BACKEND_DPCPP_LIBRARY_NAME} PRIVATE -fsycl)
+    # add additional compiler warnings
+    target_compile_options(${PLSSVM_SYCL_BACKEND_DPCPP_LIBRARY_NAME} PRIVATE
+                           -Wconversion -Wall -Wextra -Wmost -Wdouble-promotion -fno-common -Wshadow -Wcast-qual
+                           -Wextra-semi -Wunreachable-code -Wuninitialized -Wno-ctor-dtor-privacy)
     
     set(PLSSVM_DPCPP_FSYCL_TARGETS "")
     # cpu targets

--- a/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
+++ b/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
@@ -166,15 +166,15 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
 //***************************************************//
 
 auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
-    const unsigned long long num_rows_reduced = data_d.shape().x - 1;
-    const unsigned long long num_features = data_d.shape().y;
+    const std::size_t num_rows_reduced = data_d.shape().x - 1;
+    const std::size_t num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // calculate the number of data points this device is responsible for
-    const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
+    const std::size_t device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
 
     // get the offset of the data points this device is responsible for
-    const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
     // define grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -236,14 +236,14 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
 }
 
 void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
-    const unsigned long long num_rhs = B_d.shape().x;
-    const unsigned long long num_rows = B_d.shape().y;
+    const std::size_t num_rhs = B_d.shape().x;
+    const std::size_t num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // calculate the number of data points this device is responsible for
-    const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
+    const std::size_t device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
     // get the offset of the data points this device is responsible for
-    const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
     // define grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -263,7 +263,7 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     }
 
     {
-        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+        const std::size_t num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
         if (num_mirror_rows > 0) {
             const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
@@ -280,8 +280,8 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
 }
 
 void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
-    const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
+    const std::size_t num_rhs = lhs_d.shape().x;
+    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // define the grid and block sizes
@@ -299,8 +299,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_t
 }
 
 void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
-    const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
+    const std::size_t num_rhs = lhs_d.shape().x;
+    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // define the grid and block sizes
@@ -318,15 +318,15 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type
 }
 
 void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
-    const unsigned long long num_rows_reduced = A_d.shape().x - 1;
-    const unsigned long long num_features = A_d.shape().y;
-    const unsigned long long num_classes = B_d.shape().x;
+    const std::size_t num_rows_reduced = A_d.shape().x - 1;
+    const std::size_t num_features = A_d.shape().y;
+    const std::size_t num_classes = B_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     // calculate the number of data points this device is responsible for
-    const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
+    const std::size_t device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
     // get the offset of the data points this device is responsible for
-    const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
     // define the grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -385,14 +385,14 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //***************************************************//
 
 auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
-    const unsigned long long num_classes = alpha_d.shape().x;
-    const unsigned long long num_sv = alpha_d.shape().y;
-    const unsigned long long device_specific_num_sv = sv_d.shape().x;
-    const unsigned long long num_features = sv_d.shape().y;
+    const std::size_t num_classes = alpha_d.shape().x;
+    const std::size_t num_sv = alpha_d.shape().y;
+    const std::size_t device_specific_num_sv = sv_d.shape().x;
+    const std::size_t num_features = sv_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // get the offset of the data points this device is responsible for
-    const unsigned long long sv_offset = data_distribution_->place_row_offset(device_id);
+    const std::size_t sv_offset = data_distribution_->place_row_offset(device_id);
 
     // define grid and block sizes
     const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
@@ -415,9 +415,9 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
 }
 
 auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
-    const unsigned long long num_classes = alpha_d.shape().x;
-    const unsigned long long num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
-    const unsigned long long num_features = predict_points_d.shape().y;
+    const std::size_t num_classes = alpha_d.shape().x;
+    const std::size_t num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
+    const std::size_t num_features = predict_points_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
@@ -438,7 +438,7 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &para
             cgh.parallel_for(execution_range, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features });
         });
     } else {
-        const unsigned long long num_sv = sv_or_w_d.shape().x;
+        const std::size_t num_sv = sv_or_w_d.shape().x;
 
         const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
                                      static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };

--- a/src/plssvm/detail/sha256.cpp
+++ b/src/plssvm/detail/sha256.cpp
@@ -25,8 +25,8 @@ std::string sha256::operator()(std::string input) const {
     // Pre-processing (Padding):
 
     // begin with the original message of length L byte
-    const std::uint64_t L = input.size();
-    const std::uint64_t L_bits = L * 8;
+    const auto L = static_cast<std::uint32_t>(input.size());
+    const std::uint32_t L_bits = L * 8;
 
     // append a single '1' byte
     input.append(1, static_cast<char>(0x80));

--- a/tests/detail/cmd/cmd_utility.hpp
+++ b/tests/detail/cmd/cmd_utility.hpp
@@ -61,7 +61,7 @@ class ParameterBase : public ::testing::Test,
      * @brief Return the number of command line arguments encapsulated in this class.
      * @return the number of cmd arguments (`[[nodiscard]]`)
      */
-    [[nodiscard]] int get_argc() const noexcept { return cmd_argv_.size(); }
+    [[nodiscard]] int get_argc() const noexcept { return static_cast<int>(cmd_argv_.size()); }
 
     /**
      * @brief The command line arguments encapsulated in this class.

--- a/tests/utility.hpp
+++ b/tests/utility.hpp
@@ -442,7 +442,7 @@ template <typename matrix_type>
     matrix_type matrix{ shape };
     for (std::size_t i = 0; i < matrix.num_rows(); ++i) {
         for (std::size_t j = 1; j <= matrix.num_cols(); ++j) {
-            matrix(i, j - 1) = i + j / real_type{ 10.0 };
+            matrix(i, j - 1) = static_cast<real_type>(i) + static_cast<real_type>(j) / real_type{ 10.0 };
         }
     }
 
@@ -485,7 +485,7 @@ template <typename matrix_type>
     matrix_type matrix{ shape };
     for (std::size_t i = 0; i < matrix.num_rows(); ++i) {
         for (std::size_t j = 1; j <= matrix.num_cols(); ++j) {
-            matrix(i, j - 1) = i + j / real_type{ 10.0 };
+            matrix(i, j - 1) = static_cast<real_type>(i) + static_cast<real_type>(j) / real_type{ 10.0 };
         }
         // remove half of the created values randomly
         for (std::size_t j = 0; j < matrix.num_cols() / 2; ++j) {


### PR DESCRIPTION
Update the index types inside all kernels to reduce the amount of implicit conversions and potential 32bit unsigned int overflows.