### PR TITLE
Fix work group size limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,9 @@ endif ()
 ########################################################################################################################
 ## set base sources
 set(PLSSVM_BASE_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/backends/SYCL/kernel_invocation_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/backends/SYCL/implementation_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/backends/SYCL/kernel_invocation_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/backends/execution_range.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/cmd/parser_predict.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/cmd/parser_scale.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/plssvm/detail/cmd/parser_train.cpp

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If the OpenCL backend is available and NVIDIA GPUs should be targeted, an additi
 
 If the SYCL backend is available, additional options can be set.
 
-- `PLSSVM_ENABLE_SYCL_ADAPITVECPP_BACKEND=ON|OFF|AUTO` (default: `AUTO`):
+- `PLSSVM_ENABLE_SYCL_ADAPTIVECPP_BACKEND=ON|OFF|AUTO` (default: `AUTO`):
   - `ON`: check for AdaptiveCpp as implementation for the SYCL backend and fail if not available
   - `AUTO`: check for AdaptiveCpp as implementation for the SYCL backend but **do not** fail if not available
   - `OFF`: do not check for AdaptiveCpp as implementation for the SYCL backend

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(Doxygen REQUIRED OPTIONAL_COMPONENTS dot)
 ## configure doxygen
 set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/docs")
 set(DOXYGEN_IMAGE_PATH "${PROJECT_SOURCE_DIR}/docs/resources")
-set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "README.md")
+set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${PROJECT_SOURCE_DIR}/README.md")
 set(DOXYGEN_FILE_PATTERNS "*.hpp;*.cuh;*.cl;*.dox")
 set(DOXYGEN_EXTENSION_MAPPING "cu=c++;cuh=c++;cl=c++")
 set(DOXYGEN_STRIP_FROM_PATH "${PROJECT_SOURCE_DIR}")
@@ -49,10 +49,17 @@ set(DOXYGEN_ALIASES
     [[license="\par License^^\parblock^^"  ]]
 )
 
+# sanitize README formulas for Doxygen if the sed utility is available
+find_program(PLSSVM_HAS_SED "sed")
+if (PLSSVM_HAS_SED)
+    set(DOXYGEN_FILTER_PATTERNS "*.md=sed -e '1,90 s/\\$/\\\\f\\$/g' -e '/^## Table of Contents/,/^## Introduction to PLSSVM/{//!d}' -e 's/^## Table of Contents/@tableofcontents/g' -e '/^# The Python3 Bindings/,/^We currently support two kinds of Python3 bindings/{//!d}' -e 's/^# The Python3 Bindings/@tableofcontents{HTML:3}/g' -e '/^#/ s/`//g'")
+    list(APPEND DOXYGEN_FILTER_PATTERNS "*.cl=sed -e 's/ PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST)/, Args... PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST)/g'")
+endif ()
+
 ## add doxygen as target
 doxygen_add_docs(
         doc
-        "${PROJECT_SOURCE_DIR}/include;${PROJECT_SOURCE_DIR}/docs/resources;${PROJECT_SOURCE_DIR}/README.md"
+        "${PROJECT_SOURCE_DIR}/include;${PROJECT_SOURCE_DIR}/docs/resources;${PROJECT_SOURCE_DIR}/README.md;${PROJECT_SOURCE_DIR}/bindings/Python/README.md"
         ALL  # add to the default build target
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         COMMENT "Generating API documentation with Doxygen"

--- a/docs/resources/dirs.dox
+++ b/docs/resources/dirs.dox
@@ -275,6 +275,61 @@
  */
 
 /**
+ * @dir include/plssvm/backends/stdpar
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Directory containing the implementation for the stdpar backend.
+ */
+
+/**
+ * @dir include/plssvm/backends/stdpar/detail
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Directory containing implementation details for the stdpar backend.
+ */
+
+/**
+ * @dir include/plssvm/backends/stdpar/kernel
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Directory containing all kernels for the stdpar backend.
+ */
+
+/**
+ * @dir include/plssvm/backends/stdpar/kernel/cg_explicit
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Directory containing kernel implementations for the explicit CG algorithm using the stdpar backend.
+ */
+
+/**
+ * @dir include/plssvm/backends/stdpar/kernel/cg_implicit
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Directory containing kernel implementations for the implicit CG algorithm using the stdpar backend.
+ */
+
+/**
  * @dir include/plssvm/backends/SYCL
  * @author Alexander Van Craen
  * @author Marcel Breyer

--- a/include/plssvm/backends/CUDA/csvm.hpp
+++ b/include/plssvm/backends/CUDA/csvm.hpp
@@ -23,6 +23,9 @@
 #include "plssvm/parameter.hpp"                           // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                    // plssvm::target_platform
 
+#include "plssvm/backends/kernel_parameter.hpp"
+#include "plssvm/backends/execution_range.hpp"
+
 #include <cstddef>      // std::size_t
 #include <type_traits>  // std::true_type
 #include <utility>      // std::forward
@@ -140,6 +143,10 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
      * @copydoc plssvm::detail::gpu_csvm::get_max_work_group_size
      */
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
+    /**
+     * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     */
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 
     //***************************************************//
     //                        fit                        //
@@ -147,23 +154,23 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_blas_level_3_kernel_explicit
      */
-    void run_blas_level_3_kernel_explicit(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
+    void run_blas_level_3_kernel_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_implicit_blas_level_3
      */
-    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
+    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, const ::plssvm::detail::execution_range &exec, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_addition
      */
-    void run_inplace_matrix_addition(std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
+    void run_inplace_matrix_addition(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_scale
      */
-    void run_inplace_matrix_scale(std::size_t device_id, device_ptr_type &lhs_d, real_type scale) const override;
+    void run_inplace_matrix_scale(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, real_type scale) const override;
 
     //***************************************************//
     //                   predict, score                  //
@@ -171,11 +178,11 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_w_kernel
      */
-    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
+    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_predict_kernel
      */
-    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
+    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
 };
 
 }  // namespace cuda

--- a/include/plssvm/backends/CUDA/csvm.hpp
+++ b/include/plssvm/backends/CUDA/csvm.hpp
@@ -144,7 +144,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
     /**
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
      */
-    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const override;
 
     //***************************************************//
     //                        fit                        //

--- a/include/plssvm/backends/CUDA/csvm.hpp
+++ b/include/plssvm/backends/CUDA/csvm.hpp
@@ -15,7 +15,7 @@
 
 #include "plssvm/backends/CUDA/detail/device_ptr.cuh"     // plssvm::cuda::detail::device_ptr
 #include "plssvm/backends/CUDA/detail/pinned_memory.cuh"  // plssvm::cuda::detail::pinned_memory
-#include "plssvm/backends/execution_range.hpp"            // plssvm::detail::execution_range
+#include "plssvm/backends/execution_range.hpp"            // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/gpu_csvm.hpp"                   // plssvm::detail::gpu_csvm
 #include "plssvm/constants.hpp"                           // plssvm::real_type
 #include "plssvm/csvm.hpp"                                // plssvm::detail::csvm_backend_exists

--- a/include/plssvm/backends/CUDA/csvm.hpp
+++ b/include/plssvm/backends/CUDA/csvm.hpp
@@ -15,6 +15,7 @@
 
 #include "plssvm/backends/CUDA/detail/device_ptr.cuh"     // plssvm::cuda::detail::device_ptr
 #include "plssvm/backends/CUDA/detail/pinned_memory.cuh"  // plssvm::cuda::detail::pinned_memory
+#include "plssvm/backends/execution_range.hpp"            // plssvm::detail::execution_range
 #include "plssvm/backends/gpu_csvm.hpp"                   // plssvm::detail::gpu_csvm
 #include "plssvm/constants.hpp"                           // plssvm::real_type
 #include "plssvm/csvm.hpp"                                // plssvm::detail::csvm_backend_exists
@@ -22,9 +23,6 @@
 #include "plssvm/detail/type_traits.hpp"                  // PLSSVM_REQUIRES
 #include "plssvm/parameter.hpp"                           // plssvm::parameter
 #include "plssvm/target_platforms.hpp"                    // plssvm::target_platform
-
-#include "plssvm/backends/kernel_parameter.hpp"
-#include "plssvm/backends/execution_range.hpp"
 
 #include <cstddef>      // std::size_t
 #include <type_traits>  // std::true_type

--- a/include/plssvm/backends/CUDA/detail/utility.cuh
+++ b/include/plssvm/backends/CUDA/detail/utility.cuh
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "plssvm/backends/CUDA/exceptions.hpp"  // plssvm::cuda::backend_exception
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
 
 #include "fmt/core.h"     // fmt::format, fmt::formatter
 #include "fmt/ostream.h"  // fmt::ostream_formatter
@@ -33,6 +34,13 @@
     }
 
 namespace plssvm::cuda::detail {
+
+/**
+ * @brief Convert a `plssvm::detail::dim_type` to a CUDA native dim3.
+ * @param[in] dims the dimensional value to convert
+ * @return the native CUDA dim3 type (`[[nodiscard]]`)
+ */
+[[nodiscard]] dim3 dim_type_to_native(const ::plssvm::detail::dim_type &dims);
 
 /**
  * @brief Returns the number of available CUDA devices.

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
@@ -30,14 +30,14 @@ namespace plssvm::cuda::detail {
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
-__global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
+__global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -121,14 +121,14 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
-__global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
+__global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -194,14 +194,14 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
  * @param[in,out] lhs the first matrix (updated inplace)
  * @param[in] rhs the second matrix
  */
-__global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs) {
+__global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
@@ -225,14 +225,14 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
  * @param[in,out] lhs the matrix (updated inplace)
  * @param[in] scale the value to scale
  */
-__global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale) {
+__global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
@@ -36,8 +36,8 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -127,8 +127,8 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -200,8 +200,8 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
@@ -231,8 +231,8 @@ __global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh
@@ -29,6 +29,8 @@ namespace plssvm::cuda::detail {
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -120,6 +122,8 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -193,6 +197,8 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
  * @param[in] num_cols the number of columns in both matrices
  * @param[in,out] lhs the first matrix (updated inplace)
  * @param[in] rhs the second matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -224,6 +230,8 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
  * @param[in] num_cols the number of columns in the matrix
  * @param[in,out] lhs the matrix (updated inplace)
  * @param[in] scale the value to scale
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
@@ -32,6 +32,8 @@ namespace plssvm::cuda::detail {
  * @param[in] q the vector used in the dimensional reduction
  * @param[in] QA_cost the scalar used in the dimensional reduction
  * @param[in] cost the cost factor the diagonal is scaled with
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
@@ -1,13 +1,13 @@
 /**
-* @file
-* @author Alexander Van Craen
-* @author Marcel Breyer
-* @copyright 2018-today The PLSSVM project - All Rights Reserved
-* @license This file is part of the PLSSVM project which is released under the MIT license.
-*          See the LICENSE.md file in the project root for full license information.
-*
-* @brief Functions for explicitly assembling the kernel matrix using the CUDA backend.
-*/
+ * @file
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Functions for explicitly assembling the kernel matrix using the CUDA backend.
+ */
 
 #ifndef PLSSVM_BACKENDS_CUDA_KERNEL_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLY_CUH_
 #define PLSSVM_BACKENDS_CUDA_KERNEL_CG_EXPLICIT_KERNEL_MATRIX_ASSEMBLY_CUH_
@@ -20,99 +20,99 @@
 namespace plssvm::cuda::detail {
 
 /**
-* @brief Create the explicit kernel matrix using the @p kernel_function.
-* @tparam kernel_function the type of the used kernel function
-* @tparam Args the types of the parameters necessary for the specific kernel function
-* @param[out] kernel_matrix_d the calculated kernel matrix
-* @param[in] data_d the data points to calculate the kernel matrix from
-* @param[in] num_rows the total number of data points (= total number of rows)
-* @param[in] device_num_rows the number of rows the current device is responsible for
-* @param[in] row_offset the first row in @p data_d the current device is responsible for
-* @param[in] num_features the number of features per data point
-* @param[in] q the vector used in the dimensional reduction
-* @param[in] QA_cost the scalar used in the dimensional reduction
-* @param[in] cost the cost factor the diagonal is scaled with
-* @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
-*/
+ * @brief Create the explicit kernel matrix using the @p kernel_function.
+ * @tparam kernel_function the type of the used kernel function
+ * @tparam Args the types of the parameters necessary for the specific kernel function
+ * @param[out] kernel_matrix_d the calculated kernel matrix
+ * @param[in] data_d the data points to calculate the kernel matrix from
+ * @param[in] num_rows the total number of data points (= total number of rows)
+ * @param[in] device_num_rows the number of rows the current device is responsible for
+ * @param[in] row_offset the first row in @p data_d the current device is responsible for
+ * @param[in] num_features the number of features per data point
+ * @param[in] q the vector used in the dimensional reduction
+ * @param[in] QA_cost the scalar used in the dimensional reduction
+ * @param[in] cost the cost factor the diagonal is scaled with
+ * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
+ */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) {
-   // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-   const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-   const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-   const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-   const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-   const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-   const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
-   const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
-   const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
-   const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
-   const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
+__global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
+    const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
+    const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
+    const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
-   // calculate the indices used in the current thread
-   const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
-   const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
-   const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
-   const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    // calculate the indices used in the current thread
+    const auto i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
+    const auto i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
+    const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
-   // create the shared memory arrays used for caching data point features
-   __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
-   __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
+    // create the shared memory arrays used for caching data point features
+    __shared__ real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
+    __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
-   // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
-   if (blockIdx.x >= blockIdx.y) {
-       // create a thread private array used for internal caching
-       real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
+    // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
+    if (blockIdx_x >= blockIdx_y) {
+        // create a thread private array used for internal caching
+        real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
-       // iterate over all features using blocking to be able to cache them for faster memory accesses
-       for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
-           // load data into shared memory
-           for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-               const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
-               const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+        // iterate over all features using blocking to be able to cache them for faster memory accesses
+        for (unsigned long long dim = 0; dim < num_features; dim += FEATURE_BLOCK_SIZE_ull) {
+            // load data into shared memory
+            for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
+                const auto global_i = row_offset + i_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+                const auto global_j = row_offset + j_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
-               // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-               data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
-               data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
-               data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
-               data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
-           }
-           __syncthreads();  // wait until all threads loaded their part of the data
+                // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
+                data_cache_i[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                data_cache_i[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_i];
+                data_cache_j[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+                data_cache_j[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_rows + 1ull + PADDING_SIZE_ull) + global_j];
+            }
+            __syncthreads();  // wait until all threads loaded their part of the data
 
-           // perform the feature reduction calculation
-           for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
-               for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
-                   for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-                       temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i[block_dim][threadIdx.x * INTERNAL_BLOCK_SIZE + internal_i],
-                                                                                               data_cache_j[block_dim][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_j]);
-                   }
-               }
-           }
-           __syncthreads();  // wait until all threads performed their part of the calculations
-       }
+            // perform the feature reduction calculation
+            for (unsigned block_dim = 0; block_dim < FEATURE_BLOCK_SIZE; ++block_dim) {
+                for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
+                    for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
+                        temp[internal_i][internal_j] += detail::feature_reduce<kernel_function>(data_cache_i[block_dim][threadIdx.x * INTERNAL_BLOCK_SIZE + internal_i],
+                                                                                                data_cache_j[block_dim][threadIdx.y * INTERNAL_BLOCK_SIZE + internal_j]);
+                    }
+                }
+            }
+            __syncthreads();  // wait until all threads performed their part of the calculations
+        }
 
-       // apply the remaining part of the kernel function and store the value in the output kernel matrix
-       for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
-           for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
-               // calculate the indices to access the kernel matrix (the part stored on the current device)
-               const auto device_global_i = i + static_cast<unsigned long long>(internal_i);
-               const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
-               const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
-               const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
+        // apply the remaining part of the kernel function and store the value in the output kernel matrix
+        for (unsigned internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
+            for (unsigned internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
+                // calculate the indices to access the kernel matrix (the part stored on the current device)
+                const auto device_global_i = i + static_cast<unsigned long long>(internal_i);
+                const auto global_i = row_offset + i + static_cast<unsigned long long>(internal_i);
+                const auto device_global_j = j + static_cast<unsigned long long>(internal_j);
+                const auto global_j = row_offset + j + static_cast<unsigned long long>(internal_j);
 
-               // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
-               if (device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j) {
-                   real_type temp_ij = temp[internal_i][internal_j];
-                   temp_ij = detail::apply_kernel_function<kernel_function>(temp_ij, kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
-                   // apply the cost on the diagonal
-                   if (global_i == global_j) {
-                       temp_ij += cost;
-                   }
-                   // update the kernel matrix
-                   kernel_matrix_d[device_global_j * (num_rows - row_offset + PADDING_SIZE_ull) - device_global_j * (device_global_j + 1ull) / 2ull + device_global_i] = temp_ij;
-               }
-           }
-       }
-   }
+                // be sure to not perform out of bounds accesses for the kernel matrix (only using the upper triangular matrix)
+                if (device_global_i < (num_rows - row_offset) && device_global_j < device_num_rows && global_i >= global_j) {
+                    real_type temp_ij = temp[internal_i][internal_j];
+                    temp_ij = detail::apply_kernel_function<kernel_function>(temp_ij, kernel_function_parameter...) + QA_cost - q[global_i] - q[global_j];
+                    // apply the cost on the diagonal
+                    if (global_i == global_j) {
+                        temp_ij += cost;
+                    }
+                    // update the kernel matrix
+                    kernel_matrix_d[device_global_j * (num_rows - row_offset + PADDING_SIZE_ull) - device_global_j * (device_global_j + 1ull) / 2ull + device_global_i] = temp_ij;
+                }
+            }
+        }
+    }
 }
 
 }  // namespace plssvm::cuda::detail

--- a/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh
@@ -41,8 +41,8 @@ __global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_ty
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
@@ -39,14 +39,14 @@ namespace plssvm::cuda::detail {
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_assembly_symm(const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, Args... kernel_function_parameter) {
+__global__ void device_kernel_assembly_symm(const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -59,7 +59,7 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
     const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
     // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
-    if (blockIdx.x >= blockIdx.y) {
+    if (blockIdx_x >= blockIdx_y) {
         // create a thread private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 

--- a/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
@@ -36,6 +36,8 @@ namespace plssvm::cuda::detail {
  * @param[in] B the matrix @p B
  * @param[in,out] C the matrix @p C
  * @param[in] num_classes the number of classes in the data set
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>

--- a/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
+++ b/include/plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh
@@ -45,8 +45,8 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
+++ b/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
@@ -29,6 +29,8 @@ namespace plssvm::cuda::detail {
  * @param[in] num_sv the number of support vectors
  * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -98,6 +100,8 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
  * @param[in] num_classes the number of classes
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -175,6 +179,8 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
  * @param[in] num_sv the number of support vectors
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>

--- a/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
+++ b/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
@@ -30,14 +30,14 @@ namespace plssvm::cuda::detail {
  * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
  */
-__global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset) {
+__global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
@@ -99,14 +99,14 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
  */
-__global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) {
+__global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -178,14 +178,14 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_predict(real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) {
+__global__ void device_kernel_predict(real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
+++ b/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
@@ -261,7 +261,7 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
                 alpha_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
-                if (blockIdx.y == 0u) {
+                if (blockIdx_y == 0ull) {
                     out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y];
                     out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
                 } else {

--- a/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
+++ b/include/plssvm/backends/CUDA/kernel/predict_kernel.cuh
@@ -36,8 +36,8 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
@@ -105,8 +105,8 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -184,8 +184,8 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/HIP/csvm.hpp
+++ b/include/plssvm/backends/HIP/csvm.hpp
@@ -47,6 +47,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
 
   public:
     using base_type::device_ptr_type;
+    using typename base_type::pinned_memory_type;
     using typename base_type::queue_type;
 
     /**
@@ -147,7 +148,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
     /**
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
      */
-    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const override;
 
     //***************************************************//
     //                        fit                        //

--- a/include/plssvm/backends/HIP/csvm.hpp
+++ b/include/plssvm/backends/HIP/csvm.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BACKENDS_HIP_CSVM_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"               // plssvm::detail::execution_range
 #include "plssvm/backends/gpu_csvm.hpp"                      // plssvm::detail::gpu_csvm
 #include "plssvm/backends/HIP/detail/device_ptr.hip.hpp"     // plssvm::hip::detail::device_ptr
 #include "plssvm/backends/HIP/detail/pinned_memory.hip.hpp"  // plssvm::hip::detail::pinned_memory
@@ -26,6 +27,7 @@
 #include <cstddef>      // std::size_t
 #include <type_traits>  // std::true_type
 #include <utility>      // std::forward
+#include <vector>       // std::vector
 
 namespace plssvm {
 
@@ -142,6 +144,10 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
      * @copydoc plssvm::detail::gpu_csvm::get_max_work_group_size
      */
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
+    /**
+     * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     */
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 
     //***************************************************//
     //                        fit                        //
@@ -149,23 +155,23 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_blas_level_3_kernel_explicit
      */
-    void run_blas_level_3_kernel_explicit(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
+    void run_blas_level_3_kernel_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_implicit_blas_level_3
      */
-    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
+    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, const ::plssvm::detail::execution_range &exec, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_addition
      */
-    void run_inplace_matrix_addition(std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
+    void run_inplace_matrix_addition(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_scale
      */
-    void run_inplace_matrix_scale(std::size_t device_id, device_ptr_type &lhs_d, real_type scale) const override;
+    void run_inplace_matrix_scale(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, real_type scale) const override;
 
     //***************************************************//
     //                   predict, score                  //
@@ -173,11 +179,11 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, int, detail::
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_w_kernel
      */
-    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
+    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_predict_kernel
      */
-    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
+    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
 };
 
 }  // namespace hip

--- a/include/plssvm/backends/HIP/csvm.hpp
+++ b/include/plssvm/backends/HIP/csvm.hpp
@@ -13,7 +13,7 @@
 #define PLSSVM_BACKENDS_HIP_CSVM_HPP_
 #pragma once
 
-#include "plssvm/backends/execution_range.hpp"               // plssvm::detail::execution_range
+#include "plssvm/backends/execution_range.hpp"               // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/gpu_csvm.hpp"                      // plssvm::detail::gpu_csvm
 #include "plssvm/backends/HIP/detail/device_ptr.hip.hpp"     // plssvm::hip::detail::device_ptr
 #include "plssvm/backends/HIP/detail/pinned_memory.hip.hpp"  // plssvm::hip::detail::pinned_memory

--- a/include/plssvm/backends/HIP/detail/utility.hip.hpp
+++ b/include/plssvm/backends/HIP/detail/utility.hip.hpp
@@ -38,9 +38,9 @@
 namespace plssvm::hip::detail {
 
 /**
- * @brief Convert a `plssvm::detail::dim_type` to a CUDA native dim3.
+ * @brief Convert a `plssvm::detail::dim_type` to a HIP native dim3.
  * @param[in] dims the dimensional value to convert
- * @return the native CUDA dim3 type (`[[nodiscard]]`)
+ * @return the native HIP dim3 type (`[[nodiscard]]`)
  */
 [[nodiscard]] dim3 dim_type_to_native(const ::plssvm::detail::dim_type &dims);
 

--- a/include/plssvm/backends/HIP/detail/utility.hip.hpp
+++ b/include/plssvm/backends/HIP/detail/utility.hip.hpp
@@ -13,7 +13,8 @@
 #define PLSSVM_BACKENDS_HIP_DETAIL_UTILITY_HPP_
 #pragma once
 
-#include "plssvm/backends/HIP/exceptions.hpp"  // plssvm::hip::backend_exception
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+#include "plssvm/backends/HIP/exceptions.hpp"   // plssvm::hip::backend_exception
 
 #include "hip/hip_runtime_api.h"  // hipError_t, hipSuccess, hipGetErrorName, hipGetErrorString
 
@@ -35,6 +36,13 @@
     }
 
 namespace plssvm::hip::detail {
+
+/**
+ * @brief Convert a `plssvm::detail::dim_type` to a CUDA native dim3.
+ * @param[in] dims the dimensional value to convert
+ * @return the native CUDA dim3 type (`[[nodiscard]]`)
+ */
+[[nodiscard]] dim3 dim_type_to_native(const ::plssvm::detail::dim_type &dims);
 
 /**
  * @brief Returns the number of available HIP devices.

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
@@ -31,6 +31,8 @@ namespace plssvm::hip::detail {
  * @param[in] A the matrix @p A
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
 __global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
@@ -123,6 +125,8 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -196,6 +200,8 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
  * @param[in] num_cols the number of columns in both matrices
  * @param[in,out] lhs the first matrix (updated inplace)
  * @param[in] rhs the second matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -227,6 +233,8 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
  * @param[in] num_cols the number of columns in the matrix
  * @param[in,out] lhs the matrix (updated inplace)
  * @param[in] scale the value to scale
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
@@ -39,8 +39,8 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -130,8 +130,8 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -203,8 +203,8 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
@@ -234,8 +234,8 @@ __global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
@@ -31,9 +31,9 @@ namespace plssvm::hip::detail {
  * @param[in] A the matrix @p A
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
+ * @param[in,out] C the matrix @p C, also used as result matrix
  * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
  * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
- * @param[in,out] C the matrix @p C, also used as result matrix
  */
 __global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/blas.hip.hpp
@@ -33,14 +33,14 @@ namespace plssvm::hip::detail {
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
-__global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
+__global__ void device_kernel_symm(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -124,14 +124,14 @@ __global__ void device_kernel_symm(const unsigned long long num_rows, const unsi
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
-__global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C) {
+__global__ void device_kernel_symm_mirror(const unsigned long long num_rows, const unsigned long long num_rhs, const unsigned long long num_mirror_rows, const unsigned long long device_specific_num_rows, const unsigned long long row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -197,14 +197,14 @@ __global__ void device_kernel_symm_mirror(const unsigned long long num_rows, con
  * @param[in,out] lhs the first matrix (updated inplace)
  * @param[in] rhs the second matrix
  */
-__global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs) {
+__global__ void device_kernel_inplace_matrix_add(const unsigned long long num_cols, real_type *lhs, const real_type *rhs, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 
@@ -228,14 +228,14 @@ __global__ void device_kernel_inplace_matrix_add(const unsigned long long num_co
  * @param[in,out] lhs the matrix (updated inplace)
  * @param[in] scale the value to scale
  */
-__global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale) {
+__global__ void device_kernel_inplace_matrix_scale(const unsigned long long num_cols, real_type *lhs, const real_type scale, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
 

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
@@ -44,8 +44,8 @@ __global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_ty
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
@@ -23,19 +23,21 @@
 namespace plssvm::hip::detail {
 
 /**
-* @brief Create the explicit kernel matrix using the @p kernel_function.
-* @tparam kernel_function the type of the used kernel function
-* @tparam Args the types of the parameters necessary for the specific kernel function
-* @param[out] kernel_matrix_d the calculated kernel matrix
-* @param[in] data_d the data points to calculate the kernel matrix from
-* @param[in] num_rows the total number of data points (= total number of rows)
-* @param[in] device_num_rows the number of rows the current device is responsible for
-* @param[in] row_offset the first row in @p data_d the current device is responsible for
-* @param[in] num_features the number of features per data point
-* @param[in] q the vector used in the dimensional reduction
-* @param[in] QA_cost the scalar used in the dimensional reduction
-* @param[in] cost the cost factor the diagonal is scaled with
-* @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
+ * @brief Create the explicit kernel matrix using the @p kernel_function.
+ * @tparam kernel_function the type of the used kernel function
+ * @tparam Args the types of the parameters necessary for the specific kernel function
+ * @param[out] kernel_matrix_d the calculated kernel matrix
+ * @param[in] data_d the data points to calculate the kernel matrix from
+ * @param[in] num_rows the total number of data points (= total number of rows)
+ * @param[in] device_num_rows the number of rows the current device is responsible for
+ * @param[in] row_offset the first row in @p data_d the current device is responsible for
+ * @param[in] num_features the number of features per data point
+ * @param[in] q the vector used in the dimensional reduction
+ * @param[in] QA_cost the scalar used in the dimensional reduction
+ * @param[in] cost the cost factor the diagonal is scaled with
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
+ * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
 __global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {

--- a/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_explicit/kernel_matrix_assembly.hip.hpp
@@ -38,14 +38,14 @@ namespace plssvm::hip::detail {
 * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) {
+__global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type *q, const real_type QA_cost, const real_type cost, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -62,7 +62,7 @@ __global__ void device_kernel_assembly(real_type *kernel_matrix_d, const real_ty
     __shared__ real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
     // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a wavefront must progress further
-    if (blockIdx.x >= blockIdx.y) {
+    if (blockIdx_x >= blockIdx_y) {
         // create a thread private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 

--- a/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
@@ -38,6 +38,8 @@ namespace plssvm::hip::detail {
  * @param[in] B the matrix @p B
  * @param[in,out] C the matrix @p C
  * @param[in] num_classes the number of classes in the data set
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>

--- a/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
@@ -41,14 +41,14 @@ namespace plssvm::hip::detail {
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_assembly_symm(const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, Args... kernel_function_parameter) {
+__global__ void device_kernel_assembly_symm(const real_type alpha, const real_type *q, const real_type *data_d, const unsigned long long num_rows, const unsigned long long device_num_rows, const unsigned long long row_offset, const unsigned long long num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const unsigned long long num_classes, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -61,7 +61,7 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
     const auto j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
     // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a wavefront must progress further
-    if (blockIdx.x >= blockIdx.y) {
+    if (blockIdx_x >= blockIdx_y) {
         // create a thread private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 

--- a/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/cg_implicit/kernel_matrix_assembly_blas.hip.hpp
@@ -47,8 +47,8 @@ __global__ void device_kernel_assembly_symm(const real_type alpha, const real_ty
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
@@ -50,7 +50,7 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
     const auto feature_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
     const auto feature_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
     const auto class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
-    const auto class_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto class_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
     // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_feature[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -64,7 +64,7 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
             const auto global_feature_idx = feature_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
-            const auto global_class_idx = class_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_class_idx = class_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
             data_cache_feature[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE_ull) + sv + threadIdx_y];  // SoA
             data_cache_alpha[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE_ull) + sv + sv_offset + threadIdx_y];       // AoS
@@ -122,7 +122,7 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
     const auto pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
     const auto pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
     const auto class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ull;
-    const auto class_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto class_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
     // create the shared memory arrays used for caching data point features
     __shared__ real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -136,7 +136,7 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
         // load data into shared memory
         for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
             const auto global_pp_idx = pp_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
-            const auto global_class_idx = class_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
+            const auto global_class_idx = class_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE_ull;
 
             // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
             data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
@@ -202,7 +202,7 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
     // calculate the indices used in the current thread
     const auto pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ull;
     const auto pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
-    const auto sv_cached_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
+    const auto sv_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ull + threadIdx_x;
 
     // create a thread private array used for internal caching
     real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
@@ -217,7 +217,7 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                 const auto global_pp_idx = pp_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
-                const auto global_sv_idx = sv_cached_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
+                const auto global_sv_idx = sv_idx_linear + static_cast<unsigned long long>(internal) * THREAD_BLOCK_SIZE;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
                 data_cache_pp[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ull) + global_pp_idx];
@@ -256,7 +256,7 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
         for (unsigned long long dim = 0; dim < num_classes; dim += FEATURE_BLOCK_SIZE_ull) {
             // load data into shared memory
             for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
-                const unsigned long long global_sv_idx = sv_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+                const unsigned long long global_sv_idx = sv_idx_linear + internal * THREAD_BLOCK_SIZE;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
                 alpha_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];

--- a/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
@@ -38,8 +38,8 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
@@ -107,8 +107,8 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -186,8 +186,8 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
     const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
     const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
     const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
@@ -263,7 +263,7 @@ __global__ void device_kernel_predict(real_type *prediction_d, const real_type *
                 alpha_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = alpha_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ull) * (num_sv + PADDING_SIZE_ull) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
-                if (blockIdx.y == 0u) {
+                if (blockIdx_y == 0ull) {
                     out_cache[threadIdx.y][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y];
                     out_cache[threadIdx.y + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + threadIdx.x] = -rho_d[dim + threadIdx_y + THREAD_BLOCK_SIZE_ull];
                 } else {

--- a/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
@@ -31,6 +31,8 @@ namespace plssvm::hip::detail {
  * @param[in] num_sv the number of support vectors
  * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -100,6 +102,8 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
  * @param[in] num_classes the number of classes
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -177,6 +181,8 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
  * @param[in] num_sv the number of support vectors
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>

--- a/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
+++ b/include/plssvm/backends/HIP/kernel/predict_kernel.hip.hpp
@@ -32,14 +32,14 @@ namespace plssvm::hip::detail {
  * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
  */
-__global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset) {
+__global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long device_specific_num_sv, const unsigned long long sv_offset, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto PADDING_SIZE_ull = static_cast<unsigned long long>(PADDING_SIZE);
@@ -101,14 +101,14 @@ __global__ void device_kernel_w_linear(real_type *w_d, const real_type *alpha_d,
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
  */
-__global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features) {
+__global__ void device_kernel_predict_linear(real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_predict_points, const unsigned long long num_features, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);
@@ -180,14 +180,14 @@ __global__ void device_kernel_predict_linear(real_type *prediction_d, const real
  * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
  */
 template <kernel_function_type kernel_function, typename... Args>
-__global__ void device_kernel_predict(real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, Args... kernel_function_parameter) {
+__global__ void device_kernel_predict(real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const unsigned long long num_classes, const unsigned long long num_sv, const unsigned long long num_predict_points, const unsigned long long num_features, const unsigned long long grid_x_offset, const unsigned long long grid_y_offset, Args... kernel_function_parameter) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
-    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);
-    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);
-    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x);
-    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y);
-    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);
-    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);
+    const auto threadIdx_x = static_cast<unsigned long long>(threadIdx.x);                // current thread in block x-dimension
+    const auto threadIdx_y = static_cast<unsigned long long>(threadIdx.y);                // current thread in block y-dimension
+    const auto blockDim_x = static_cast<unsigned long long>(blockDim.x);                  // number of threads in block x-dimension
+    const auto blockDim_y = static_cast<unsigned long long>(blockDim.y);                  // number of threads in block y-dimension
+    const auto blockIdx_x = static_cast<unsigned long long>(blockIdx.x + grid_x_offset);  // current block in grid x-dimension
+    const auto blockIdx_y = static_cast<unsigned long long>(blockIdx.y + grid_y_offset);  // current block in grid y-dimension
     const auto INTERNAL_BLOCK_SIZE_ull = static_cast<unsigned long long>(INTERNAL_BLOCK_SIZE);
     const auto THREAD_BLOCK_SIZE_ull = static_cast<unsigned long long>(THREAD_BLOCK_SIZE);
     const auto FEATURE_BLOCK_SIZE_ull = static_cast<unsigned long long>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/OpenCL/csvm.hpp
+++ b/include/plssvm/backends/OpenCL/csvm.hpp
@@ -145,6 +145,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::comma
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     * @note Uses hardcoded values: int32_t max for all dimensions on the CPU and int32_t max for the first dimension and uint16_t max for the remaining dimensions otherwise.
      */
     [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 

--- a/include/plssvm/backends/OpenCL/csvm.hpp
+++ b/include/plssvm/backends/OpenCL/csvm.hpp
@@ -147,7 +147,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::comma
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
      * @note Uses hardcoded values: int32_t max for all dimensions on the CPU and int32_t max for the first dimension and uint16_t max for the remaining dimensions otherwise.
      */
-    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const override;
 
     //***************************************************//
     //                        fit                        //

--- a/include/plssvm/backends/OpenCL/csvm.hpp
+++ b/include/plssvm/backends/OpenCL/csvm.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BACKENDS_OPENCL_CSVM_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"              // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/gpu_csvm.hpp"                     // plssvm::detail::gpu_csvm
 #include "plssvm/backends/OpenCL/detail/command_queue.hpp"  // plssvm::opencl::detail::command_queue
 #include "plssvm/backends/OpenCL/detail/context.hpp"        // plssvm::opencl::detail::context
@@ -142,6 +143,10 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::comma
      * @copydoc plssvm::detail::gpu_csvm::get_max_work_group_size
      */
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
+    /**
+     * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     */
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 
     //***************************************************//
     //                        fit                        //
@@ -149,23 +154,23 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::comma
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_blas_level_3_kernel_explicit
      */
-    void run_blas_level_3_kernel_explicit(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
+    void run_blas_level_3_kernel_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_implicit_blas_level_3
      */
-    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
+    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, const ::plssvm::detail::execution_range &exec, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_addition
      */
-    void run_inplace_matrix_addition(std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
+    void run_inplace_matrix_addition(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_scale
      */
-    void run_inplace_matrix_scale(std::size_t device_id, device_ptr_type &lhs_d, real_type scale) const override;
+    void run_inplace_matrix_scale(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, real_type scale) const override;
 
     //***************************************************//
     //                   predict, score                  //
@@ -173,11 +178,11 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::comma
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_w_kernel
      */
-    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
+    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_predict_kernel
      */
-    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
+    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
 
     /// The available OpenCL contexts for the current target platform with the associated devices.
     std::vector<detail::context> contexts_{};

--- a/include/plssvm/backends/OpenCL/detail/utility.hpp
+++ b/include/plssvm/backends/OpenCL/detail/utility.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BACKENDS_OPENCL_DETAIL_UTILITY_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"              // plssvm::detail::dim_type
 #include "plssvm/backends/OpenCL/detail/command_queue.hpp"  // plssvm::opencl::detail::command_queue
 #include "plssvm/backends/OpenCL/detail/context.hpp"        // plssvm::opencl::detail::context
 #include "plssvm/backends/OpenCL/detail/error_code.hpp"     // plssvm::opencl::detail::error_code
@@ -41,11 +42,30 @@
  * @throws plssvm::opencl::backend_exception if the error code signals a failure
  */
 #define PLSSVM_OPENCL_ERROR_CHECK(err, additional_msg)                                                                                                \
-    if (const plssvm::opencl::detail::error_code err_code{ err }; !err_code) {                                                                              \
+    if (const plssvm::opencl::detail::error_code err_code{ err }; !err_code) {                                                                        \
         throw plssvm::opencl::backend_exception{ fmt::format("OpenCL assert '{}' ({}): {}!", err_code.message(), err_code.value(), additional_msg) }; \
     }
 
 namespace plssvm::opencl::detail {
+
+/**
+ * @brief Convert a `plssvm::detail::dim_type` to a OpenCL native range, i.e., a std::vector.
+ * @tparam I the number of dimensions in the OpenCL range
+ * @param[in] dims the dimensional value to convert
+ * @return the native OpenCL range type (`[[nodiscard]]`)
+ */
+template <std::size_t I>
+[[nodiscard]] std::vector<std::size_t> dim_type_to_native(const ::plssvm::detail::dim_type &dims) {
+    if constexpr (I == 1) {
+        return { static_cast<std::size_t>(dims.x) };
+    } else if constexpr (I == 2) {
+        return { static_cast<std::size_t>(dims.x), static_cast<std::size_t>(dims.y) };
+    } else if constexpr (I == 3) {
+        return { static_cast<std::size_t>(dims.x), static_cast<std::size_t>(dims.y), static_cast<std::size_t>(dims.z) };
+    } else {
+        static_assert(I != I, "Invalid number of native OpenCL range dimension!");
+    }
+}
 
 /**
  * @brief Returns the context listing all devices matching the target platform @p target and the actually used target platform

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/blas.cl
@@ -23,6 +23,8 @@
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, const ulong device_specific_num_rows, const ulong row_offset, const real_type alpha, const __global real_type *A, const __global real_type *B, const real_type beta, __global real_type *C, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
@@ -114,6 +116,8 @@ __kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, cons
  * @param[in] B the matrix @p B
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rhs, const ulong num_mirror_rows, const ulong device_specific_num_rows, const ulong row_offset, const real_type alpha, const __global real_type *A, const __global real_type *B, const real_type beta, __global real_type *C, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
@@ -187,6 +191,8 @@ __kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rh
  * @param[in] num_cols the number of columns in both matrices
  * @param[in,out] lhs the first matrix (updated inplace)
  * @param[in] rhs the second matrix
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __kernel void device_kernel_inplace_matrix_add(const ulong num_cols, real_type __global *lhs, const real_type __global *rhs, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
@@ -216,6 +222,8 @@ __kernel void device_kernel_inplace_matrix_add(const ulong num_cols, real_type _
  * @param[in] num_cols the number of columns in the matrix
  * @param[in,out] lhs the matrix (updated inplace)
  * @param[in] scale the value to scale
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __kernel void device_kernel_inplace_matrix_scale(const ulong num_cols, real_type __global *lhs, const real_type scale, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/blas.cl
@@ -34,8 +34,8 @@ __kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, cons
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current work-item
     const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // #rhs
@@ -125,8 +125,8 @@ __kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rh
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current work-item
     const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // #rhs
@@ -194,8 +194,8 @@ __kernel void device_kernel_inplace_matrix_add(const ulong num_cols, real_type _
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // # num_rows
@@ -223,8 +223,8 @@ __kernel void device_kernel_inplace_matrix_scale(const ulong num_cols, real_type
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // # num_rows

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/blas.cl
@@ -24,16 +24,24 @@
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
-__kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, const ulong device_specific_num_rows, const ulong row_offset, const real_type alpha, const __global real_type *A, const __global real_type *B, const real_type beta, __global real_type *C) {
+__kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, const ulong device_specific_num_rows, const ulong row_offset, const real_type alpha, const __global real_type *A, const __global real_type *B, const real_type beta, __global real_type *C, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current work-item
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;  // # rhs
-    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;  // # rows
-    const ulong j_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // #rhs
+    const ulong i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;  // # row
+    const ulong j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type A_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -51,19 +59,19 @@ __kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, cons
 
             // determine on which side of the diagonal we are located
             if (dim + get_local_id(1) < global_j) {
-                A_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + get_local_id(1)) * (num_rows - row_offset + PADDING_SIZE_ul) + global_j - (dim + get_local_id(1)) * (dim + get_local_id(1) + (ulong) 1) / (ulong) 2];
+                A_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + threadIdx_y) * (num_rows - row_offset + PADDING_SIZE_ul) + global_j - (dim + threadIdx_y) * (dim + threadIdx_y + (ulong) 1) / (ulong) 2];
             } else {
-                A_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ul) + dim + get_local_id(1) - global_j * (global_j + (ulong) 1) / (ulong) 2];
+                A_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ul) + dim + threadIdx_y - global_j * (global_j + (ulong) 1) / (ulong) 2];
             }
             // determine on which side of the diagonal we are located
             if (dim + get_local_id(1) + THREAD_BLOCK_SIZE < global_j) {
-                A_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows - row_offset + PADDING_SIZE_ul) + global_j - (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul + (ulong) 1) / (ulong) 2];
+                A_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rows - row_offset + PADDING_SIZE_ul) + global_j - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (dim + threadIdx_y + THREAD_BLOCK_SIZE_ul + (ulong) 1) / (ulong) 2];
             } else {
-                A_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul - global_j * (global_j + (ulong) 1) / (ulong) 2];
+                A_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = A[global_j * (num_rows - row_offset + PADDING_SIZE_ul) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ul - global_j * (global_j + (ulong) 1) / (ulong) 2];
             }
 
-            B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + get_local_id(1)) * (num_rhs + PADDING_SIZE_ul) + global_i];
-            B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rhs + PADDING_SIZE_ul) + global_i];
+            B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + threadIdx_y) * (num_rhs + PADDING_SIZE_ul) + global_i];
+            B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rhs + PADDING_SIZE_ul) + global_i];
         }
         barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
@@ -107,16 +115,24 @@ __kernel void device_kernel_symm(const ulong num_rows, const ulong num_rhs, cons
  * @param[in] beta the scalar beta value
  * @param[in,out] C the matrix @p C, also used as result matrix
  */
-__kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rhs, const ulong num_mirror_rows, const ulong device_specific_num_rows, const ulong row_offset, const real_type alpha, const __global real_type *A, const __global real_type *B, const real_type beta, __global real_type *C) {
+__kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rhs, const ulong num_mirror_rows, const ulong device_specific_num_rows, const ulong row_offset, const real_type alpha, const __global real_type *A, const __global real_type *B, const real_type beta, __global real_type *C, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current work-item
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;  // # rhs
-    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;  // # rows
-    const ulong j_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // #rhs
+    const ulong i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;  // # row
+    const ulong j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type A_cache[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -133,10 +149,10 @@ __kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rh
             const ulong global_j = j_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
             // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-            A_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + get_local_id(1)) * (num_rows - row_offset + PADDING_SIZE_ul) - (dim + get_local_id(1) - (ulong) 1) * (dim + get_local_id(1)) / (ulong) 2 + device_specific_num_rows - (dim + get_local_id(1)) + global_j];
-            A_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows - row_offset + PADDING_SIZE_ul) - (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul - (ulong) 1) * (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) / (ulong) 2 + device_specific_num_rows - (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) + global_j];
-            B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + get_local_id(1)) * (num_rhs + PADDING_SIZE_ul) + global_i];
-            B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rhs + PADDING_SIZE_ul) + global_i];
+            A_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + threadIdx_y) * (num_rows - row_offset + PADDING_SIZE_ul) - (dim + threadIdx_y - (ulong) 1) * (dim + threadIdx_y) / (ulong) 2 + device_specific_num_rows - (dim + get_local_id(1)) + global_j];
+            A_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = A[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rows - row_offset + PADDING_SIZE_ul) - (dim + threadIdx_y + THREAD_BLOCK_SIZE_ul - (ulong) 1) * (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) / (ulong) 2 + device_specific_num_rows - (dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) + global_j];
+            B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + threadIdx_y) * (num_rhs + PADDING_SIZE_ul) + global_i];
+            B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = B[(dim + row_offset + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rhs + PADDING_SIZE_ul) + global_i];
         }
         barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
@@ -172,9 +188,18 @@ __kernel void device_kernel_symm_mirror(const ulong num_rows, const ulong num_rh
  * @param[in,out] lhs the first matrix (updated inplace)
  * @param[in] rhs the second matrix
  */
-__kernel void device_kernel_inplace_matrix_add(const ulong num_cols, real_type __global *lhs, const real_type __global *rhs) {
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;  // # num_rows
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;  // # num_rhs
+__kernel void device_kernel_inplace_matrix_add(const ulong num_cols, real_type __global *lhs, const real_type __global *rhs, const ulong grid_x_offset, const ulong grid_y_offset) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
+    // calculate the indices used in the current thread
+    const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // # num_rows
+    const ulong j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;  // # num_rhs
 
     for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {
@@ -192,9 +217,18 @@ __kernel void device_kernel_inplace_matrix_add(const ulong num_cols, real_type _
  * @param[in,out] lhs the matrix (updated inplace)
  * @param[in] scale the value to scale
  */
-__kernel void device_kernel_inplace_matrix_scale(const ulong num_cols, real_type __global *lhs, const real_type scale) {
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;  // # num_rows
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;  // # num_rhs
+__kernel void device_kernel_inplace_matrix_scale(const ulong num_cols, real_type __global *lhs, const real_type scale, const ulong grid_x_offset, const ulong grid_y_offset) {
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
+    // calculate the indices used in the current thread
+    const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;  // # num_rows
+    const ulong j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;  // # num_rhs
 
     for (uint internal_i = 0; internal_i < INTERNAL_BLOCK_SIZE; ++internal_i) {
         for (uint internal_j = 0; internal_j < INTERNAL_BLOCK_SIZE; ++internal_j) {

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
@@ -25,23 +25,31 @@
  * @param[in] cost the cost factor the diagonal is scaled with
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
  */
-__kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const __global real_type *q, const real_type QA_cost, const real_type cost PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
+__kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const __global real_type *q, const real_type QA_cost, const real_type cost, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current thread
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong j_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
     __local real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
     // only calculate the upper triangular matrix -> can't use get_local_id() since all work-items in a work-group must progress further
-    if (get_group_id(0) >= get_group_id(1)) {
+    if (blockIdx_x >= blockIdx_y) {
         // create a thread private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 
@@ -50,13 +58,13 @@ __kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const 
             // load data into local memory
             for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                 const ulong global_i = row_offset + i_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
-                const ulong global_j = row_offset + j_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
+                const ulong global_j = row_offset + j_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
-                data_cache_i[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
-                data_cache_i[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
-                data_cache_j[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
-                data_cache_j[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
+                data_cache_i[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_i[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_j[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
+                data_cache_j[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
             }
             barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
@@ -23,6 +23,8 @@
  * @param[in] q the vector used in the dimensional reduction
  * @param[in] QA_cost the scalar used in the dimensional reduction
  * @param[in] cost the cost factor the diagonal is scaled with
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!; Args... only added for Doxygen)
  */
 __kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const __global real_type *q, const real_type QA_cost, const real_type cost, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
@@ -35,8 +35,8 @@ __kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const 
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;

--- a/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_explicit/kernel_matrix_assembly.cl
@@ -23,7 +23,7 @@
  * @param[in] q the vector used in the dimensional reduction
  * @param[in] QA_cost the scalar used in the dimensional reduction
  * @param[in] cost the cost factor the diagonal is scaled with
- * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
+ * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!; Args... only added for Doxygen)
  */
 __kernel void device_kernel_assembly(__global real_type *kernel_matrix_d, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const __global real_type *q, const real_type QA_cost, const real_type cost, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions

--- a/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
@@ -29,6 +29,8 @@
  * @param[in] B the matrix @p B
  * @param[in,out] C the matrix @p C
  * @param[in] num_classes the number of classes in the data set
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!; Args... only added for Doxygen)
  */
 __kernel void device_kernel_assembly_symm(const real_type alpha, const __global real_type *q, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const real_type QA_cost, const real_type cost, const __global real_type *B, __global real_type *C, const ulong num_classes, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {

--- a/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
@@ -29,16 +29,24 @@
  * @param[in] num_classes the number of classes in the data set
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
  */
-__kernel void device_kernel_assembly_symm(const real_type alpha, const __global real_type *q, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const real_type QA_cost, const real_type cost, const __global real_type *B, __global real_type *C, const ulong num_classes PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
+__kernel void device_kernel_assembly_symm(const real_type alpha, const __global real_type *q, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const real_type QA_cost, const real_type cost, const __global real_type *B, __global real_type *C, const ulong num_classes, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current thread
-    const ulong i = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong i_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong j = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong j_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong i_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong j = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong j_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type data_cache_i[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -57,10 +65,10 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
                 const ulong global_j = row_offset + j_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-                data_cache_i[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
-                data_cache_i[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
-                data_cache_j[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1)) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
-                data_cache_j[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
+                data_cache_i[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_i[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_i];
+                data_cache_j[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
+                data_cache_j[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = data_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_rows + (ulong) 1 + PADDING_SIZE_ul) + global_j];
             }
             barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
@@ -109,8 +117,8 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
                     const ulong global_i = row_offset + i_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
                     // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-                    B_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1] = alpha * B[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)];
-                    B_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1 + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul];
+                    B_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1] = alpha * B[global_i * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y];
+                    B_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1 + THREAD_BLOCK_SIZE] = alpha * B[global_i * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ul];
                     C_out_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1] = (real_type) 0.0;
                     C_out_cache[internal * THREAD_BLOCK_SIZE + local_id_0][local_id_1 + THREAD_BLOCK_SIZE] = (real_type) 0.0;
                 }
@@ -130,8 +138,8 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
                 // add intermediate cached results to C
                 for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                     const ulong global_j = row_offset + j + (ulong) internal;
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(0)], C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal][local_id_0]);
-                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(0) + THREAD_BLOCK_SIZE_ul], C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal][local_id_0 + THREAD_BLOCK_SIZE]);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_x], C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal][local_id_0]);
+                    atomicAdd(&C[global_j * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_x + THREAD_BLOCK_SIZE_ul], C_out_cache[local_id_1 * INTERNAL_BLOCK_SIZE + internal][local_id_0 + THREAD_BLOCK_SIZE]);
                 }
                 barrier(CLK_LOCAL_MEM_FENCE);  // wai until all threads updated C with their values
             }
@@ -162,8 +170,8 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
                     const ulong global_j = row_offset + j_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
                     // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-                    B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha * B[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)];
-                    B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha * B[global_j * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul];
+                    B_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha * B[global_j * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y];
+                    B_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha * B[global_j * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ul];
                     C_out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
                     C_out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
                 }
@@ -183,8 +191,8 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
                 // add intermediate cached results to C
                 for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                     const ulong global_i = row_offset + i + (ulong) internal;
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)], C_out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0]);
-                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul], C_out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0]);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y], C_out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0]);
+                    atomicAdd(&C[global_i * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ul], C_out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0]);
                 }
                 barrier(CLK_LOCAL_MEM_FENCE);   // wait until all threads updated C with their values
             }

--- a/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
@@ -57,7 +57,7 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
     __local real_type data_cache_j[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
 
     // only calculate the upper triangular matrix -> can't use threadIdx since all threads in a warp must progress further
-    if (get_group_id(0) >= get_group_id(1)) {
+    if (blockIdx_x >= blockIdx_y) {
         // create a thread private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE] = { (real_type) 0.0 };
 

--- a/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
@@ -39,8 +39,8 @@ __kernel void device_kernel_assembly_symm(const real_type alpha, const __global 
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong i = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;

--- a/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
+++ b/include/plssvm/backends/OpenCL/kernel/cg_implicit/kernel_matrix_assembly_blas.cl
@@ -21,13 +21,15 @@
  * @param[in] q the vector used in the dimensional reduction
  * @param[in] data_d the data points to calculate the implicit kernel matrix from
  * @param[in] num_rows the number of data points
+ * @param[in] device_num_rows the number of rows the current device is responsible for
+ * @param[in] row_offset the first row in @p data_d the current device is responsible for
  * @param[in] num_features the number of features per data point
  * @param[in] QA_cost the scalar used in the dimensional reduction
  * @param[in] cost the cost factor the diagonal is scaled with
  * @param[in] B the matrix @p B
  * @param[in,out] C the matrix @p C
  * @param[in] num_classes the number of classes in the data set
- * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
+ * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!; Args... only added for Doxygen)
  */
 __kernel void device_kernel_assembly_symm(const real_type alpha, const __global real_type *q, const __global real_type *data_d, const ulong num_rows, const ulong device_num_rows, const ulong row_offset, const ulong num_features, const real_type QA_cost, const real_type cost, const __global real_type *B, __global real_type *C, const ulong num_classes, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
@@ -25,6 +25,8 @@
  * @param[in] num_sv the number of support vectors
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!; Args... only added for Doxygen)
  */
 __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d, const __global real_type *alpha_d, const __global real_type *rho_d, const __global real_type *sv_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_sv, const ulong num_predict_points, const ulong num_features, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
@@ -25,7 +25,7 @@
  * @param[in] num_sv the number of support vectors
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
- * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
+ * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!; Args... only added for Doxygen)
  */
 __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d, const __global real_type *alpha_d, const __global real_type *rho_d, const __global real_type *sv_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_sv, const ulong num_predict_points, const ulong num_features, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
@@ -37,8 +37,8 @@ __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
@@ -27,15 +27,23 @@
  * @param[in] num_features the number of features per data point
  * @param[in] PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST a placeholder that is used to string replace the correct kernel parameter (attention: no comma!)
  */
-__kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d, const __global real_type *alpha_d, const __global real_type *rho_d, const __global real_type *sv_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_sv, const ulong num_predict_points, const ulong num_features PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
+__kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d, const __global real_type *alpha_d, const __global real_type *rho_d, const __global real_type *sv_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_sv, const ulong num_predict_points, const ulong num_features, const ulong grid_x_offset, const ulong grid_y_offset PLSSVM_OPENCL_KERNEL_FUNCTION_PARAMETER_LIST) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current thread
-    const ulong pp_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong pp_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong sv_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong sv_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -52,10 +60,10 @@ __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d
             const ulong global_sv_idx = sv_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
             // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-            data_cache_pp[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1)) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
-            data_cache_pp[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
-            data_cache_sv[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[(dim + get_local_id(1)) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
-            data_cache_sv[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
+            data_cache_pp[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_pp[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_sv[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
+            data_cache_sv[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
         }
         barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
@@ -89,13 +97,13 @@ __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d
                 const ulong global_sv_idx = sv_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-                alpha_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + get_local_id(1)) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
-                alpha_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
+                alpha_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + threadIdx_y) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
+                alpha_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
                 if (get_group_id(1) == (ulong) 0) {
-                    out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + get_local_id(1)];
-                    out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul];
+                    out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + threadIdx_y];
+                    out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + threadIdx_y + THREAD_BLOCK_SIZE_ul];
                 } else {
                     out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
                     out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = (real_type) 0.0;
@@ -118,8 +126,8 @@ __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d
             for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                 const ulong global_pp_idx = pp_idx + (ulong) internal;
 
-                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1)], out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0]);
-                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul], out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y], out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0]);
+                atomicAdd(&prediction_d[global_pp_idx * (num_classes + PADDING_SIZE_ul) + dim + threadIdx_y + THREAD_BLOCK_SIZE_ul], out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0]);
             }
             barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items updated their part of the prediction
         }

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel.cl
@@ -103,7 +103,7 @@ __kernel void PLSSVM_DEVICE_KERNEL_PREDICT_NAME(__global real_type *prediction_d
                 alpha_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_sv + PADDING_SIZE_ul) + global_sv_idx];
 
                 // the bias (rho) must only be applied once for all support vectors
-                if (get_group_id(1) == (ulong) 0) {
+                if (blockIdx_y == (ulong) 0) {
                     out_cache[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + threadIdx_y];
                     out_cache[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = -rho_d[dim + threadIdx_y + THREAD_BLOCK_SIZE_ul];
                 } else {

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
@@ -23,16 +23,24 @@
  * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
  */
-__kernel void device_kernel_w_linear(__global real_type *w_d, const __global real_type *alpha_d, const __global real_type *sv_d, const ulong num_classes, const ulong num_sv, const ulong device_specific_num_sv, const ulong sv_offset) {
+__kernel void device_kernel_w_linear(__global real_type *w_d, const __global real_type *alpha_d, const __global real_type *sv_d, const ulong num_classes, const ulong num_sv, const ulong device_specific_num_sv, const ulong sv_offset, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current thread
-    const ulong feature_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong feature_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong class_idx = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong class_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong feature_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong feature_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong class_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type data_cache_feature[THREAD_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -46,10 +54,10 @@ __kernel void device_kernel_w_linear(__global real_type *w_d, const __global rea
         // load data into local memory
         for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
             const ulong global_feature_idx = feature_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
-            const ulong global_class_idx = class_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
+            const ulong global_class_idx = class_idx_linear + (ulong) internal * THREAD_BLOCK_SIZE_ul;
 
-            data_cache_feature[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE_ul) + sv + get_local_id(1)];  // SoA
-            data_cache_alpha[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE_ul) + sv + sv_offset + get_local_id(1)];       // AoS
+            data_cache_feature[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = sv_d[global_feature_idx * (device_specific_num_sv + PADDING_SIZE_ul) + sv + threadIdx_y];  // SoA
+            data_cache_alpha[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = alpha_d[global_class_idx * (num_sv + PADDING_SIZE_ul) + sv + sv_offset + threadIdx_y];       // AoS
         }
         barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 
@@ -85,16 +93,24 @@ __kernel void device_kernel_w_linear(__global real_type *w_d, const __global rea
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
  */
-__kernel void device_kernel_predict_linear(__global real_type *prediction_d, const __global real_type *w_d, const __global real_type *rho_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_predict_points, const ulong num_features) {
+__kernel void device_kernel_predict_linear(__global real_type *prediction_d, const __global real_type *w_d, const __global real_type *rho_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_predict_points, const ulong num_features, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
     const uint local_id_0 = get_local_id(0);
     const uint local_id_1 = get_local_id(1);
 
+    // cast all values to 64-bit unsigned long long to prevent potential 32-bit overflows
+    const ulong threadIdx_x = get_local_id(0);                 // current thread in block x-dimension
+    const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
+    const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
+    const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+
     // calculate the indices used in the current thread
-    const ulong pp_idx = get_global_id(0) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong pp_idx_linear = get_group_id(0) * get_local_size(0) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
-    const ulong class_idx = get_global_id(1) * INTERNAL_BLOCK_SIZE_ul;
-    const ulong class_cached_idx_linear = get_group_id(1) * get_local_size(1) * INTERNAL_BLOCK_SIZE_ul + get_local_id(0);
+    const ulong pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong pp_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
+    const ulong class_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_ul;
+    const ulong class_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_ul + threadIdx_x;
 
     // create the local memory arrays used for caching data point features
     __local real_type data_cache_pp[FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE];
@@ -108,13 +124,13 @@ __kernel void device_kernel_predict_linear(__global real_type *prediction_d, con
         // load data into local memory
         for (uint internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
             const ulong global_pp_idx = pp_idx_linear + internal * THREAD_BLOCK_SIZE;
-            const ulong global_class_idx = class_cached_idx_linear + internal * THREAD_BLOCK_SIZE;
+            const ulong global_class_idx = class_idx_linear + internal * THREAD_BLOCK_SIZE;
 
             // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-            data_cache_pp[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1)) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
-            data_cache_pp[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
-            data_cache_w[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = w_d[(dim + get_local_id(1)) * (num_classes + PADDING_SIZE_ul) + global_class_idx];
-            data_cache_w[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = w_d[(dim + get_local_id(1) + THREAD_BLOCK_SIZE_ul) * (num_classes + PADDING_SIZE_ul) + global_class_idx];
+            data_cache_pp[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + threadIdx_y) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_pp[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = predict_points_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_predict_points + PADDING_SIZE_ul) + global_pp_idx];
+            data_cache_w[local_id_1][internal * THREAD_BLOCK_SIZE + local_id_0] = w_d[(dim + threadIdx_y) * (num_classes + PADDING_SIZE_ul) + global_class_idx];
+            data_cache_w[local_id_1 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_0] = w_d[(dim + threadIdx_y + THREAD_BLOCK_SIZE_ul) * (num_classes + PADDING_SIZE_ul) + global_class_idx];
         }
         barrier(CLK_LOCAL_MEM_FENCE);  // wait until all work-items loaded their part of the data
 

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
@@ -33,8 +33,8 @@ __kernel void device_kernel_w_linear(__global real_type *w_d, const __global rea
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong feature_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;
@@ -103,8 +103,8 @@ __kernel void device_kernel_predict_linear(__global real_type *prediction_d, con
     const ulong threadIdx_y = get_local_id(1);                 // current thread in block y-dimension
     const ulong blockDim_x = get_local_size(0);                // number of threads in block x-dimension
     const ulong blockDim_y = get_local_size(1);                // number of threads in block y-dimension
-    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension
-    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension
+    const ulong blockIdx_x = get_group_id(0) + grid_x_offset;  // current block in grid x-dimension + offsets if the grid size would be too large
+    const ulong blockIdx_y = get_group_id(1) + grid_y_offset;  // current block in grid y-dimension + offsets if the grid size would be too large
 
     // calculate the indices used in the current thread
     const ulong pp_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_ul;

--- a/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
+++ b/include/plssvm/backends/OpenCL/kernel/predict_kernel_linear.cl
@@ -22,6 +22,8 @@
  * @param[in] num_sv the number of support vectors
  * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
  * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __kernel void device_kernel_w_linear(__global real_type *w_d, const __global real_type *alpha_d, const __global real_type *sv_d, const ulong num_classes, const ulong num_sv, const ulong device_specific_num_sv, const ulong sv_offset, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions
@@ -92,6 +94,8 @@ __kernel void device_kernel_w_linear(__global real_type *w_d, const __global rea
  * @param[in] num_classes the number of classes
  * @param[in] num_predict_points the number of data points to predict
  * @param[in] num_features the number of features per data point
+ * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+ * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
  */
 __kernel void device_kernel_predict_linear(__global real_type *prediction_d, const __global real_type *w_d, const __global real_type *rho_d, const __global real_type *predict_points_d, const ulong num_classes, const ulong num_predict_points, const ulong num_features, const ulong grid_x_offset, const ulong grid_y_offset) {
     // cast values to 32-bit unsigned int values to prevent implicit conversions

--- a/include/plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp
+++ b/include/plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp
@@ -160,7 +160,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
      * @note Uses hardcoded values: int32_t max for all dimensions on the CPU and int32_t max for the first dimension and uint16_t max for the remaining dimensions otherwise.
      */
-    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const override;
 
     //***************************************************//
     //                        fit                        //

--- a/include/plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp
+++ b/include/plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BACKENDS_SYCL_ADAPTIVECPP_CSVM_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"                        // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/gpu_csvm.hpp"                               // plssvm::detail::gpu_csvm
 #include "plssvm/backends/SYCL/AdaptiveCpp/detail/device_ptr.hpp"     // plssvm::adaptivecpp::detail::device_ptr
 #include "plssvm/backends/SYCL/AdaptiveCpp/detail/pinned_memory.hpp"  // plssvm::adaptivecpp::detail::pinned_memory
@@ -155,6 +156,10 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
      * @copydoc plssvm::detail::gpu_csvm::get_max_work_group_size
      */
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
+    /**
+     * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     */
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 
     //***************************************************//
     //                        fit                        //
@@ -162,23 +167,23 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_blas_level_3_kernel_explicit
      */
-    void run_blas_level_3_kernel_explicit(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
+    void run_blas_level_3_kernel_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_implicit_blas_level_3
      */
-    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
+    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, const ::plssvm::detail::execution_range &exec, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_addition
      */
-    void run_inplace_matrix_addition(std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
+    void run_inplace_matrix_addition(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_scale
      */
-    void run_inplace_matrix_scale(std::size_t device_id, device_ptr_type &lhs_d, real_type scale) const override;
+    void run_inplace_matrix_scale(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, real_type scale) const override;
 
     //***************************************************//
     //                   predict, score                  //
@@ -186,11 +191,11 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_w_kernel
      */
-    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
+    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_predict_kernel
      */
-    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
+    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
 
     /// The SYCL kernel invocation type for the svm kernel.
     sycl::kernel_invocation_type invocation_type_{ sycl::kernel_invocation_type::automatic };

--- a/include/plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp
+++ b/include/plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp
@@ -158,6 +158,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     * @note Uses hardcoded values: int32_t max for all dimensions on the CPU and int32_t max for the first dimension and uint16_t max for the remaining dimensions otherwise.
      */
     [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 

--- a/include/plssvm/backends/SYCL/AdaptiveCpp/detail/utility.hpp
+++ b/include/plssvm/backends/SYCL/AdaptiveCpp/detail/utility.hpp
@@ -13,14 +13,38 @@
 #define PLSSVM_BACKENDS_SYCL_ADAPTIVECPP_DETAIL_UTILITY_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"                // plssvm::detail::dim_type
 #include "plssvm/backends/SYCL/AdaptiveCpp/detail/queue.hpp"  // plssvm::adaptivecpp::detail::queue (PImpl)
 #include "plssvm/target_platforms.hpp"                        // plssvm::target_platform
+
+#include "sycl/sycl.hpp"  // sycl::range
 
 #include <string>   // std::string
 #include <utility>  // std::pair
 #include <vector>   // std::vector
 
 namespace plssvm::adaptivecpp::detail {
+
+/**
+ * @brief Convert a `plssvm::detail::dim_type` to a SYCL native range.
+ * @tparam I the number of dimensions in the SYCL range
+ * @param[in] dims the dimensional value to convert
+ * @note Inverts the dimensions to account for SYCL's different iteration range!
+ * @return the native SYCL range type (`[[nodiscard]]`)
+ */
+template <std::size_t I>
+[[nodiscard]] ::sycl::range<I> dim_type_to_native(const ::plssvm::detail::dim_type &dims) {
+    // note: invert order to account for SYCL's different iteration range
+    if constexpr (I == 1) {
+        return ::sycl::range<I>{ static_cast<std::size_t>(dims.x) };
+    } else if constexpr (I == 2) {
+        return ::sycl::range<I>{ static_cast<std::size_t>(dims.y), static_cast<std::size_t>(dims.x) };
+    } else if constexpr (I == 3) {
+        return ::sycl::range<I>{ static_cast<std::size_t>(dims.z), static_cast<std::size_t>(dims.y), static_cast<std::size_t>(dims.x) };
+    } else {
+        static_assert(I != I, "Invalid number of native sycl::range dimension!");
+    }
+}
 
 /**
  * @brief Returns the list devices matching the target platform @p target and the actually used target platform

--- a/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
+++ b/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
@@ -32,6 +32,7 @@
 #include <cstddef>      // std::size_t
 #include <type_traits>  // std::is_same_v, std::true_type
 #include <utility>      // std::forward
+#include <vector>       // std::vector
 
 namespace plssvm {
 

--- a/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
+++ b/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
@@ -160,7 +160,7 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
      * @note Uses the DPC++ experimental extension `sycl::ext::oneapi::experimental::info::device::max_work_groups` if the feature test macro `SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY` is defined,
      *       otherwise it uses hardcoded values (int32_t max for all dimensions on the CPU and int32_t max for the first dimension and uint16_t max for the remaining dimensions otherwise).
      */
-    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const override;
 
     //***************************************************//
     //                        fit                        //

--- a/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
+++ b/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
@@ -13,6 +13,7 @@
 #define PLSSVM_BACKENDS_SYCL_DPCPP_CSVM_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"                  // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/gpu_csvm.hpp"                         // plssvm::detail::gpu_csvm
 #include "plssvm/backends/SYCL/DPCPP/detail/device_ptr.hpp"     // plssvm::dpcpp::detail::device_ptr
 #include "plssvm/backends/SYCL/DPCPP/detail/pinned_memory.hpp"  // plssvm::dpcpp::detail::pinned_memory
@@ -153,6 +154,10 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
      * @copydoc plssvm::detail::gpu_csvm::get_max_work_group_size
      */
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
+    /**
+     * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     */
+    [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 
     //***************************************************//
     //                        fit                        //
@@ -160,23 +165,23 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_explicit
      */
-    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
+    [[nodiscard]] device_ptr_type run_assemble_kernel_matrix_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_blas_level_3_kernel_explicit
      */
-    void run_blas_level_3_kernel_explicit(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
+    void run_blas_level_3_kernel_explicit(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, real_type beta, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_assemble_kernel_matrix_implicit_blas_level_3
      */
-    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
+    void run_assemble_kernel_matrix_implicit_blas_level_3(std::size_t device_id, const ::plssvm::detail::execution_range &exec, real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red_d, real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_addition
      */
-    void run_inplace_matrix_addition(std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
+    void run_inplace_matrix_addition(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const override;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_inplace_matrix_scale
      */
-    void run_inplace_matrix_scale(std::size_t device_id, device_ptr_type &lhs_d, real_type scale) const override;
+    void run_inplace_matrix_scale(std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, real_type scale) const override;
 
     //***************************************************//
     //                   predict, score                  //
@@ -184,11 +189,11 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_w_kernel
      */
-    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
+    [[nodiscard]] device_ptr_type run_w_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::run_predict_kernel
      */
-    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
+    [[nodiscard]] device_ptr_type run_predict_kernel(std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const final;
 
     /// The SYCL kernel invocation type for the svm kernel.
     sycl::kernel_invocation_type invocation_type_{ sycl::kernel_invocation_type::automatic };

--- a/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
+++ b/include/plssvm/backends/SYCL/DPCPP/csvm.hpp
@@ -157,6 +157,8 @@ class csvm : public ::plssvm::detail::gpu_csvm<detail::device_ptr, detail::queue
     [[nodiscard]] std::size_t get_max_work_group_size(std::size_t device_id) const final;
     /**
      * @copydoc plssvm::detail::gpu_csvm::get_max_grid_size
+     * @note Uses the DPC++ experimental extension `sycl::ext::oneapi::experimental::info::device::max_work_groups` if the feature test macro `SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY` is defined,
+     *       otherwise it uses hardcoded values (int32_t max for all dimensions on the CPU and int32_t max for the first dimension and uint16_t max for the remaining dimensions otherwise).
      */
     [[nodiscard]] ::plssvm::detail::dim_type get_max_grid_size(std::size_t device_id) const final;
 

--- a/include/plssvm/backends/SYCL/DPCPP/detail/utility.hpp
+++ b/include/plssvm/backends/SYCL/DPCPP/detail/utility.hpp
@@ -13,14 +13,39 @@
 #define PLSSVM_BACKENDS_SYCL_DPCPP_DETAIL_UTILITY_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"          // plssvm::detail::dim_type
 #include "plssvm/backends/SYCL/DPCPP/detail/queue.hpp"  // plssvm::dpcpp::detail::queue (PImpl)
 #include "plssvm/target_platforms.hpp"                  // plssvm::target_platform
 
+#include "sycl/sycl.hpp"  // sycl::range
+
+#include <cstddef>  // std::size_t
 #include <string>   // std::string
 #include <utility>  // std::pair
 #include <vector>   // std::vector
 
 namespace plssvm::dpcpp::detail {
+
+/**
+ * @brief Convert a `plssvm::detail::dim_type` to a SYCL native range.
+ * @tparam I the number of dimensions in the SYCL range
+ * @param[in] dims the dimensional value to convert
+ * @note Inverts the dimensions to account for SYCL's different iteration range!
+ * @return the native SYCL range type (`[[nodiscard]]`)
+ */
+template <std::size_t I>
+[[nodiscard]] ::sycl::range<I> dim_type_to_native(const ::plssvm::detail::dim_type &dims) {
+    // note: invert order to account for SYCL's different iteration range
+    if constexpr (I == 1) {
+        return ::sycl::range<I>{ static_cast<std::size_t>(dims.x) };
+    } else if constexpr (I == 2) {
+        return ::sycl::range<I>{ static_cast<std::size_t>(dims.y), static_cast<std::size_t>(dims.x) };
+    } else if constexpr (I == 3) {
+        return ::sycl::range<I>{ static_cast<std::size_t>(dims.z), static_cast<std::size_t>(dims.y), static_cast<std::size_t>(dims.x) };
+    } else {
+        static_assert(I != I, "Invalid number of native sycl::range dimension!");
+    }
+}
 
 /**
  * @brief Returns the list devices matching the target platform @p target and the actually used target platform

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
@@ -38,6 +38,8 @@ class device_kernel_symm {
      * @param[in] B the matrix @p B
      * @param[in] beta the scalar beta value
      * @param[in,out] C the matrix @p C, also used as result matrix
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      */
     device_kernel_symm(::sycl::handler &cgh, const std::size_t num_rows, const std::size_t num_rhs, const std::size_t device_specific_num_rows, const std::size_t row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         A_cache_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
@@ -175,6 +177,8 @@ class device_kernel_symm_mirror {
      * @param[in] B the matrix @p B
      * @param[in] beta the scalar beta value
      * @param[in,out] C the matrix @p C, also used as result matrix
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      */
     device_kernel_symm_mirror(::sycl::handler &cgh, const std::size_t num_rows, const std::size_t num_rhs, const std::size_t num_mirror_rows, const std::size_t device_specific_num_rows, const std::size_t row_offset, const real_type alpha, const real_type *A, const real_type *B, const real_type beta, real_type *C, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         A_cache_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
@@ -296,6 +300,8 @@ class device_kernel_inplace_matrix_add {
      * @param[in] num_cols the number of columns in both matrices
      * @param[in,out] lhs the first matrix (updated inplace)
      * @param[in] rhs the second matrix
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      */
     device_kernel_inplace_matrix_add(const std::size_t num_cols, real_type *lhs, const real_type *rhs, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         num_cols_{ num_cols },
@@ -353,6 +359,8 @@ class device_kernel_inplace_matrix_scale {
      * @param[in] num_cols the number of columns in the matrix
      * @param[in,out] lhs the first matrix (updated inplace)
      * @param[in] scale the value to scale
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      */
     device_kernel_inplace_matrix_scale(const std::size_t num_cols, real_type *lhs, const real_type scale, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         num_cols_{ num_cols },

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/blas.hpp
@@ -64,12 +64,12 @@ class device_kernel_symm {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
@@ -202,12 +202,12 @@ class device_kernel_symm_mirror {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
@@ -310,12 +310,12 @@ class device_kernel_inplace_matrix_add {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
@@ -367,12 +367,12 @@ class device_kernel_inplace_matrix_scale {
      */
     void operator()(::sycl::nd_item<2> nd_idx) const {
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
@@ -44,6 +44,8 @@ class device_kernel_assembly {
      * @param[in] q the vector used in the dimensional reduction
      * @param[in] QA_cost the scalar used in the dimensional reduction
      * @param[in] cost the cost factor the diagonal is scaled with
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
     device_kernel_assembly(::sycl::handler &cgh, real_type *kernel_matrix_d, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type *q, const real_type QA_cost, const real_type cost, const std::size_t grid_x_offset, const std::size_t grid_y_offset, Args... kernel_function_parameter) :

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
@@ -73,12 +73,12 @@ class device_kernel_assembly {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_explicit/kernel_matrix_assembly.hpp
@@ -46,7 +46,7 @@ class device_kernel_assembly {
      * @param[in] cost the cost factor the diagonal is scaled with
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
-    device_kernel_assembly(::sycl::handler &cgh, real_type *kernel_matrix_d, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type *q, const real_type QA_cost, const real_type cost, Args... kernel_function_parameter) :
+    device_kernel_assembly(::sycl::handler &cgh, real_type *kernel_matrix_d, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type *q, const real_type QA_cost, const real_type cost, const std::size_t grid_x_offset, const std::size_t grid_y_offset, Args... kernel_function_parameter) :
         data_cache_i_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         data_cache_j_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         kernel_matrix_d_{ kernel_matrix_d },
@@ -58,6 +58,8 @@ class device_kernel_assembly {
         q_{ q },
         QA_cost_{ QA_cost },
         cost_{ cost },
+        grid_x_offset_{ grid_x_offset },
+        grid_y_offset_{ grid_y_offset },
         kernel_function_parameter_{ std::make_tuple(std::forward<Args>(kernel_function_parameter)...) } {
     }
 
@@ -71,19 +73,25 @@ class device_kernel_assembly {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
+        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
+        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
+        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
+        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
+        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
         // calculate the indices used in the current work-item
-        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
-        const auto i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
-        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
-        const auto j_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto i = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_uz;
+        const auto i_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
+        const auto j = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_uz;
+        const auto j_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
 
         // only calculate the upper triangular matrix -> can't use get_local_id() since all work-items in a work-group must progress further
-        if (nd_idx.get_group(1) >= nd_idx.get_group(0)) {
+        if (blockIdx_y >= blockIdx_x) {
             // create a work-item private array used for internal caching
             real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
@@ -95,10 +103,10 @@ class device_kernel_assembly {
                     const auto global_j = row_offset_ + j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                     // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
-                    data_cache_i_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
-                    data_cache_i_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
-                    data_cache_j_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
-                    data_cache_j_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
+                    data_cache_i_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                    data_cache_i_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                    data_cache_j_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
+                    data_cache_j_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
                 }
                 nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
@@ -155,6 +163,8 @@ class device_kernel_assembly {
     const real_type *q_;
     const real_type QA_cost_;
     const real_type cost_;
+    const std::size_t grid_x_offset_;
+    const std::size_t grid_y_offset_;
     const std::tuple<Args...> kernel_function_parameter_;
     /// @endcond
 };

--- a/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
@@ -79,12 +79,12 @@ class device_kernel_assembly_symm {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
@@ -48,6 +48,8 @@ class device_kernel_assembly_symm {
      * @param[in] B the matrix @p B
      * @param[in,out] C the matrix @p C
      * @param[in] num_classes the number of classes in the data set
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
     device_kernel_assembly_symm(::sycl::handler &cgh, const real_type alpha, const real_type *q, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const std::size_t num_classes, const std::size_t grid_x_offset, const std::size_t grid_y_offset, Args... kernel_function_parameter) :

--- a/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
+++ b/include/plssvm/backends/SYCL/kernel/cg_implicit/kernel_matrix_assembly_blas.hpp
@@ -50,7 +50,7 @@ class device_kernel_assembly_symm {
      * @param[in] num_classes the number of classes in the data set
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
-    device_kernel_assembly_symm(::sycl::handler &cgh, const real_type alpha, const real_type *q, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const std::size_t num_classes, Args... kernel_function_parameter) :
+    device_kernel_assembly_symm(::sycl::handler &cgh, const real_type alpha, const real_type *q, const real_type *data_d, const std::size_t num_rows, const std::size_t device_num_rows, const std::size_t row_offset, const std::size_t num_features, const real_type QA_cost, const real_type cost, const real_type *B, real_type *C, const std::size_t num_classes, const std::size_t grid_x_offset, const std::size_t grid_y_offset, Args... kernel_function_parameter) :
         data_cache_i_{ ::sycl::range<1>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE) * static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
         data_cache_j_{ ::sycl::range<1>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE) * static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },  // [FEATURE_BLOCK_SIZE][INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE]
         alpha_{ alpha },
@@ -65,6 +65,8 @@ class device_kernel_assembly_symm {
         B_{ B },
         C_{ C },
         num_classes_{ num_classes },
+        grid_x_offset_{ grid_x_offset },
+        grid_y_offset_{ grid_y_offset },
         kernel_function_parameter_{ std::make_tuple(std::forward<Args>(kernel_function_parameter)...) } { }
 
     /**
@@ -77,19 +79,25 @@ class device_kernel_assembly_symm {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
+        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
+        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
+        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
+        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
+        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
         // calculate the indices used in the current work-item
-        const auto i = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
-        const auto i_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
-        const auto j = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
-        const auto j_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto i = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_uz;
+        const auto i_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
+        const auto j = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_uz;
+        const auto j_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
 
         // only calculate the upper triangular matrix -> can't use get_local_id() since all work-items in a work-group must progress further
-        if (nd_idx.get_group(1) >= nd_idx.get_group(0)) {
+        if (blockIdx_y >= blockIdx_x) {
             // create a work-item private array used for internal caching
             real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
 
@@ -102,10 +110,10 @@ class device_kernel_assembly_symm {
                         const auto global_j = row_offset_ + j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                         // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
-                        data_cache_i_[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
-                        data_cache_i_[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
-                        data_cache_j_[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0)) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
-                        data_cache_j_[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
+                        data_cache_i_[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                        data_cache_i_[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_i];
+                        data_cache_j_[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
+                        data_cache_j_[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = data_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_rows_ + std::size_t{ 1 } + PADDING_SIZE_uz) + global_j];
                     }
                     nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
@@ -157,8 +165,8 @@ class device_kernel_assembly_symm {
                         const std::size_t global_i = row_offset_ + i_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                         // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
-                        B_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)];
-                        B_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0 + THREAD_BLOCK_SIZE] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz];
+                        B_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x];
+                        B_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0 + THREAD_BLOCK_SIZE] = alpha_ * B_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x + THREAD_BLOCK_SIZE_uz];
                         C_out_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0] = real_type{ 0.0 };
                         C_out_cache[(internal * THREAD_BLOCK_SIZE + local_id_1) * FEATURE_BLOCK_SIZE + local_id_0 + THREAD_BLOCK_SIZE] = real_type{ 0.0 };
                     }
@@ -178,8 +186,8 @@ class device_kernel_assembly_symm {
                     // add intermediate cached results to C
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                         const auto global_j = row_offset_ + j + static_cast<std::size_t>(internal);
-                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(1)] } += C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + local_id_1];
-                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(1) + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + local_id_1 + THREAD_BLOCK_SIZE];
+                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_y] } += C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + local_id_1];
+                        detail::atomic_op<real_type>{ C_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_y + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 * INTERNAL_BLOCK_SIZE + internal) * FEATURE_BLOCK_SIZE + local_id_1 + THREAD_BLOCK_SIZE];
                     }
                     nd_idx.barrier();  // wai until all work-items updated C with their values
                 }
@@ -210,8 +218,8 @@ class device_kernel_assembly_symm {
                         const auto global_j = row_offset_ + j_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                         // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-                        B_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)];
-                        B_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz];
+                        B_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x];
+                        B_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_ * B_[global_j * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x + THREAD_BLOCK_SIZE_uz];
                         C_out_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
                         C_out_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
                     }
@@ -231,8 +239,8 @@ class device_kernel_assembly_symm {
                     // add intermediate cached results to C
                     for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                         const auto global_i = row_offset_ + i + static_cast<std::size_t>(internal);
-                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)] } += C_out_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
-                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
+                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x] } += C_out_cache[local_id_0 * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
+                        detail::atomic_op<real_type>{ C_[global_i * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x + THREAD_BLOCK_SIZE_uz] } += C_out_cache[(local_id_0 + THREAD_BLOCK_SIZE) * INTERNAL_BLOCK_SIZE * THREAD_BLOCK_SIZE + internal * THREAD_BLOCK_SIZE + local_id_1];
                     }
                     nd_idx.barrier();  // wait until all threads updated C with their values
                 }
@@ -259,6 +267,8 @@ class device_kernel_assembly_symm {
     const real_type *B_;
     real_type *C_;
     const std::size_t num_classes_;
+    const std::size_t grid_x_offset_;
+    const std::size_t grid_y_offset_;
     const std::tuple<Args...> kernel_function_parameter_;
     /// @endcond
 };

--- a/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
+++ b/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
@@ -40,6 +40,8 @@ class device_kernel_w_linear {
      * @param[in] num_sv the number of support vectors
      * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
      * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      */
     device_kernel_w_linear(::sycl::handler &cgh, real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t device_specific_num_sv, const std::size_t sv_offset, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         data_cache_feature_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
@@ -151,6 +153,8 @@ class device_kernel_predict_linear {
      * @param[in] num_classes the number of classes
      * @param[in] num_predict_points the number of data points to predict
      * @param[in] num_features the number of features per data point
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      */
     device_kernel_predict_linear(::sycl::handler &cgh, real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_predict_points, const std::size_t num_features, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         data_cache_pp_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
@@ -271,6 +275,8 @@ class device_kernel_predict {
      * @param[in] num_sv the number of support vectors
      * @param[in] num_predict_points the number of data points to predict
      * @param[in] num_features the number of features per data point
+     * @param[in] grid_x_offset the offset in x-dimension into the data points if more than one execution grid has to be used
+     * @param[in] grid_y_offset the offset in y-dimension into the data points if more than one execution grid has to be used
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
     device_kernel_predict(::sycl::handler &cgh, real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t num_predict_points, const std::size_t num_features, const std::size_t grid_x_offset, const std::size_t grid_y_offset, Args... kernel_function_parameter) :

--- a/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
+++ b/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
@@ -64,12 +64,12 @@ class device_kernel_w_linear {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
@@ -175,12 +175,12 @@ class device_kernel_predict_linear {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
@@ -299,12 +299,12 @@ class device_kernel_predict {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
-        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
-        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
-        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
-        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
-        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
-        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
+        const std::size_t threadIdx_x = nd_idx.get_local_id(0);               // current thread in block x-dimension
+        const std::size_t threadIdx_y = nd_idx.get_local_id(1);               // current thread in block y-dimension
+        const std::size_t blockDim_x = nd_idx.get_local_range(0);             // number of threads in block x-dimension
+        const std::size_t blockDim_y = nd_idx.get_local_range(1);             // number of threads in block y-dimension
+        const std::size_t blockIdx_x = nd_idx.get_group(0) + grid_x_offset_;  // current block in grid x-dimension + offsets if the grid size would be too large
+        const std::size_t blockIdx_y = nd_idx.get_group(1) + grid_y_offset_;  // current block in grid y-dimension + offsets if the grid size would be too large
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);

--- a/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
+++ b/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
@@ -375,7 +375,7 @@ class device_kernel_predict {
                     alpha_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
 
                     // the bias (rho) must only be applied once for all support vectors
-                    if (nd_idx.get_group(0) == std::size_t{ 0 }) {
+                    if (blockIdx_x == std::size_t{ 0 }) {
                         out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + threadIdx_x];
                         out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + threadIdx_x + THREAD_BLOCK_SIZE_uz];
                     } else {

--- a/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
+++ b/include/plssvm/backends/SYCL/kernel/predict_kernel.hpp
@@ -41,7 +41,7 @@ class device_kernel_w_linear {
      * @param[in] device_specific_num_sv the number of support vectors the current device is responsible for
      * @param[in] sv_offset the first support vector (row in @p alpha_d) the current device is responsible for
      */
-    device_kernel_w_linear(::sycl::handler &cgh, real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t device_specific_num_sv, const std::size_t sv_offset) :
+    device_kernel_w_linear(::sycl::handler &cgh, real_type *w_d, const real_type *alpha_d, const real_type *sv_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t device_specific_num_sv, const std::size_t sv_offset, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         data_cache_feature_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         data_cache_alpha_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         w_d_{ w_d },
@@ -50,7 +50,9 @@ class device_kernel_w_linear {
         num_classes_{ num_classes },
         num_sv_{ num_sv },
         device_specific_num_sv_{ device_specific_num_sv },
-        sv_offset_{ sv_offset } { }
+        sv_offset_{ sv_offset },
+        grid_x_offset_{ grid_x_offset },
+        grid_y_offset_{ grid_y_offset } { }
 
     /**
      * @brief Function call operator overload performing the actual calculation.
@@ -62,15 +64,21 @@ class device_kernel_w_linear {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
+        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
+        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
+        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
+        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
+        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
         // calculate the indices used in the current work-item
-        const auto feature_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
-        const auto feature_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
-        const auto class_idx = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
-        const auto class_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto feature_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_uz;
+        const auto feature_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
+        const auto class_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_uz;
+        const auto class_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
 
         // create a work-item private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
@@ -82,8 +90,8 @@ class device_kernel_w_linear {
                 const auto global_class_idx = class_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
                 const auto global_feature_idx = feature_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                data_cache_feature_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[global_feature_idx * (device_specific_num_sv_ + PADDING_SIZE_uz) + sv + sv_offset_ + nd_idx.get_local_id(0)];  // SoA
-                data_cache_alpha_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[global_class_idx * (num_sv_ + PADDING_SIZE_uz) + sv + nd_idx.get_local_id(0)];                                // AoS
+                data_cache_feature_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[global_feature_idx * (device_specific_num_sv_ + PADDING_SIZE_uz) + sv + sv_offset_ + threadIdx_x];  // SoA
+                data_cache_alpha_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[global_class_idx * (num_sv_ + PADDING_SIZE_uz) + sv + threadIdx_x];                                // AoS
             }
             nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
@@ -123,6 +131,8 @@ class device_kernel_w_linear {
     const std::size_t num_sv_;
     const std::size_t device_specific_num_sv_;
     const std::size_t sv_offset_;
+    const std::size_t grid_x_offset_;
+    const std::size_t grid_y_offset_;
     /// @endcond
 };
 
@@ -142,7 +152,7 @@ class device_kernel_predict_linear {
      * @param[in] num_predict_points the number of data points to predict
      * @param[in] num_features the number of features per data point
      */
-    device_kernel_predict_linear(::sycl::handler &cgh, real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_predict_points, const std::size_t num_features) :
+    device_kernel_predict_linear(::sycl::handler &cgh, real_type *prediction_d, const real_type *w_d, const real_type *rho_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_predict_points, const std::size_t num_features, const std::size_t grid_x_offset, const std::size_t grid_y_offset) :
         data_cache_pp_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         data_cache_w_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         prediction_d_{ prediction_d },
@@ -151,7 +161,9 @@ class device_kernel_predict_linear {
         predict_points_d_{ predict_points_d },
         num_classes_{ num_classes },
         num_predict_points_{ num_predict_points },
-        num_features_{ num_features } { }
+        num_features_{ num_features },
+        grid_x_offset_{ grid_x_offset },
+        grid_y_offset_{ grid_y_offset } { }
 
     /**
      * @brief Function call operator overload performing the actual calculation.
@@ -163,16 +175,22 @@ class device_kernel_predict_linear {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
+        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
+        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
+        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
+        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
+        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
         // calculate the indices used in the current work-item
-        const auto pp_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
-        const auto pp_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
-        const auto class_idx = nd_idx.get_global_id(0) * INTERNAL_BLOCK_SIZE_uz;
-        const auto class_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto pp_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_uz;
+        const auto pp_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
+        const auto class_idx = (blockIdx_x * blockDim_x + threadIdx_x) * INTERNAL_BLOCK_SIZE_uz;
+        const auto class_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
 
         // create a work-item private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
@@ -185,10 +203,10 @@ class device_kernel_predict_linear {
                 const auto global_class_idx = class_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                 // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the local memory
-                data_cache_pp_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0)) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
-                data_cache_pp_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
-                data_cache_w_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = w_d_[(dim + nd_idx.get_local_id(0)) * (num_classes_ + PADDING_SIZE_uz) + global_class_idx];
-                data_cache_w_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = w_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_classes_ + PADDING_SIZE_uz) + global_class_idx];
+                data_cache_pp_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + threadIdx_x) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                data_cache_pp_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                data_cache_w_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = w_d_[(dim + threadIdx_x) * (num_classes_ + PADDING_SIZE_uz) + global_class_idx];
+                data_cache_w_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = w_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_classes_ + PADDING_SIZE_uz) + global_class_idx];
             }
             nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
@@ -228,6 +246,8 @@ class device_kernel_predict_linear {
     const std::size_t num_classes_;
     const std::size_t num_predict_points_;
     const std::size_t num_features_;
+    const std::size_t grid_x_offset_;
+    const std::size_t grid_y_offset_;
     /// @endcond
 };
 
@@ -253,7 +273,7 @@ class device_kernel_predict {
      * @param[in] num_features the number of features per data point
      * @param[in] kernel_function_parameter the parameters necessary to apply the @p kernel_function
      */
-    device_kernel_predict(::sycl::handler &cgh, real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t num_predict_points, const std::size_t num_features, Args... kernel_function_parameter) :
+    device_kernel_predict(::sycl::handler &cgh, real_type *prediction_d, const real_type *alpha_d, const real_type *rho_d, const real_type *sv_d, const real_type *predict_points_d, const std::size_t num_classes, const std::size_t num_sv, const std::size_t num_predict_points, const std::size_t num_features, const std::size_t grid_x_offset, const std::size_t grid_y_offset, Args... kernel_function_parameter) :
         data_cache_pp_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         data_cache_sv_{ ::sycl::range<2>{ static_cast<std::size_t>(FEATURE_BLOCK_SIZE), static_cast<std::size_t>(INTERNAL_BLOCK_SIZE) * static_cast<std::size_t>(THREAD_BLOCK_SIZE) }, cgh },
         prediction_d_{ prediction_d },
@@ -265,6 +285,8 @@ class device_kernel_predict {
         num_sv_{ num_sv },
         num_predict_points_{ num_predict_points },
         num_features_{ num_features },
+        grid_x_offset_{ grid_x_offset },
+        grid_y_offset_{ grid_y_offset },
         kernel_function_parameter_{ std::make_tuple(std::forward<Args>(kernel_function_parameter)...) } { }
 
     /**
@@ -277,15 +299,21 @@ class device_kernel_predict {
         const auto local_id_1 = static_cast<unsigned>(nd_idx.get_local_id(1));
 
         // cast all values to 64-bit std::size_t to prevent potential 32-bit overflows
+        const auto threadIdx_x = static_cast<std::size_t>(nd_idx.get_local_id(0));               // current thread in block x-dimension
+        const auto threadIdx_y = static_cast<std::size_t>(nd_idx.get_local_id(1));               // current thread in block y-dimension
+        const auto blockDim_x = static_cast<std::size_t>(nd_idx.get_local_range(0));             // number of threads in block x-dimension
+        const auto blockDim_y = static_cast<std::size_t>(nd_idx.get_local_range(1));             // number of threads in block y-dimension
+        const auto blockIdx_x = static_cast<std::size_t>(nd_idx.get_group(0) + grid_x_offset_);  // current block in grid x-dimension
+        const auto blockIdx_y = static_cast<std::size_t>(nd_idx.get_group(1) + grid_y_offset_);  // current block in grid y-dimension
         const auto INTERNAL_BLOCK_SIZE_uz = static_cast<std::size_t>(INTERNAL_BLOCK_SIZE);
         const auto THREAD_BLOCK_SIZE_uz = static_cast<std::size_t>(THREAD_BLOCK_SIZE);
         const auto FEATURE_BLOCK_SIZE_uz = static_cast<std::size_t>(FEATURE_BLOCK_SIZE);
         const auto PADDING_SIZE_uz = static_cast<std::size_t>(PADDING_SIZE);
 
         // calculate the indices used in the current work-item
-        const auto pp_idx = nd_idx.get_global_id(1) * INTERNAL_BLOCK_SIZE_uz;
-        const auto pp_idx_linear = nd_idx.get_group(1) * nd_idx.get_local_range(1) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
-        const auto sv_idx_linear = nd_idx.get_group(0) * nd_idx.get_local_range(0) * INTERNAL_BLOCK_SIZE_uz + nd_idx.get_local_id(1);
+        const auto pp_idx = (blockIdx_y * blockDim_y + threadIdx_y) * INTERNAL_BLOCK_SIZE_uz;
+        const auto pp_idx_linear = blockIdx_y * blockDim_y * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
+        const auto sv_idx_linear = blockIdx_x * blockDim_x * INTERNAL_BLOCK_SIZE_uz + threadIdx_y;
 
         // create a work-item private array used for internal caching
         real_type temp[INTERNAL_BLOCK_SIZE][INTERNAL_BLOCK_SIZE]{};
@@ -299,10 +327,10 @@ class device_kernel_predict {
                     const auto global_sv_idx = sv_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
                     // FEATURE_BLOCK_SIZE = 2 * THREAD_BLOCK_SIZE -> store twice as many values in the shared memory
-                    data_cache_pp_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0)) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
-                    data_cache_pp_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
-                    data_cache_sv_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[(dim + nd_idx.get_local_id(0)) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
-                    data_cache_sv_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
+                    data_cache_pp_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + threadIdx_x) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                    data_cache_pp_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = predict_points_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE) * (num_predict_points_ + PADDING_SIZE_uz) + global_pp_idx];
+                    data_cache_sv_[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[(dim + threadIdx_x) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
+                    data_cache_sv_[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = sv_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
                 }
                 nd_idx.barrier();  // wait until all work-items loaded their part of the data
 
@@ -337,13 +365,13 @@ class device_kernel_predict {
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                     const std::size_t global_sv_idx = sv_idx_linear + static_cast<std::size_t>(internal) * THREAD_BLOCK_SIZE_uz;
 
-                    alpha_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + nd_idx.get_local_id(0)) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
-                    alpha_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
+                    alpha_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + threadIdx_x) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
+                    alpha_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = alpha_d_[(dim + threadIdx_x + THREAD_BLOCK_SIZE_uz) * (num_sv_ + PADDING_SIZE_uz) + global_sv_idx];
 
                     // the bias (rho) must only be applied once for all support vectors
                     if (nd_idx.get_group(0) == std::size_t{ 0 }) {
-                        out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + nd_idx.get_local_id(0)];
-                        out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz];
+                        out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + threadIdx_x];
+                        out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = -rho_d_[dim + threadIdx_x + THREAD_BLOCK_SIZE_uz];
                     } else {
                         out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
                         out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1] = real_type{ 0.0 };
@@ -366,8 +394,8 @@ class device_kernel_predict {
                 for (unsigned internal = 0; internal < INTERNAL_BLOCK_SIZE; ++internal) {
                     const auto global_pp_idx = pp_idx + static_cast<std::size_t>(internal);
 
-                    detail::atomic_op<real_type>{ prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0)] } += out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1];
-                    detail::atomic_op<real_type>{ prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + dim + nd_idx.get_local_id(0) + THREAD_BLOCK_SIZE_uz] } += out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1];
+                    detail::atomic_op<real_type>{ prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x] } += out_cache[local_id_0][internal * THREAD_BLOCK_SIZE + local_id_1];
+                    detail::atomic_op<real_type>{ prediction_d_[global_pp_idx * (num_classes_ + PADDING_SIZE_uz) + dim + threadIdx_x + THREAD_BLOCK_SIZE_uz] } += out_cache[local_id_0 + THREAD_BLOCK_SIZE][internal * THREAD_BLOCK_SIZE + local_id_1];
                 }
                 nd_idx.barrier();  // wait until all work-items updated their part of the prediction
             }
@@ -390,6 +418,8 @@ class device_kernel_predict {
     const std::size_t num_sv_;
     const std::size_t num_predict_points_;
     const std::size_t num_features_;
+    const std::size_t grid_x_offset_;
+    const std::size_t grid_y_offset_;
     const std::tuple<Args...> kernel_function_parameter_;
     /// @endcond
 };

--- a/include/plssvm/backends/execution_range.hpp
+++ b/include/plssvm/backends/execution_range.hpp
@@ -36,12 +36,15 @@ struct [[nodiscard]] dim_type {
 
     /**
      * @brief Construct an one-dimensional dimensional type.
+     * @param[in] x_p the value of the first dimension
      */
     constexpr explicit dim_type(const unsigned long long x_p) :
         x{ x_p } { }
 
     /**
      * @brief Construct a two-dimensional dimensional type.
+     * @param[in] x_p the value of the first dimension
+     * @param[in] y_p the value of the second dimension
      */
     constexpr dim_type(const unsigned long long x_p, const unsigned long long y_p) :
         x{ x_p },
@@ -49,6 +52,9 @@ struct [[nodiscard]] dim_type {
 
     /**
      * @brief Construct a three-dimensional dimensional type.
+     * @param[in] x_p the value of the first dimension
+     * @param[in] y_p the value of the second dimension
+     * @param[in] z_p the value of the third dimension
      */
     constexpr dim_type(const unsigned long long x_p, const unsigned long long y_p, const unsigned long long z_p) :
         x{ x_p },

--- a/include/plssvm/backends/execution_range.hpp
+++ b/include/plssvm/backends/execution_range.hpp
@@ -150,6 +150,12 @@ struct execution_range {
      */
     void swap(execution_range &other) noexcept;
 
+    /**
+     * @brief Calculate the number of threads in a block described by this execution range.
+     * @return the number of threads, i.e., `block.x * block.y * block.z` (`[[nodiscard]]`)
+     */
+    [[nodiscard]] unsigned long long num_threads_in_block() const noexcept;
+
     /// The up-to three dimensional block (work-group) size.
     dim_type block{};
     /// The grids. Multiple grids are used, if the grid sizes would exceed the maximum allowed number. Also stores the offsets for the respective grids used in the kernels.

--- a/include/plssvm/backends/execution_range.hpp
+++ b/include/plssvm/backends/execution_range.hpp
@@ -1,0 +1,121 @@
+/**
+ * @file
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Defines a struct containing the GPU backend's execution ranges.
+ */
+
+#ifndef PLSSVM_BACKENDS_EXECUTION_RANGE_HPP_
+#define PLSSVM_BACKENDS_EXECUTION_RANGE_HPP_
+
+#include "plssvm/exceptions/exceptions.hpp"  // plssvm::kernel_launch_resources
+
+#include "fmt/core.h"  // fmt::format
+
+#include <algorithm>  // std::min
+#include <cmath>      // std::ceil
+#include <utility>    // std::move, std::pair
+#include <vector>     // std::vector
+
+namespace plssvm::detail {
+
+/**
+ * @brief A type encapsulating up-to three dimensions for kernel launches.
+ */
+struct dim_type {
+    /**
+     * @brief Construct an empty dimensional type.
+     */
+    dim_type() = default;
+
+    /**
+     * @brief Construct an one-dimensional dimensional type.
+     */
+    explicit dim_type(const unsigned long long x_p) :
+        x{ x_p } { }
+
+    /**
+     * @brief Construct a two-dimensional dimensional type.
+     */
+    dim_type(const unsigned long long x_p, const unsigned long long y_p) :
+        x{ x_p },
+        y{ y_p } { }
+
+    /**
+     * @brief Construct a three-dimensional dimensional type.
+     */
+    dim_type(const unsigned long long x_p, const unsigned long long y_p, const unsigned long long z_p) :
+        x{ x_p },
+        y{ y_p },
+        z{ z_p } { }
+
+    /// The dimensional size in x direction.
+    unsigned long long x{ 1 };
+    /// The dimensional size in y direction.
+    unsigned long long y{ 1 };
+    /// The dimensional size in z direction.
+    unsigned long long z{ 1 };
+};
+
+/**
+ * @brief A struct encapsulating an arbitrary execution range used to launch a kernel.
+ */
+struct execution_range {
+    /// The type used to store the grid sizes and offsets.
+    using grid_type = std::pair<dim_type, dim_type>;
+
+    /**
+     * @brief Create a block and grid(s) used to launch the kernels.
+     * @details If the provided grid would be too large to be launched, it is split into multiple sub-grids.
+     * @param[in] block_p the requested block size
+     * @param[in] max_allowed_block_size the maximum allowed 1D block size (i.e., `block.x * block.y * block.z`)
+     * @param[in] grid the requested grid size
+     * @param[in] max_allowed_grid_size the maximum allowed 3D grid sizes
+     * @throws plssvm::kernel_launch_resources if the block size exceeds the upper limits
+     */
+    execution_range(const dim_type block_p, const unsigned long long max_allowed_block_size, const dim_type grid, const dim_type max_allowed_grid_size) :
+        block{ block_p } {
+        // check whether the provided block size is valid
+        if (max_allowed_block_size < block.x * block.y * block.z) {
+            throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}x{}, max {}! Try reducing THREAD_BLOCK_SIZE.", block.x, block.y, block.z, max_allowed_block_size) };
+        }
+
+        // TODO: implement better?!
+        // split the large grid into sub-grids
+        const unsigned long long num_grid_x = grid.x / max_allowed_grid_size.x;
+        for (unsigned long long x = 0; x < num_grid_x; ++x) {
+            const unsigned long long num_grid_y = grid.y / max_allowed_grid_size.y;
+            for (unsigned long long y = 0; y < num_grid_y; ++y) {
+                grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), std::min(grid.y, max_allowed_grid_size.y) }, dim_type{ x * max_allowed_grid_size.x, y * max_allowed_grid_size.y });
+            }
+            const unsigned long long remaining_y = grid.y % max_allowed_grid_size.y;
+            if (remaining_y > 0ull) {
+                grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), remaining_y }, dim_type{ x * max_allowed_grid_size.x, num_grid_y * max_allowed_grid_size.y });
+            }
+        }
+        const unsigned long long remaining_x = grid.x % max_allowed_grid_size.x;
+        if (remaining_x > 0ull) {
+            const unsigned long long num_grid_y = grid.y / max_allowed_grid_size.y;
+            for (unsigned long long y = 0; y < num_grid_y; ++y) {
+                grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), std::min(grid.y, max_allowed_grid_size.y) }, dim_type{ num_grid_x * max_allowed_grid_size.x, y * max_allowed_grid_size.y });
+            }
+            const unsigned long long remaining_y = grid.y % max_allowed_grid_size.y;
+            if (remaining_y > 0ull) {
+                grids.emplace_back(dim_type{ remaining_x, remaining_y }, dim_type{ num_grid_x * max_allowed_grid_size.x, num_grid_y * max_allowed_grid_size.y });
+            }
+        }
+    }
+
+    /// The up-to three dimensional block (work-group) size.
+    dim_type block{};
+    /// The grids. Multiple grids are used, if the grid sizes would exceed the maximum allowed number. Also stores the offsets for the respective grids used in the kernels.
+    std::vector<grid_type> grids{};
+};
+
+}  // namespace plssvm::detail
+
+#endif  // PLSSVM_BACKENDS_EXECUTION_RANGE_HPP_

--- a/include/plssvm/backends/gpu_csvm.hpp
+++ b/include/plssvm/backends/gpu_csvm.hpp
@@ -151,6 +151,7 @@ class gpu_csvm : public ::plssvm::csvm {
      * @brief Perform an explicit BLAS level 3 operation: `C = alpha * A * B + beta * C` where @p A, @p B, and @p C are matrices, and @p alpha and @p beta are scalars.
      * @param[in] device_id the device to run the kernel on
      * @param[in] exec the execution range used in the device call
+     * @param[in] mirror_exec the execution range used in the mirror device call (since the explicit BLAS level 3 kernel is split into two support multi-device execution)
      * @param[in] alpha the scalar alpha value
      * @param[in] A_d the matrix @p A
      * @param[in] B_d the matrix @p B

--- a/include/plssvm/backends/gpu_csvm.hpp
+++ b/include/plssvm/backends/gpu_csvm.hpp
@@ -270,7 +270,7 @@ std::vector<::plssvm::detail::move_only_any> gpu_csvm<device_ptr_t, queue_t, pin
         q_red_d[device_id].copy_to_device(q_red, 0, q_red.size());
         q_red_d[device_id].memset(0, q_red.size());
 
-        // set kernel parameter
+        // kernel launch specific sizes
         const unsigned long long device_specific_num_rows = data_distribution_->place_specific_num_rows(device_id);
         const unsigned long long device_row_offset = data_distribution_->place_row_offset(device_id);
 

--- a/include/plssvm/backends/gpu_csvm.hpp
+++ b/include/plssvm/backends/gpu_csvm.hpp
@@ -658,7 +658,7 @@ aos_matrix<real_type> gpu_csvm<device_ptr_t, queue_t, pinned_memory_t>::predict_
 
         // define the full execution grid
         const unsigned long long device_specific_num_predict_points = predict_points_d[device_id].shape().x;
-        const unsigned long long y_dim_size = params.kernel_type == kernel_function_type::linear ? alpha_d[device_id].shape().x : sv_or_w_d[device_id].shape().x;
+        const unsigned long long y_dim_size = params.kernel_type == kernel_function_type::linear ? num_classes : num_support_vectors;
         const dim_type grid{
             static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
             static_cast<std::size_t>(std::ceil(static_cast<double>(y_dim_size) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE)))

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -143,7 +143,7 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
     cudaDeviceProp prop{};
     PLSSVM_CUDA_ERROR_CHECK(cudaGetDeviceProperties(&prop, devices_[device_id]));
-     return { static_cast<std::size_t>(prop.maxGridSize[0]), static_cast<std::size_t>(prop.maxGridSize[1]), static_cast<std::size_t>(prop.maxGridSize[2]) };
+    return { static_cast<std::size_t>(prop.maxGridSize[0]), static_cast<std::size_t>(prop.maxGridSize[1]), static_cast<std::size_t>(prop.maxGridSize[2]) };
 }
 
 //***************************************************//

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -10,12 +10,13 @@
 
 #include "plssvm/backend_types.hpp"                                                 // plssvm::backend_type
 #include "plssvm/backends/CUDA/detail/device_ptr.cuh"                               // plssvm::cuda::detail::device_ptr
-#include "plssvm/backends/CUDA/detail/utility.cuh"                                  // PLSSVM_CUDA_ERROR_CHECK, plssvm::cuda::detail::{device_synchronize, get_device_count, set_device, peek_at_last_error, get_runtime_version}
+#include "plssvm/backends/CUDA/detail/utility.cuh"                                  // PLSSVM_CUDA_ERROR_CHECK, plssvm::cuda::detail::{dim_type_to_native, device_synchronize, get_device_count, set_device, peek_at_last_error, get_runtime_version}
 #include "plssvm/backends/CUDA/exceptions.hpp"                                      // plssvm::cuda::backend_exception
 #include "plssvm/backends/CUDA/kernel/cg_explicit/blas.cuh"                         // plssvm::cuda::detail::{device_kernel_symm, device_kernel_symm_mirror, device_kernel_inplace_matrix_add, device_kernel_inplace_matrix_scale}
 #include "plssvm/backends/CUDA/kernel/cg_explicit/kernel_matrix_assembly.cuh"       // plssvm::cuda::detail::device_kernel_assembly
 #include "plssvm/backends/CUDA/kernel/cg_implicit/kernel_matrix_assembly_blas.cuh"  // plssvm::cuda::detail::device_kernel_assembly_symm
 #include "plssvm/backends/CUDA/kernel/predict_kernel.cuh"                           // plssvm::cuda::detail::{device_kernel_w_linear, device_kernel_predict_linear, device_kernel_predict}
+#include "plssvm/backends/execution_range.hpp"                                      // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/constants.hpp"                                                     // plssvm::{real_type, THREAD_BLOCK_SIZE, INTERNAL_BLOCK_SIZE, PADDING_SIZE}
 #include "plssvm/detail/assert.hpp"                                                 // PLSSVM_ASSERT
 #include "plssvm/detail/data_distribution.hpp"                                      // plssvm::detail::{data_distribution, triangular_data_distribution, rectangular_data_distribution}
@@ -138,11 +139,18 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     return static_cast<std::size_t>(prop.maxThreadsPerBlock);
 }
 
+::plssvm::detail::dim_type csvm::get_max_grid_size(const std::size_t device_id) const {
+    PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
+    cudaDeviceProp prop{};
+    PLSSVM_CUDA_ERROR_CHECK(cudaGetDeviceProperties(&prop, devices_[device_id]));
+     return { static_cast<std::size_t>(prop.maxGridSize[0]), static_cast<std::size_t>(prop.maxGridSize[1]), static_cast<std::size_t>(prop.maxGridSize[2]) };
+}
+
 //***************************************************//
 //                        fit                        //
 //***************************************************//
 
-auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
+auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const unsigned long long num_rows_reduced = data_d.shape().x - 1;
     const unsigned long long num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -153,15 +161,6 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
     const std::size_t num_entries_padded = dist.calculate_explicit_kernel_matrix_num_entries_padded(device_id);
@@ -169,26 +168,35 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     device_ptr_type kernel_matrix_d{ num_entries_padded, device };  // only explicitly store the upper triangular matrix
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
+
     detail::set_device(device);
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            detail::device_kernel_assembly<kernel_function_type::linear><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor);
-            break;
-        case kernel_function_type::polynomial:
-            detail::device_kernel_assembly<kernel_function_type::polynomial><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, params.degree, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::rbf:
-            detail::device_kernel_assembly<kernel_function_type::rbf><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::sigmoid:
-            detail::device_kernel_assembly<kernel_function_type::sigmoid><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::laplacian:
-            detail::device_kernel_assembly<kernel_function_type::laplacian><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::chi_squared:
-            detail::device_kernel_assembly<kernel_function_type::chi_squared><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                detail::device_kernel_assembly<kernel_function_type::linear><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y);
+                break;
+            case kernel_function_type::polynomial:
+                detail::device_kernel_assembly<kernel_function_type::polynomial><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::rbf:
+                detail::device_kernel_assembly<kernel_function_type::rbf><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::sigmoid:
+                detail::device_kernel_assembly<kernel_function_type::sigmoid><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::laplacian:
+                detail::device_kernel_assembly<kernel_function_type::laplacian><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::chi_squared:
+                detail::device_kernel_assembly<kernel_function_type::chi_squared><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+        }
     }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
@@ -196,7 +204,7 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     return kernel_matrix_d;
 }
 
-void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
+void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
     const unsigned long long num_rhs = B_d.shape().x;
     const unsigned long long num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -206,77 +214,75 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    {
-        const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
+        {
+            const auto [partial_grid, offsets] = exec.grids[i];
+            // convert execution range grid[i] to CUDA's native dim3
+            const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-        detail::device_kernel_symm<<<grid, block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
-    }
+            detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+        }
 
-    {
-        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+        {
+            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
-        if (num_mirror_rows > 0) {
-            const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-            const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                            static_cast<unsigned int>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+            if (num_mirror_rows > 0) {
+                const auto [partial_grid, offsets] = mirror_exec.grids[i];
+                // convert execution range grid[i] to CUDA's native dim3
+                const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-            detail::device_kernel_symm_mirror<<<grid, block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
+                detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+            }
         }
     }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
+void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
     const unsigned long long num_rhs = lhs_d.shape().x;
     const unsigned long long num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    detail::device_kernel_inplace_matrix_add<<<grid, block>>>(num_rhs, lhs_d.get(), rhs_d.get());
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_inplace_matrix_add<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y);
+    }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
+void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const real_type scale) const {
     const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    detail::device_kernel_inplace_matrix_scale<<<grid, block>>>(num_rhs, lhs_d.get(), scale);
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_inplace_matrix_scale<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), scale, offsets.x, offsets.y);
+    }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 }
 
-void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
+void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
     const unsigned long long num_rows_reduced = A_d.shape().x - 1;
     const unsigned long long num_features = A_d.shape().y;
     const unsigned long long num_classes = B_d.shape().x;
@@ -287,37 +293,37 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
-    detail::set_device(device);
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            detail::device_kernel_assembly_symm<kernel_function_type::linear><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes);
-            break;
-        case kernel_function_type::polynomial:
-            detail::device_kernel_assembly_symm<kernel_function_type::polynomial><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, params.degree, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::rbf:
-            detail::device_kernel_assembly_symm<kernel_function_type::rbf><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::sigmoid:
-            detail::device_kernel_assembly_symm<kernel_function_type::sigmoid><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::laplacian:
-            detail::device_kernel_assembly_symm<kernel_function_type::laplacian><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::chi_squared:
-            detail::device_kernel_assembly_symm<kernel_function_type::chi_squared><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
+    // convert general execution range's block to CUDA specific block
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
+
+    detail::set_device(device);
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                detail::device_kernel_assembly_symm<kernel_function_type::linear><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y);
+                break;
+            case kernel_function_type::polynomial:
+                detail::device_kernel_assembly_symm<kernel_function_type::polynomial><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::rbf:
+                detail::device_kernel_assembly_symm<kernel_function_type::rbf><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::sigmoid:
+                detail::device_kernel_assembly_symm<kernel_function_type::sigmoid><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::laplacian:
+                detail::device_kernel_assembly_symm<kernel_function_type::laplacian><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::chi_squared:
+                detail::device_kernel_assembly_symm<kernel_function_type::chi_squared><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+        }
     }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
@@ -327,7 +333,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //                   predict, score                  //
 //***************************************************//
 
-auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
+auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
     const unsigned long long num_classes = alpha_d.shape().x;
     const unsigned long long num_sv = alpha_d.shape().y;
     const unsigned long long device_specific_num_sv = sv_d.shape().x;
@@ -337,72 +343,61 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
     // get the offset of the data points this device is responsible for
     const unsigned long long sv_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
+
     detail::set_device(device);
-    detail::device_kernel_w_linear<<<grid, block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset);
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_w_linear<<<native_partial_grid, native_block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y);
+    }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 
     return w_d;
 }
 
-auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
+auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
     const unsigned long long num_classes = alpha_d.shape().x;
     const unsigned long long num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
     const unsigned long long num_features = predict_points_d.shape().y;
+    const unsigned long long num_sv = sv_or_w_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // define the block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    if (params.kernel_type == kernel_function_type::linear) {
-        // define the grid sizes
-        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
-        detail::device_kernel_predict_linear<<<grid, block>>>(out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features);
-    } else {
-        const unsigned long long num_sv = sv_or_w_d.shape().x;
-
-        // define the grid sizes
-        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                // already handled
+                detail::device_kernel_predict_linear<<<native_partial_grid, native_block>>>(out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.x, offsets.y);
                 break;
             case kernel_function_type::polynomial:
-                detail::device_kernel_predict<kernel_function_type::polynomial><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                detail::device_kernel_predict<kernel_function_type::polynomial><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0);
                 break;
             case kernel_function_type::rbf:
-                detail::device_kernel_predict<kernel_function_type::rbf><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::device_kernel_predict<kernel_function_type::rbf><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma));
                 break;
             case kernel_function_type::sigmoid:
-                detail::device_kernel_predict<kernel_function_type::sigmoid><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma), params.coef0);
+                detail::device_kernel_predict<kernel_function_type::sigmoid><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0);
                 break;
             case kernel_function_type::laplacian:
-                detail::device_kernel_predict<kernel_function_type::laplacian><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::device_kernel_predict<kernel_function_type::laplacian><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma));
                 break;
             case kernel_function_type::chi_squared:
-                detail::device_kernel_predict<kernel_function_type::chi_squared><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::device_kernel_predict<kernel_function_type::chi_squared><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma));
                 break;
         }
     }

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -214,29 +214,29 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // convert execution range block to CUDA's native dim3
-    const dim3 native_block = detail::dim_type_to_native(exec.block);
-
     detail::set_device(device);
-    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
-        {
-            const auto [partial_grid, offsets] = exec.grids[i];
+    for (const auto &grid : exec.grids) {
+        // convert execution range block to CUDA's native dim3
+        const dim3 native_block = detail::dim_type_to_native(exec.block);
+
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to CUDA's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+    }
+    for (const auto &mirror_grid : mirror_exec.grids) {
+        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+        if (num_mirror_rows > 0) {
+            // convert execution range block to CUDA's native dim3
+            const dim3 native_block = detail::dim_type_to_native(mirror_exec.block);
+
+            const auto [partial_grid, offsets] = mirror_grid;
             // convert execution range grid[i] to CUDA's native dim3
             const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-            detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
-        }
-
-        {
-            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
-
-            if (num_mirror_rows > 0) {
-                const auto [partial_grid, offsets] = mirror_exec.grids[i];
-                // convert execution range grid[i] to CUDA's native dim3
-                const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
-
-                detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
-            }
+            detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
         }
     }
     detail::peek_at_last_error();

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -245,7 +245,6 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
 
 void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
     const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
     // convert execution range block to CUDA's native dim3

--- a/src/plssvm/backends/CUDA/csvm.cu
+++ b/src/plssvm/backends/CUDA/csvm.cu
@@ -172,9 +172,8 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {
@@ -214,29 +213,28 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        // convert execution range block to CUDA's native dim3
-        const dim3 native_block = detail::dim_type_to_native(exec.block);
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    detail::set_device(device);
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
     }
-    for (const auto &mirror_grid : mirror_exec.grids) {
+
+    // convert execution range block to CUDA's native dim3
+    const dim3 native_mirror_block = detail::dim_type_to_native(mirror_exec.block);
+
+    for (const auto &[partial_grid, offsets] : mirror_exec.grids) {
         const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
         if (num_mirror_rows > 0) {
-            // convert execution range block to CUDA's native dim3
-            const dim3 native_block = detail::dim_type_to_native(mirror_exec.block);
-
-            const auto [partial_grid, offsets] = mirror_grid;
-            // convert execution range grid[i] to CUDA's native dim3
+            // convert execution range partial_grid to CUDA's native dim3
             const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-            detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+            detail::device_kernel_symm_mirror<<<native_partial_grid, native_mirror_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
         }
     }
     detail::peek_at_last_error();
@@ -251,9 +249,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plss
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_inplace_matrix_add<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y);
@@ -270,9 +267,8 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm:
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_inplace_matrix_scale<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), scale, offsets.x, offsets.y);
@@ -298,9 +294,8 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {
@@ -348,9 +343,8 @@ auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::exe
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_w_linear<<<native_partial_grid, native_block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y);
@@ -374,9 +368,8 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to CUDA's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to CUDA's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {

--- a/src/plssvm/backends/CUDA/detail/utility.cu
+++ b/src/plssvm/backends/CUDA/detail/utility.cu
@@ -8,20 +8,26 @@
 
 #include "plssvm/backends/CUDA/detail/utility.cuh"
 
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+
 #include "fmt/core.h"  // fmt::format
 
 #include <string>  // std::string
 
 namespace plssvm::cuda::detail {
 
-[[nodiscard]] int get_device_count() {
+dim3 dim_type_to_native(const ::plssvm::detail::dim_type &dims) {
+    return dim3{ static_cast<unsigned int>(dims.x), static_cast<unsigned int>(dims.y), static_cast<unsigned int>(dims.z) };
+}
+
+int get_device_count() {
     int count{};
     PLSSVM_CUDA_ERROR_CHECK(cudaGetDeviceCount(&count))
     return count;
 }
 
 void set_device(const int device) {
-    if (device < 0 || device >= static_cast<int>(get_device_count())) {
+    if (device < 0 || device >= get_device_count()) {
         throw backend_exception{ fmt::format("Illegal device ID! Must be in range: [0, {}) but is {}!", get_device_count(), device) };
     }
     PLSSVM_CUDA_ERROR_CHECK(cudaSetDevice(device))
@@ -32,7 +38,7 @@ void peek_at_last_error() {
 }
 
 void device_synchronize(const int device) {
-    if (device < 0 || device >= static_cast<int>(get_device_count())) {
+    if (device < 0 || device >= get_device_count()) {
         throw backend_exception{ fmt::format("Illegal device ID! Must be in range: [0, {}) but is {}!", get_device_count(), device) };
     }
     peek_at_last_error();

--- a/src/plssvm/backends/HIP/csvm.hip
+++ b/src/plssvm/backends/HIP/csvm.hip
@@ -213,29 +213,29 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // convert execution range block to HIP's native dim3
-    const dim3 native_block = detail::dim_type_to_native(exec.block);
-
     detail::set_device(device);
-    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
-        {
-            const auto [partial_grid, offsets] = exec.grids[i];
+    for (const auto &grid : exec.grids) {
+        // convert execution range block to HIP's native dim3
+        const dim3 native_block = detail::dim_type_to_native(exec.block);
+
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+    }
+    for (const auto &mirror_grid : mirror_exec.grids) {
+        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+        if (num_mirror_rows > 0) {
+            // convert execution range block to HIP's native dim3
+            const dim3 native_block = detail::dim_type_to_native(mirror_exec.block);
+
+            const auto [partial_grid, offsets] = mirror_grid;
             // convert execution range grid[i] to HIP's native dim3
             const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-            detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
-        }
-
-        {
-            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
-
-            if (num_mirror_rows > 0) {
-                const auto [partial_grid, offsets] = mirror_exec.grids[i];
-                // convert execution range grid[i] to HIP's native dim3
-                const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
-
-                detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
-            }
+            detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
         }
     }
     detail::peek_at_last_error();

--- a/src/plssvm/backends/HIP/csvm.hip
+++ b/src/plssvm/backends/HIP/csvm.hip
@@ -171,9 +171,8 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {
@@ -213,29 +212,28 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        // convert execution range block to HIP's native dim3
-        const dim3 native_block = detail::dim_type_to_native(exec.block);
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    detail::set_device(device);
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
     }
-    for (const auto &mirror_grid : mirror_exec.grids) {
+
+    // convert execution range block to HIP's native dim3
+    const dim3 native_mirror_block = detail::dim_type_to_native(mirror_exec.block);
+
+    for (const auto &[partial_grid, offsets] : mirror_exec.grids) {
         const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
         if (num_mirror_rows > 0) {
-            // convert execution range block to HIP's native dim3
-            const dim3 native_block = detail::dim_type_to_native(mirror_exec.block);
-
-            const auto [partial_grid, offsets] = mirror_grid;
-            // convert execution range grid[i] to HIP's native dim3
+            // convert execution range partial_grid to HIP's native dim3
             const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-            detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+            detail::device_kernel_symm_mirror<<<native_partial_grid, native_mirror_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
         }
     }
     detail::peek_at_last_error();
@@ -250,9 +248,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plss
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_inplace_matrix_add<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y);
@@ -269,9 +266,8 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm:
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_inplace_matrix_scale<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), scale, offsets.x, offsets.y);
@@ -297,9 +293,8 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {
@@ -347,9 +342,8 @@ auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::exe
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         detail::device_kernel_w_linear<<<native_partial_grid, native_block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y);
@@ -373,9 +367,8 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
     const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to HIP's native dim3
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to HIP's native dim3
         const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {

--- a/src/plssvm/backends/HIP/csvm.hip
+++ b/src/plssvm/backends/HIP/csvm.hip
@@ -136,11 +136,18 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     return static_cast<std::size_t>(prop.maxThreadsPerBlock);
 }
 
+::plssvm::detail::dim_type csvm::get_max_grid_size(const std::size_t device_id) const {
+    PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
+    hipDeviceProp_t prop{};
+    PLSSVM_HIP_ERROR_CHECK(hipGetDeviceProperties(&prop, devices_[device_id]));
+    return { static_cast<std::size_t>(prop.maxGridSize[0]), static_cast<std::size_t>(prop.maxGridSize[1]), static_cast<std::size_t>(prop.maxGridSize[2]) };
+}
+
 //***************************************************//
 //                        fit                        //
 //***************************************************//
 
-auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
+auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const unsigned long long num_rows_reduced = data_d.shape().x - 1;
     const unsigned long long num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -151,15 +158,6 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
     const std::size_t num_entries_padded = dist.calculate_explicit_kernel_matrix_num_entries_padded(device_id);
@@ -167,26 +165,35 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     device_ptr_type kernel_matrix_d{ num_entries_padded, device };  // only explicitly store the upper triangular matrix
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
+
     detail::set_device(device);
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            detail::device_kernel_assembly<kernel_function_type::linear><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor);
-            break;
-        case kernel_function_type::polynomial:
-            detail::device_kernel_assembly<kernel_function_type::polynomial><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, params.degree, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::rbf:
-            detail::device_kernel_assembly<kernel_function_type::rbf><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::sigmoid:
-            detail::device_kernel_assembly<kernel_function_type::sigmoid><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::laplacian:
-            detail::device_kernel_assembly<kernel_function_type::laplacian><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::chi_squared:
-            detail::device_kernel_assembly<kernel_function_type::chi_squared><<<grid, block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                detail::device_kernel_assembly<kernel_function_type::linear><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y);
+                break;
+            case kernel_function_type::polynomial:
+                detail::device_kernel_assembly<kernel_function_type::polynomial><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::rbf:
+                detail::device_kernel_assembly<kernel_function_type::rbf><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::sigmoid:
+                detail::device_kernel_assembly<kernel_function_type::sigmoid><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::laplacian:
+                detail::device_kernel_assembly<kernel_function_type::laplacian><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::chi_squared:
+                detail::device_kernel_assembly<kernel_function_type::chi_squared><<<native_partial_grid, native_block>>>(kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+        }
     }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
@@ -194,7 +201,7 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     return kernel_matrix_d;
 }
 
-void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
+void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
     const unsigned long long num_rhs = B_d.shape().x;
     const unsigned long long num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -204,77 +211,74 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    {
-        const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
+        {
+            const auto [partial_grid, offsets] = exec.grids[i];
+            // convert execution range grid[i] to HIP's native dim3
+            const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-        detail::device_kernel_symm<<<grid, block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
-    }
+            detail::device_kernel_symm<<<native_partial_grid, native_block>>>(num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+        }
 
-    {
-        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+        {
+            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
-        if (num_mirror_rows > 0) {
-            const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-            const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                            static_cast<unsigned int>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+            if (num_mirror_rows > 0) {
+                const auto [partial_grid, offsets] = mirror_exec.grids[i];
+                // convert execution range grid[i] to HIP's native dim3
+                const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
-            detail::device_kernel_symm_mirror<<<grid, block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
+                detail::device_kernel_symm_mirror<<<native_partial_grid, native_block>>>(num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y);
+            }
         }
     }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
+void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
     const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    detail::device_kernel_inplace_matrix_add<<<grid, block>>>(num_rhs, lhs_d.get(), rhs_d.get());
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_inplace_matrix_add<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y);
+    }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
+void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const real_type scale) const {
     const unsigned long long num_rhs = lhs_d.shape().x;
-    const unsigned long long num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    detail::device_kernel_inplace_matrix_scale<<<grid, block>>>(num_rhs, lhs_d.get(), scale);
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_inplace_matrix_scale<<<native_partial_grid, native_block>>>(num_rhs, lhs_d.get(), scale, offsets.x, offsets.y);
+    }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 }
 
-void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
+void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
     const unsigned long long num_rows_reduced = A_d.shape().x - 1;
     const unsigned long long num_features = A_d.shape().y;
     const unsigned long long num_classes = B_d.shape().x;
@@ -285,37 +289,37 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     // get the offset of the data points this device is responsible for
     const unsigned long long row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
-    detail::set_device(device);
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            detail::device_kernel_assembly_symm<kernel_function_type::linear><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes);
-            break;
-        case kernel_function_type::polynomial:
-            detail::device_kernel_assembly_symm<kernel_function_type::polynomial><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, params.degree, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::rbf:
-            detail::device_kernel_assembly_symm<kernel_function_type::rbf><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::sigmoid:
-            detail::device_kernel_assembly_symm<kernel_function_type::sigmoid><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::laplacian:
-            detail::device_kernel_assembly_symm<kernel_function_type::laplacian><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::chi_squared:
-            detail::device_kernel_assembly_symm<kernel_function_type::chi_squared><<<grid, block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
+    // convert general execution range's block to HIP specific block
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
+
+    detail::set_device(device);
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                detail::device_kernel_assembly_symm<kernel_function_type::linear><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y);
+                break;
+            case kernel_function_type::polynomial:
+                detail::device_kernel_assembly_symm<kernel_function_type::polynomial><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::rbf:
+                detail::device_kernel_assembly_symm<kernel_function_type::rbf><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::sigmoid:
+                detail::device_kernel_assembly_symm<kernel_function_type::sigmoid><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::laplacian:
+                detail::device_kernel_assembly_symm<kernel_function_type::laplacian><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::chi_squared:
+                detail::device_kernel_assembly_symm<kernel_function_type::chi_squared><<<native_partial_grid, native_block>>>(alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma));
+                break;
+        }
     }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
@@ -325,7 +329,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //                   predict, score                  //
 //***************************************************//
 
-auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
+auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
     const unsigned long long num_classes = alpha_d.shape().x;
     const unsigned long long num_sv = alpha_d.shape().y;
     const unsigned long long device_specific_num_sv = sv_d.shape().x;
@@ -335,72 +339,61 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
     // get the offset of the data points this device is responsible for
     const unsigned long long sv_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
-    const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                    static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
+
     detail::set_device(device);
-    detail::device_kernel_w_linear<<<grid, block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset);
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
+
+        detail::device_kernel_w_linear<<<native_partial_grid, native_block>>>(w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y);
+    }
     detail::peek_at_last_error();
     detail::device_synchronize(device);
 
     return w_d;
 }
 
-auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
+auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
     const unsigned long long num_classes = alpha_d.shape().x;
     const unsigned long long num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
     const unsigned long long num_features = predict_points_d.shape().y;
+    const unsigned long long num_sv = sv_or_w_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // define the block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const dim3 block(THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE);
+    // convert execution range block to HIP's native dim3
+    const dim3 native_block = detail::dim_type_to_native(exec.block);
 
     detail::set_device(device);
-    if (params.kernel_type == kernel_function_type::linear) {
-        // define the grid sizes
-        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
-
-        detail::device_kernel_predict_linear<<<grid, block>>>(out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features);
-    } else {
-        const unsigned long long num_sv = sv_or_w_d.shape().x;
-
-        // define the grid sizes
-        const dim3 grid(static_cast<unsigned int>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block.x * INTERNAL_BLOCK_SIZE))),
-                        static_cast<unsigned int>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block.y * INTERNAL_BLOCK_SIZE))));
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to HIP's native dim3
+        const dim3 native_partial_grid = detail::dim_type_to_native(partial_grid);
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                // already handled
+                detail::device_kernel_predict_linear<<<native_partial_grid, native_block>>>(out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.x, offsets.y);
                 break;
             case kernel_function_type::polynomial:
-                detail::device_kernel_predict<kernel_function_type::polynomial><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                detail::device_kernel_predict<kernel_function_type::polynomial><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0);
                 break;
             case kernel_function_type::rbf:
-                detail::device_kernel_predict<kernel_function_type::rbf><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::device_kernel_predict<kernel_function_type::rbf><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma));
                 break;
             case kernel_function_type::sigmoid:
-                detail::device_kernel_predict<kernel_function_type::sigmoid><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma), params.coef0);
+                detail::device_kernel_predict<kernel_function_type::sigmoid><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0);
                 break;
             case kernel_function_type::laplacian:
-                detail::device_kernel_predict<kernel_function_type::laplacian><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::device_kernel_predict<kernel_function_type::laplacian><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma));
                 break;
             case kernel_function_type::chi_squared:
-                detail::device_kernel_predict<kernel_function_type::chi_squared><<<grid, block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::device_kernel_predict<kernel_function_type::chi_squared><<<native_partial_grid, native_block>>>(out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma));
                 break;
         }
     }

--- a/src/plssvm/backends/HIP/csvm.hip
+++ b/src/plssvm/backends/HIP/csvm.hip
@@ -6,8 +6,10 @@
  *          See the LICENSE.md file in the project root for full license information.
  */
 
-#include "plssvm/backend_types.hpp"  // plssvm::backend_type
 #include "plssvm/backends/HIP/csvm.hpp"
+
+#include "plssvm/backend_types.hpp"                                                    // plssvm::backend_type
+#include "plssvm/backends/execution_range.hpp"                                         // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/HIP/detail/device_ptr.hip.hpp"                               // plssvm::hip::detail::device_ptr
 #include "plssvm/backends/HIP/detail/utility.hip.hpp"                                  // PLSSVM_HIP_ERROR_CHECK, plssvm::hip::detail::{device_synchronize, get_device_count, set_device, peek_at_last_error, get_runtime_version}
 #include "plssvm/backends/HIP/exceptions.hpp"                                          // plssvm::hip::backend_exception

--- a/src/plssvm/backends/HIP/detail/utility.hip
+++ b/src/plssvm/backends/HIP/detail/utility.hip
@@ -8,6 +8,8 @@
 
 #include "plssvm/backends/HIP/detail/utility.hip.hpp"
 
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+
 #include "hip/hip_runtime_api.h"  // hipGetDeviceCount, hipSetDevice, hipPeekAtLastError, hipDeviceSynchronize, hipRuntimeGetVersion
 
 #include "fmt/core.h"  // fmt::format
@@ -15,6 +17,10 @@
 #include <string>  // std::string
 
 namespace plssvm::hip::detail {
+
+dim3 dim_type_to_native(const ::plssvm::detail::dim_type &dims) {
+    return dim3{ static_cast<unsigned int>(dims.x), static_cast<unsigned int>(dims.y), static_cast<unsigned int>(dims.z) };
+}
 
 [[nodiscard]] int get_device_count() {
     int count{};

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -285,9 +285,8 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
 
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to OpenCL's native std::vector
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         // cast offsets to OpenCL type
@@ -330,13 +329,12 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const cl_ulong row_offset = data_distribution_->place_row_offset(device_id);
 
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
+
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        // convert execution range block to OpenCL's native std::vector
-        const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
-
-        const auto [partial_grid, offsets] = grid;
+    for (const auto &[partial_grid, offsets] : exec.grids) {
         // convert execution range grid[i] to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
@@ -346,22 +344,22 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
 
         detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
     }
-    for (const auto &mirror_grid : mirror_exec.grids) {
+
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_mirror_block = detail::dim_type_to_native<2>(mirror_exec.block);
+
+    for (const auto &[partial_grid, offsets] : mirror_exec.grids) {
         const cl_ulong num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
         if (num_mirror_rows > 0) {
-            // convert execution range block to OpenCL's native std::vector
-            const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(mirror_exec.block);
-
-            const auto [partial_grid, offsets] = mirror_grid;
             // convert execution range grid[i] to OpenCL's native std::vector
-            const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+            const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_mirror_block;
 
             // cast offsets to OpenCL type
             const cl_ulong grid_offset_x = offsets.x;
             const cl_ulong grid_offset_y = offsets.y;
 
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::mirror_symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
+            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::mirror_symm_kernel_explicit), native_partial_grid, native_mirror_block, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
         }
     }
     detail::device_synchronize(device);
@@ -376,9 +374,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plss
 
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to OpenCL's native std::vector
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         // cast offsets to OpenCL type
@@ -399,9 +396,8 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm:
 
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to OpenCL's native std::vector
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         // cast offsets to OpenCL type
@@ -431,9 +427,8 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to OpenCL's native std::vector
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         // cast offsets to OpenCL type
@@ -485,9 +480,8 @@ auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::exe
 
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to OpenCL's native std::vector
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         // cast offsets to OpenCL type
@@ -515,9 +509,8 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
 
     using namespace plssvm::operators;
 
-    for (const auto &grid : exec.grids) {
-        const auto [partial_grid, offsets] = grid;
-        // convert execution range grid[i] to OpenCL's native std::vector
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to OpenCL's native std::vector
         const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         // cast offsets to OpenCL type

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -40,8 +40,10 @@
 #include <chrono>     // std::chrono
 #include <cmath>      // std::ceil
 #include <cstddef>    // std::size_t
+#include <cstdint>    // std::int32_t, std::uint16_t
 #include <exception>  // std::terminate
 #include <iostream>   // std::cout, std::endl
+#include <limits>     // std::numeric_limits::max
 #include <string>     // std::string
 #include <tuple>      // std::tie
 #include <utility>    // std::pair, std::make_pair, std::move
@@ -239,11 +241,26 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     return static_cast<std::size_t>(max_work_group_size);
 }
 
+::plssvm::detail::dim_type csvm::get_max_grid_size([[maybe_unused]] const std::size_t device_id) const {
+    PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
+
+    // fallback to maximum theoretical value, may break at runtime!
+    ::plssvm::detail::dim_type native_range{};
+    const std::size_t max_int32 = std::numeric_limits<std::int32_t>::max();
+    const std::size_t max_uint16 = std::numeric_limits<std::uint16_t>::max();
+    if (target_ == target_platform::cpu) {
+        native_range = ::plssvm::detail::dim_type{ max_int32, max_int32, max_int32 };
+    } else {
+        native_range = ::plssvm::detail::dim_type{ max_int32, max_uint16, max_uint16 };
+    }
+    return native_range;
+}
+
 //***************************************************//
 //                        fit                        //
 //***************************************************//
 
-auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
+auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const cl_ulong num_rows_reduced = data_d.shape().x - 1;
     const cl_ulong num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -254,15 +271,6 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     // get the offset of the data points this device is responsible for
     const cl_ulong row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                            static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
     const std::size_t num_entries_padded = dist.calculate_explicit_kernel_matrix_num_entries_padded(device_id);
@@ -270,32 +278,47 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     device_ptr_type kernel_matrix_d{ num_entries_padded, device };  // only explicitly store the upper triangular matrix
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), grid, block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor);
-            break;
-        case kernel_function_type::polynomial:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), grid, block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, params.degree, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::rbf:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), grid, block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::sigmoid:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), grid, block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::laplacian:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), grid, block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::chi_squared:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), grid, block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma));
-            break;
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
+
+    using namespace plssvm::operators;
+
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), native_partial_grid, native_block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, grid_offset_x, grid_offset_y);
+                break;
+            case kernel_function_type::polynomial:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), native_partial_grid, native_block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, grid_offset_x, grid_offset_y, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::rbf:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), native_partial_grid, native_block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::sigmoid:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), native_partial_grid, native_block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::laplacian:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), native_partial_grid, native_block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::chi_squared:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_explicit), native_partial_grid, native_block, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
+                break;
+        }
     }
     detail::device_synchronize(device);
 
     return kernel_matrix_d;
 }
 
-void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
+void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
     const cl_ulong num_rhs = B_d.shape().x;
     const cl_ulong num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -305,71 +328,90 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     // get the offset of the data points this device is responsible for
     const cl_ulong row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
 
-    {
-        const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-        const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                                static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
+    using namespace plssvm::operators;
 
-        detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::symm_kernel_explicit), grid, block, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
-    }
+    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
+        {
+            const auto [partial_grid, offsets] = exec.grids[i];
+            // convert execution range grid[i] to OpenCL's native std::vector
+            const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
-    {
-        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+            // cast offsets to OpenCL type
+            const cl_ulong grid_offset_x = offsets.x;
+            const cl_ulong grid_offset_y = offsets.y;
 
-        if (num_mirror_rows > 0) {
-            const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-            const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                                    static_cast<std::size_t>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
+            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
+        }
 
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::mirror_symm_kernel_explicit), grid, block, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get());
+        {
+            const cl_ulong num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+            if (num_mirror_rows > 0) {
+                const auto [partial_grid, offsets] = mirror_exec.grids[i];
+                // convert execution range grid[i] to OpenCL's native std::vector
+                const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+                // cast offsets to OpenCL type
+                const cl_ulong grid_offset_x = offsets.x;
+                const cl_ulong grid_offset_y = offsets.y;
+
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::mirror_symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
+            }
         }
     }
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
+void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
     const cl_ulong num_rhs = lhs_d.shape().x;
-    const cl_ulong num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                            static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
 
-    detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::inplace_matrix_add_kernel), grid, block, num_rhs, lhs_d.get(), rhs_d.get());
+    using namespace plssvm::operators;
+
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
+
+        detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::inplace_matrix_add_kernel), native_partial_grid, native_block, num_rhs, lhs_d.get(), rhs_d.get(), grid_offset_x, grid_offset_y);
+    }
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
+void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const real_type scale) const {
     const cl_ulong num_rhs = lhs_d.shape().x;
-    const cl_ulong num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                            static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
 
-    detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::inplace_matrix_scale_kernel), grid, block, num_rhs, lhs_d.get(), scale);
+    using namespace plssvm::operators;
+
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
+
+        detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::inplace_matrix_scale_kernel), native_partial_grid, native_block, num_rhs, lhs_d.get(), scale, grid_offset_x, grid_offset_y);
+    }
     detail::device_synchronize(device);
 }
 
-void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
+void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
     const cl_ulong num_rows_reduced = A_d.shape().x - 1;
     const cl_ulong num_features = A_d.shape().y;
     const cl_ulong num_classes = B_d.shape().x;
@@ -380,36 +422,42 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     // get the offset of the data points this device is responsible for
     const cl_ulong row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                            static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), grid, block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes);
-            break;
-        case kernel_function_type::polynomial:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), grid, block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, params.degree, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::rbf:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), grid, block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::sigmoid:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), grid, block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma), params.coef0);
-            break;
-        case kernel_function_type::laplacian:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), grid, block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
-        case kernel_function_type::chi_squared:
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), grid, block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma));
-            break;
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
+
+    using namespace plssvm::operators;
+
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), native_partial_grid, native_block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, grid_offset_x, grid_offset_y);
+                break;
+            case kernel_function_type::polynomial:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), native_partial_grid, native_block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, grid_offset_x, grid_offset_y, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::rbf:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), native_partial_grid, native_block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::sigmoid:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), native_partial_grid, native_block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma), params.coef0);
+                break;
+            case kernel_function_type::laplacian:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), native_partial_grid, native_block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
+                break;
+            case kernel_function_type::chi_squared:
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::assemble_kernel_matrix_implicit_blas), native_partial_grid, native_block, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
+                break;
+        }
     }
     detail::device_synchronize(device);
 }
@@ -418,7 +466,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //                   predict, score                  //
 //***************************************************//
 
-auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
+auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
     const cl_ulong num_classes = alpha_d.shape().x;
     const cl_ulong num_sv = alpha_d.shape().y;
     const cl_ulong device_specific_num_sv = sv_d.shape().x;
@@ -428,69 +476,70 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
     // get the offset of the data points this device is responsible for
     const cl_ulong sv_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                            static_cast<std::size_t>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::w_kernel), grid, block, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset);
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
+
+    using namespace plssvm::operators;
+
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
+
+        detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::w_kernel), native_partial_grid, native_block, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, grid_offset_x, grid_offset_y);
+    }
     detail::device_synchronize(device);
 
     return w_d;
 }
 
-auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
+auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
     const cl_ulong num_classes = alpha_d.shape().x;
     const cl_ulong num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
     const cl_ulong num_features = predict_points_d.shape().y;
+    const cl_ulong num_sv = sv_or_w_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // define the block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const std::vector<std::size_t> block = { THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
+    // convert execution range block to OpenCL's native std::vector
+    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
 
-    if (params.kernel_type == kernel_function_type::linear) {
-        // define the grid sizes
-        const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                                static_cast<std::size_t>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
+    using namespace plssvm::operators;
 
-        detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_linear), grid, block, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features);
-    } else {
-        const cl_ulong num_sv = sv_or_w_d.shape().x;
+    for (const auto &grid : exec.grids) {
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
-        // define the grid sizes
-        const std::vector<std::size_t> grid = { static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                                static_cast<std::size_t>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                // already handled
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_linear), native_partial_grid, native_block, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, grid_offset_x, grid_offset_y);
                 break;
             case kernel_function_type::polynomial:
-                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_polynomial), grid, block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, params.degree, std::get<real_type>(params.gamma), params.coef0);
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_polynomial), native_partial_grid, native_block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, grid_offset_x, grid_offset_y, params.degree, std::get<real_type>(params.gamma), params.coef0);
                 break;
             case kernel_function_type::rbf:
-                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_rbf), grid, block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_rbf), native_partial_grid, native_block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
                 break;
             case kernel_function_type::sigmoid:
-                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_sigmoid), grid, block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma), params.coef0);
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_sigmoid), native_partial_grid, native_block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma), params.coef0);
                 break;
             case kernel_function_type::laplacian:
-                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_laplacian), grid, block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_laplacian), native_partial_grid, native_block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
                 break;
             case kernel_function_type::chi_squared:
-                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_chi_squared), grid, block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma));
+                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::predict_kernel_chi_squared), native_partial_grid, native_block, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, grid_offset_x, grid_offset_y, std::get<real_type>(params.gamma));
                 break;
         }
     }

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -330,14 +330,30 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const cl_ulong row_offset = data_distribution_->place_row_offset(device_id);
 
-    // convert execution range block to OpenCL's native std::vector
-    const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
-
     using namespace plssvm::operators;
 
-    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
-        {
-            const auto [partial_grid, offsets] = exec.grids[i];
+    for (const auto &grid : exec.grids) {
+        // convert execution range block to OpenCL's native std::vector
+        const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(exec.block);
+
+        const auto [partial_grid, offsets] = grid;
+        // convert execution range grid[i] to OpenCL's native std::vector
+        const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        // cast offsets to OpenCL type
+        const cl_ulong grid_offset_x = offsets.x;
+        const cl_ulong grid_offset_y = offsets.y;
+
+        detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
+    }
+    for (const auto &mirror_grid : mirror_exec.grids) {
+        const cl_ulong num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+        if (num_mirror_rows > 0) {
+            // convert execution range block to OpenCL's native std::vector
+            const std::vector<std::size_t> native_block = detail::dim_type_to_native<2>(mirror_exec.block);
+
+            const auto [partial_grid, offsets] = mirror_grid;
             // convert execution range grid[i] to OpenCL's native std::vector
             const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
@@ -345,23 +361,7 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
             const cl_ulong grid_offset_x = offsets.x;
             const cl_ulong grid_offset_y = offsets.y;
 
-            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
-        }
-
-        {
-            const cl_ulong num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
-
-            if (num_mirror_rows > 0) {
-                const auto [partial_grid, offsets] = mirror_exec.grids[i];
-                // convert execution range grid[i] to OpenCL's native std::vector
-                const std::vector<std::size_t> native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
-
-                // cast offsets to OpenCL type
-                const cl_ulong grid_offset_x = offsets.x;
-                const cl_ulong grid_offset_y = offsets.y;
-
-                detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::mirror_symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
-            }
+            detail::run_kernel(device, device.get_kernel(detail::compute_kernel_name::mirror_symm_kernel_explicit), native_partial_grid, native_block, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), grid_offset_x, grid_offset_y);
         }
     }
     detail::device_synchronize(device);

--- a/src/plssvm/backends/OpenCL/csvm.cpp
+++ b/src/plssvm/backends/OpenCL/csvm.cpp
@@ -9,6 +9,7 @@
 #include "plssvm/backends/OpenCL/csvm.hpp"
 
 #include "plssvm/backend_types.hpp"                         // plssvm::backend_type
+#include "plssvm/backends/execution_range.hpp"              // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/OpenCL/detail/command_queue.hpp"  // plssvm::opencl::detail::command_queue
 #include "plssvm/backends/OpenCL/detail/context.hpp"        // plssvm::opencl::detail::context
 #include "plssvm/backends/OpenCL/detail/device_ptr.hpp"     // plssvm::opencl::detail::device_ptr
@@ -244,6 +245,7 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
 ::plssvm::detail::dim_type csvm::get_max_grid_size([[maybe_unused]] const std::size_t device_id) const {
     PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
 
+    // TODO: replace with function if there will be one in the future
     // fallback to maximum theoretical value, may break at runtime!
     ::plssvm::detail::dim_type native_range{};
     const std::size_t max_int32 = std::numeric_limits<std::int32_t>::max();

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -9,6 +9,7 @@
 #include "plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp"
 
 #include "plssvm/backend_types.hpp"                                                 // plssvm::backend_type
+#include "plssvm/backends/execution_range.hpp"                                      // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/SYCL/AdaptiveCpp/detail/device_ptr.hpp"                   // plssvm::adaptivecpp::detail::::device_ptr
 #include "plssvm/backends/SYCL/AdaptiveCpp/detail/queue_impl.hpp"                   // plssvm::adaptivecpp::detail::queue (PImpl implementation)
 #include "plssvm/backends/SYCL/AdaptiveCpp/detail/utility.hpp"                      // plssvm::adaptivecpp::detail::{get_device_list, device_synchronize, get_adaptivecpp_version_short, get_adaptivecpp_version}
@@ -183,6 +184,7 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
 ::plssvm::detail::dim_type csvm::get_max_grid_size([[maybe_unused]] const std::size_t device_id) const {
     PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
 
+    // TODO: replace with function if there will be one in the future
     // fallback to maximum theoretical value, may break at runtime!
     ::sycl::id<3> native_range{};
     const std::size_t max_int32 = std::numeric_limits<std::int32_t>::max();

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -180,7 +180,7 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     return devices_[device_id].impl->sycl_queue.get_device().get_info<::sycl::info::device::max_work_group_size>();
 }
 
-::plssvm::detail::dim_type csvm::get_max_grid_size(const std::size_t device_id) const {
+::plssvm::detail::dim_type csvm::get_max_grid_size([[maybe_unused]] const std::size_t device_id) const {
     PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
 
     // fallback to maximum theoretical value, may break at runtime!

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -40,8 +40,10 @@
 #include "fmt/ostream.h"  // can use fmt using operator<< overloads
 
 #include <cstddef>    // std::size_t
+#include <cstdint>    // std::int32_t, std::uint16_t
 #include <exception>  // std::terminate
 #include <iostream>   // std::cout, std::endl
+#include <limits>     // std::numeric_limits::max
 #include <string>     // std::string
 #include <tuple>      // std::tie
 #include <variant>    // std::get
@@ -178,11 +180,28 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     return devices_[device_id].impl->sycl_queue.get_device().get_info<::sycl::info::device::max_work_group_size>();
 }
 
+::plssvm::detail::dim_type csvm::get_max_grid_size(const std::size_t device_id) const {
+    PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
+
+    // fallback to maximum theoretical value, may break at runtime!
+    ::sycl::id<3> native_range{};
+    const std::size_t max_int32 = std::numeric_limits<std::int32_t>::max();
+    const std::size_t max_uint16 = std::numeric_limits<std::uint16_t>::max();
+    if (target_ == target_platform::cpu) {
+        native_range = ::sycl::id<3>{ max_int32, max_int32, max_int32 };
+    } else {
+        native_range = ::sycl::id<3>{ max_int32, max_uint16, max_uint16 };
+    }
+
+    // note: account for SYCL's different iteration range!
+    return { native_range[2], native_range[1], native_range[0] };
+}
+
 //***************************************************//
 //                        fit                        //
 //***************************************************//
 
-auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
+auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const std::size_t num_rows_reduced = data_d.shape().x - 1;
     const std::size_t num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -193,16 +212,6 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
-
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
     const std::size_t num_entries_padded = dist.calculate_explicit_kernel_matrix_num_entries_padded(device_id);
@@ -210,49 +219,63 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     device_ptr_type kernel_matrix_d{ num_entries_padded, device };  // only explicitly store the upper triangular matrix
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(execution_range, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor });
-            });
-            break;
-        case kernel_function_type::polynomial:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, params.degree, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::rbf:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::rbf, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::sigmoid:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::laplacian:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::laplacian, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::chi_squared:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::chi_squared, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma) });
-            });
-            break;
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y });
+                });
+                break;
+            case kernel_function_type::polynomial:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::rbf:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::rbf, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::sigmoid:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::laplacian:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::laplacian, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::chi_squared:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::chi_squared, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+        }
     }
     detail::device_synchronize(device);
 
     return kernel_matrix_d;
 }
 
-void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
+void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
     const std::size_t num_rhs = B_d.shape().x;
     const std::size_t num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -262,79 +285,92 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    {
-        const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-        const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                     static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-        const ::sycl::nd_range<2> execution_range{ grid, block };
+    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
+        {
+            // capturing structured bindings is a C++20 extension
+            ::plssvm::detail::dim_type partial_grid{};
+            ::plssvm::detail::dim_type offsets{};
+            std::tie(partial_grid, offsets) = exec.grids[i];
+            // convert execution range grid[i] to SYCL's native range<3>
+            const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
-        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(execution_range, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get() });
-        });
-    }
-
-    {
-        const std::size_t num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
-
-        if (num_mirror_rows > 0) {
-            const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-            const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                         static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-            const ::sycl::nd_range<2> execution_range{ grid, block };
+            const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
             device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(execution_range, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get() });
+                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y });
             });
+        }
+
+        {
+            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+            if (num_mirror_rows > 0) {
+                // capturing structured bindings is a C++20 extension
+                ::plssvm::detail::dim_type partial_grid{};
+                ::plssvm::detail::dim_type offsets{};
+                std::tie(partial_grid, offsets) = mirror_exec.grids[i];
+                // convert execution range grid[i] to SYCL's native range<3>
+                const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+                const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y });
+                });
+            }
         }
     }
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
+void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
     const std::size_t num_rhs = lhs_d.shape().x;
-    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    device.impl->sycl_queue.parallel_for(execution_range, sycl::detail::device_kernel_inplace_matrix_add{ num_rhs, lhs_d.get(), rhs_d.get() });
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_add{ num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y });
+    }
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
+void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const real_type scale) const {
     const std::size_t num_rhs = lhs_d.shape().x;
-    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    device.impl->sycl_queue.parallel_for(execution_range, sycl::detail::device_kernel_inplace_matrix_scale{ num_rhs, lhs_d.get(), scale });
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_scale{ num_rhs, lhs_d.get(), scale, offsets.x, offsets.y });
+    }
     detail::device_synchronize(device);
 }
 
-void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
+void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
     const std::size_t num_rows_reduced = A_d.shape().x - 1;
     const std::size_t num_features = A_d.shape().y;
     const std::size_t num_classes = B_d.shape().x;
@@ -345,54 +381,58 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
-
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(execution_range, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes });
-            });
-            break;
-        case kernel_function_type::polynomial:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, params.degree, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::rbf:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::rbf, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::sigmoid:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::laplacian:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::laplacian, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::chi_squared:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::chi_squared, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma) });
-            });
-            break;
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y });
+                });
+                break;
+            case kernel_function_type::polynomial:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::rbf:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::rbf, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::sigmoid:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::laplacian:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::laplacian, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::chi_squared:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::chi_squared, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+        }
     }
     detail::device_synchronize(device);
 }
@@ -401,7 +441,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //                   predict, score                  //
 //***************************************************//
 
-auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
+auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
     const std::size_t num_classes = alpha_d.shape().x;
     const std::size_t num_sv = alpha_d.shape().y;
     const std::size_t device_specific_num_sv = sv_d.shape().x;
@@ -411,88 +451,86 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
     // get the offset of the data points this device is responsible for
     const std::size_t sv_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
-
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-        cgh.parallel_for(execution_range, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset });
-    });
-    detail::device_synchronize(devices_[0]);
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+            cgh.parallel_for(native_exec, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y });
+        });
+    }
+    detail::device_synchronize(device);
 
     return w_d;
 }
 
-auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
+auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
     const std::size_t num_classes = alpha_d.shape().x;
     const std::size_t num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
     const std::size_t num_features = predict_points_d.shape().y;
+    const std::size_t num_sv = sv_or_w_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // define block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    if (params.kernel_type == kernel_function_type::linear) {
-        const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                     static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-        const ::sycl::nd_range<2> execution_range{ grid, block };
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
-        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(execution_range, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features });
-        });
-    } else {
-        const std::size_t num_sv = sv_or_w_d.shape().x;
-
-        const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                     static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-        const ::sycl::nd_range<2> execution_range{ grid, block };
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                // already handled
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.x, offsets.y });
+                });
                 break;
             case kernel_function_type::polynomial:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
                 });
                 break;
         }

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -225,50 +225,46 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (const auto &grid : exec.grids) {
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x });
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets_ref.y, offsets_ref.x });
                 });
                 break;
             case kernel_function_type::polynomial:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets_ref.y, offsets_ref.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
         }
@@ -288,41 +284,34 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    for (const auto &grid : exec.grids) {
-        // convert execution range block to SYCL's native range<2>
-        const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+    // convert execution range block to SYCL's native range<2>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
-        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
+        device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
+            cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets_ref.y, offsets_ref.x });
         });
     }
-    for (const auto &mirror_grid : mirror_exec.grids) {
+
+    // convert execution range block to SYCL's native range<2>
+    const ::sycl::range native_mirror_block = detail::dim_type_to_native<2>(mirror_exec.block);
+
+    for (const auto &[partial_grid, offsets] : mirror_exec.grids) {
         const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
 
         if (num_mirror_rows > 0) {
-            // convert execution range block to SYCL's native range<2>
-            const ::sycl::range native_block = detail::dim_type_to_native<2>(mirror_exec.block);
+            // convert execution range partial_grid to SYCL's native range<2>
+            const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_mirror_block;
 
-            // capturing structured bindings is a C++20 extension
-            ::plssvm::detail::dim_type partial_grid{};
-            ::plssvm::detail::dim_type offsets{};
-            std::tie(partial_grid, offsets) = mirror_grid;
-            // convert execution range grid[i] to SYCL's native range<2>
-            const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+            const ::sycl::nd_range native_exec{ native_partial_grid, native_mirror_block };
 
-            const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
-
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
+            device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
+                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets_ref.y, offsets_ref.x });
             });
         }
     }
@@ -336,12 +325,8 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plss
     // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (const auto &grid : exec.grids) {
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
@@ -358,12 +343,8 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm:
     // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (const auto &grid : exec.grids) {
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
@@ -389,50 +370,46 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (const auto &grid : exec.grids) {
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x });
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets_ref.y, offsets_ref.x });
                 });
                 break;
             case kernel_function_type::polynomial:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets_ref.y, offsets_ref.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
         }
@@ -459,18 +436,14 @@ auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::exe
     // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (const auto &grid : exec.grids) {
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
-        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(native_exec, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.y, offsets.x });
+        device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
+            cgh.parallel_for(native_exec, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets_ref.y, offsets_ref.x });
         });
     }
     detail::device_synchronize(device);
@@ -490,50 +463,46 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
     // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (const auto &grid : exec.grids) {
-        // capturing structured bindings is a C++20 extension
-        ::plssvm::detail::dim_type partial_grid{};
-        ::plssvm::detail::dim_type offsets{};
-        std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<2>
+    for (const auto &[partial_grid, offsets] : exec.grids) {
+        // convert execution range partial_grid to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.y, offsets.x });
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets_ref.y, offsets_ref.x });
                 });
                 break;
             case kernel_function_type::polynomial:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets_ref.y, offsets_ref.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                device.impl->sycl_queue.submit([&, &offsets_ref = offsets](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets_ref.y, offsets_ref.x, std::get<real_type>(params.gamma) });
                 });
                 break;
         }

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -22,6 +22,7 @@
 #include "plssvm/backends/SYCL/kernel_invocation_types.hpp"                         // plssvm::kernel_invocation_type
 #include "plssvm/constants.hpp"                                                     // plssvm::{real_type, THREAD_BLOCK_SIZE, INTERNAL_BLOCK_SIZE, PADDING_SIZE}
 #include "plssvm/detail/assert.hpp"                                                 // PLSSVM_ASSERT
+#include "plssvm/detail/data_distribution.hpp"                                      // plssvm::detail::{data_distribution, triangular_data_distribution, rectangular_data_distribution}
 #include "plssvm/detail/logging.hpp"                                                // plssvm::detail::log
 #include "plssvm/detail/memory_size.hpp"                                            // plssvm::detail::memory_size
 #include "plssvm/detail/performance_tracker.hpp"                                    // plssvm::detail::tracking_entry
@@ -221,7 +222,7 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     device_ptr_type kernel_matrix_d{ num_entries_padded, device };  // only explicitly store the upper triangular matrix
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (const auto &grid : exec.grids) {
@@ -229,7 +230,7 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
         ::plssvm::detail::dim_type partial_grid{};
         ::plssvm::detail::dim_type offsets{};
         std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<3>
+        // convert execution range grid[i] to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
@@ -237,37 +238,37 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
         switch (params.kernel_type) {
             case kernel_function_type::linear:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y });
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x });
                 });
                 break;
             case kernel_function_type::polynomial:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
         }
@@ -287,7 +288,7 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (std::size_t i = 0; i < exec.grids.size(); ++i) {
@@ -296,13 +297,13 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
             ::plssvm::detail::dim_type partial_grid{};
             ::plssvm::detail::dim_type offsets{};
             std::tie(partial_grid, offsets) = exec.grids[i];
-            // convert execution range grid[i] to SYCL's native range<3>
+            // convert execution range grid[i] to SYCL's native range<2>
             const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
             const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
             device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y });
+                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
             });
         }
 
@@ -314,13 +315,13 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
                 ::plssvm::detail::dim_type partial_grid{};
                 ::plssvm::detail::dim_type offsets{};
                 std::tie(partial_grid, offsets) = mirror_exec.grids[i];
-                // convert execution range grid[i] to SYCL's native range<3>
+                // convert execution range grid[i] to SYCL's native range<2>
                 const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
                 const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y });
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
                 });
             }
         }
@@ -332,7 +333,7 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plss
     const std::size_t num_rhs = lhs_d.shape().x;
     const queue_type &device = devices_[device_id];
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (const auto &grid : exec.grids) {
@@ -340,12 +341,12 @@ void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plss
         ::plssvm::detail::dim_type partial_grid{};
         ::plssvm::detail::dim_type offsets{};
         std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<3>
+        // convert execution range grid[i] to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
-        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_add{ num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y });
+        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_add{ num_rhs, lhs_d.get(), rhs_d.get(), offsets.y, offsets.x });
     }
     detail::device_synchronize(device);
 }
@@ -354,7 +355,7 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm:
     const std::size_t num_rhs = lhs_d.shape().x;
     const queue_type &device = devices_[device_id];
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (const auto &grid : exec.grids) {
@@ -362,12 +363,12 @@ void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm:
         ::plssvm::detail::dim_type partial_grid{};
         ::plssvm::detail::dim_type offsets{};
         std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<3>
+        // convert execution range grid[i] to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
-        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_scale{ num_rhs, lhs_d.get(), scale, offsets.x, offsets.y });
+        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_scale{ num_rhs, lhs_d.get(), scale, offsets.y, offsets.x });
     }
     detail::device_synchronize(device);
 }
@@ -385,7 +386,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (const auto &grid : exec.grids) {
@@ -393,7 +394,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
         ::plssvm::detail::dim_type partial_grid{};
         ::plssvm::detail::dim_type offsets{};
         std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<3>
+        // convert execution range grid[i] to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
@@ -401,37 +402,37 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
         switch (params.kernel_type) {
             case kernel_function_type::linear:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y });
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x });
                 });
                 break;
             case kernel_function_type::polynomial:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
         }
@@ -455,7 +456,7 @@ auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::exe
 
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (const auto &grid : exec.grids) {
@@ -463,13 +464,13 @@ auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::exe
         ::plssvm::detail::dim_type partial_grid{};
         ::plssvm::detail::dim_type offsets{};
         std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<3>
+        // convert execution range grid[i] to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
         device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(native_exec, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y });
+            cgh.parallel_for(native_exec, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.y, offsets.x });
         });
     }
     detail::device_synchronize(device);
@@ -486,7 +487,7 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // convert execution range block to SYCL's native range<3>
+    // convert execution range block to SYCL's native range<2>
     const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
     for (const auto &grid : exec.grids) {
@@ -494,7 +495,7 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
         ::plssvm::detail::dim_type partial_grid{};
         ::plssvm::detail::dim_type offsets{};
         std::tie(partial_grid, offsets) = grid;
-        // convert execution range grid[i] to SYCL's native range<3>
+        // convert execution range grid[i] to SYCL's native range<2>
         const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
         const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
@@ -502,37 +503,37 @@ auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detai
         switch (params.kernel_type) {
             case kernel_function_type::linear:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.x, offsets.y });
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.y, offsets.x });
                 });
                 break;
             case kernel_function_type::polynomial:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.y, offsets.x, std::get<real_type>(params.gamma) });
                 });
                 break;
         }

--- a/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
+++ b/src/plssvm/backends/SYCL/AdaptiveCpp/csvm.cpp
@@ -288,42 +288,42 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const :
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // convert execution range block to SYCL's native range<2>
-    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+    for (const auto &grid : exec.grids) {
+        // convert execution range block to SYCL's native range<2>
+        const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
-        {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<2>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+            cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
+        });
+    }
+    for (const auto &mirror_grid : mirror_exec.grids) {
+        const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+        if (num_mirror_rows > 0) {
+            // convert execution range block to SYCL's native range<2>
+            const ::sycl::range native_block = detail::dim_type_to_native<2>(mirror_exec.block);
+
             // capturing structured bindings is a C++20 extension
             ::plssvm::detail::dim_type partial_grid{};
             ::plssvm::detail::dim_type offsets{};
-            std::tie(partial_grid, offsets) = exec.grids[i];
+            std::tie(partial_grid, offsets) = mirror_grid;
             // convert execution range grid[i] to SYCL's native range<2>
             const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
             const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
             device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
+                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
             });
-        }
-
-        {
-            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
-
-            if (num_mirror_rows > 0) {
-                // capturing structured bindings is a C++20 extension
-                ::plssvm::detail::dim_type partial_grid{};
-                ::plssvm::detail::dim_type offsets{};
-                std::tie(partial_grid, offsets) = mirror_exec.grids[i];
-                // convert execution range grid[i] to SYCL's native range<2>
-                const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
-
-                const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
-
-                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.y, offsets.x });
-                });
-            }
         }
     }
     detail::device_synchronize(device);

--- a/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
+++ b/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
@@ -9,7 +9,7 @@
 #include "plssvm/backends/SYCL/DPCPP/csvm.hpp"
 
 #include "plssvm/backend_types.hpp"                                                 // plssvm::backend_type
-#include "plssvm/backends/execution_range.hpp"                                      // plssvm::detail::dim_type
+#include "plssvm/backends/execution_range.hpp"                                      // plssvm::detail::{dim_type, execution_range}
 #include "plssvm/backends/SYCL/DPCPP/detail/device_ptr.hpp"                         // plssvm::dpcpp::detail::::device_ptr
 #include "plssvm/backends/SYCL/DPCPP/detail/queue_impl.hpp"                         // plssvm::dpcpp::detail::queue (PImpl implementation)
 #include "plssvm/backends/SYCL/DPCPP/detail/utility.hpp"                            // plssvm::dpcpp::detail::{get_device_list, device_synchronize, get_dpcpp_version}
@@ -169,6 +169,7 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
 ::plssvm::detail::dim_type csvm::get_max_grid_size(const std::size_t device_id) const {
     PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
 
+    // TODO: replace with standardized function if there will be one in the future
 #if defined(SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY)
     const ::sycl::id<3> native_range = devices_[device_id].impl->sycl_queue.get_device().get_info<::sycl::ext::oneapi::experimental::info::device::max_work_groups<3>>();
 #else

--- a/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
+++ b/src/plssvm/backends/SYCL/DPCPP/csvm.cpp
@@ -9,6 +9,7 @@
 #include "plssvm/backends/SYCL/DPCPP/csvm.hpp"
 
 #include "plssvm/backend_types.hpp"                                                 // plssvm::backend_type
+#include "plssvm/backends/execution_range.hpp"                                      // plssvm::detail::dim_type
 #include "plssvm/backends/SYCL/DPCPP/detail/device_ptr.hpp"                         // plssvm::dpcpp::detail::::device_ptr
 #include "plssvm/backends/SYCL/DPCPP/detail/queue_impl.hpp"                         // plssvm::dpcpp::detail::queue (PImpl implementation)
 #include "plssvm/backends/SYCL/DPCPP/detail/utility.hpp"                            // plssvm::dpcpp::detail::{get_device_list, device_synchronize, get_dpcpp_version}
@@ -41,6 +42,7 @@
 #include <cstddef>    // std::size_t
 #include <exception>  // std::terminate
 #include <iostream>   // std::cout, std::endl
+#include <limits>     // std::numeric_limits::max
 #include <string>     // std::string
 #include <tuple>      // std::tie
 #include <variant>    // std::get
@@ -163,11 +165,25 @@ std::size_t csvm::get_max_work_group_size(const std::size_t device_id) const {
     return devices_[device_id].impl->sycl_queue.get_device().get_info<::sycl::info::device::max_work_group_size>();
 }
 
+::plssvm::detail::dim_type csvm::get_max_grid_size(const std::size_t device_id) const {
+    PLSSVM_ASSERT(device_id < this->num_available_devices(), "Invalid device {} requested!", device_id);
+
+#if defined(SYCL_EXT_ONEAPI_MAX_WORK_GROUP_QUERY)
+    const ::sycl::id<3> native_range = devices_[device_id].impl->sycl_queue.get_device().get_info<::sycl::ext::oneapi::experimental::info::device::max_work_groups<3>>();
+#else
+    // fallback to maximum theoretical value, may break at runtime!
+    const std::size_t max_value = std::numeric_limits<std::size_t>::max();
+    const ::sycl::id<3> native_range{ max_value, max_value, max_value };
+#endif
+    // note: account for SYCL's different iteration range!
+    return { native_range[2], native_range[1], native_range[0] };
+}
+
 //***************************************************//
 //                        fit                        //
 //***************************************************//
 
-auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
+auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &data_d, const device_ptr_type &q_red_d, real_type QA_cost) const -> device_ptr_type {
     const std::size_t num_rows_reduced = data_d.shape().x - 1;
     const std::size_t num_features = data_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -178,16 +194,6 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
-
     // calculate the number of matrix entries
     const ::plssvm::detail::triangular_data_distribution &dist = dynamic_cast<::plssvm::detail::triangular_data_distribution &>(*data_distribution_);
     const std::size_t num_entries_padded = dist.calculate_explicit_kernel_matrix_num_entries_padded(device_id);
@@ -195,49 +201,63 @@ auto csvm::run_assemble_kernel_matrix_explicit(const std::size_t device_id, cons
     device_ptr_type kernel_matrix_d{ num_entries_padded, device };  // only explicitly store the upper triangular matrix
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(execution_range, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor });
-            });
-            break;
-        case kernel_function_type::polynomial:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, params.degree, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::rbf:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::rbf, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::sigmoid:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::laplacian:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::laplacian, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::chi_squared:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::chi_squared, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, std::get<real_type>(params.gamma) });
-            });
-            break;
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly<kernel_function_type::linear>{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y });
+                });
+                break;
+            case kernel_function_type::polynomial:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::rbf:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::rbf, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::sigmoid:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::laplacian:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::laplacian, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::chi_squared:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly<kernel_function_type::chi_squared, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, kernel_matrix_d.get(), data_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, q_red_d.get(), QA_cost, cost_factor, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+        }
     }
     detail::device_synchronize(device);
 
     return kernel_matrix_d;
 }
 
-void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
+void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const ::plssvm::detail::execution_range &mirror_exec, const real_type alpha, const device_ptr_type &A_d, const device_ptr_type &B_d, const real_type beta, device_ptr_type &C_d) const {
     const std::size_t num_rhs = B_d.shape().x;
     const std::size_t num_rows = B_d.shape().y;
     const queue_type &device = devices_[device_id];
@@ -247,79 +267,92 @@ void csvm::run_blas_level_3_kernel_explicit(const std::size_t device_id, const r
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    {
-        const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-        const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                     static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-        const ::sycl::nd_range<2> execution_range{ grid, block };
+    for (std::size_t i = 0; i < exec.grids.size(); ++i) {
+        {
+            // capturing structured bindings is a C++20 extension
+            ::plssvm::detail::dim_type partial_grid{};
+            ::plssvm::detail::dim_type offsets{};
+            std::tie(partial_grid, offsets) = exec.grids[i];
+            // convert execution range grid[i] to SYCL's native range<3>
+            const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
-        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(execution_range, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get() });
-        });
-    }
-
-    {
-        const std::size_t num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
-
-        if (num_mirror_rows > 0) {
-            const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-            const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_mirror_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                         static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-            const ::sycl::nd_range<2> execution_range{ grid, block };
+            const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
             device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(execution_range, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get() });
+                cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm{ cgh, num_rows, num_rhs, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y });
             });
+        }
+
+        {
+            const unsigned long long num_mirror_rows = num_rows - row_offset - device_specific_num_rows;
+
+            if (num_mirror_rows > 0) {
+                // capturing structured bindings is a C++20 extension
+                ::plssvm::detail::dim_type partial_grid{};
+                ::plssvm::detail::dim_type offsets{};
+                std::tie(partial_grid, offsets) = mirror_exec.grids[i];
+                // convert execution range grid[i] to SYCL's native range<3>
+                const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+                const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_symm_mirror{ cgh, num_rows, num_rhs, num_mirror_rows, device_specific_num_rows, row_offset, alpha, A_d.get(), B_d.get(), beta, C_d.get(), offsets.x, offsets.y });
+                });
+            }
         }
     }
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_addition(const std::size_t device_id, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
+void csvm::run_inplace_matrix_addition(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const device_ptr_type &rhs_d) const {
     const std::size_t num_rhs = lhs_d.shape().x;
-    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    device.impl->sycl_queue.parallel_for(execution_range, sycl::detail::device_kernel_inplace_matrix_add{ num_rhs, lhs_d.get(), rhs_d.get() });
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_add{ num_rhs, lhs_d.get(), rhs_d.get(), offsets.x, offsets.y });
+    }
     detail::device_synchronize(device);
 }
 
-void csvm::run_inplace_matrix_scale(const std::size_t device_id, device_ptr_type &lhs_d, const real_type scale) const {
+void csvm::run_inplace_matrix_scale(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, device_ptr_type &lhs_d, const real_type scale) const {
     const std::size_t num_rhs = lhs_d.shape().x;
-    const std::size_t num_rows = lhs_d.shape().y;
     const queue_type &device = devices_[device_id];
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_rhs) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    device.impl->sycl_queue.parallel_for(execution_range, sycl::detail::device_kernel_inplace_matrix_scale{ num_rhs, lhs_d.get(), scale });
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.parallel_for(native_exec, sycl::detail::device_kernel_inplace_matrix_scale{ num_rhs, lhs_d.get(), scale, offsets.x, offsets.y });
+    }
     detail::device_synchronize(device);
 }
 
-void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
+void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const real_type alpha, const device_ptr_type &A_d, const parameter &params, const device_ptr_type &q_red, const real_type QA_cost, const device_ptr_type &B_d, device_ptr_type &C_d) const {
     const std::size_t num_rows_reduced = A_d.shape().x - 1;
     const std::size_t num_features = A_d.shape().y;
     const std::size_t num_classes = B_d.shape().x;
@@ -330,54 +363,58 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
     // get the offset of the data points this device is responsible for
     const std::size_t row_offset = data_distribution_->place_row_offset(device_id);
 
-    // define the grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(device_specific_num_rows) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_rows_reduced - row_offset) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
-
     const real_type cost_factor = real_type{ 1.0 } / params.cost;
 
-    switch (params.kernel_type) {
-        case kernel_function_type::linear:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                cgh.parallel_for(execution_range, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes });
-            });
-            break;
-        case kernel_function_type::polynomial:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, params.degree, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::rbf:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::rbf, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::sigmoid:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma), params.coef0 });
-            });
-            break;
-        case kernel_function_type::laplacian:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::laplacian, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma) });
-            });
-            break;
-        case kernel_function_type::chi_squared:
-            device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-                using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::chi_squared, real_type>;
-                cgh.parallel_for(execution_range, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, std::get<real_type>(params.gamma) });
-            });
-            break;
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        switch (params.kernel_type) {
+            case kernel_function_type::linear:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_assembly_symm<kernel_function_type::linear>{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y });
+                });
+                break;
+            case kernel_function_type::polynomial:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::rbf:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::rbf, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::sigmoid:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
+                });
+                break;
+            case kernel_function_type::laplacian:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::laplacian, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+            case kernel_function_type::chi_squared:
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    using functor_type = sycl::detail::device_kernel_assembly_symm<kernel_function_type::chi_squared, real_type>;
+                    cgh.parallel_for(native_exec, functor_type{ cgh, alpha, q_red.get(), A_d.get(), num_rows_reduced, device_specific_num_rows, row_offset, num_features, QA_cost, cost_factor, B_d.get(), C_d.get(), num_classes, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
+                });
+                break;
+        }
     }
     detail::device_synchronize(device);
 }
@@ -386,7 +423,7 @@ void csvm::run_assemble_kernel_matrix_implicit_blas_level_3(const std::size_t de
 //                   predict, score                  //
 //***************************************************//
 
-auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
+auto csvm::run_w_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const device_ptr_type &alpha_d, const device_ptr_type &sv_d) const -> device_ptr_type {
     const std::size_t num_classes = alpha_d.shape().x;
     const std::size_t num_sv = alpha_d.shape().y;
     const std::size_t device_specific_num_sv = sv_d.shape().x;
@@ -396,88 +433,86 @@ auto csvm::run_w_kernel(const std::size_t device_id, const device_ptr_type &alph
     // get the offset of the data points this device is responsible for
     const std::size_t sv_offset = data_distribution_->place_row_offset(device_id);
 
-    // define grid and block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
-    const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                 static_cast<std::size_t>(std::ceil(static_cast<double>(num_features) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-    const ::sycl::nd_range<2> execution_range{ grid, block };
-
     device_ptr_type w_d{ shape{ num_classes, num_features }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-        cgh.parallel_for(execution_range, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset });
-    });
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
+
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
+
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
+
+        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+            cgh.parallel_for(native_exec, sycl::detail::device_kernel_w_linear{ cgh, w_d.get(), alpha_d.get(), sv_d.get(), num_classes, num_sv, device_specific_num_sv, sv_offset, offsets.x, offsets.y });
+        });
+    }
     detail::device_synchronize(device);
 
     return w_d;
 }
 
-auto csvm::run_predict_kernel(const std::size_t device_id, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
+auto csvm::run_predict_kernel(const std::size_t device_id, const ::plssvm::detail::execution_range &exec, const parameter &params, const device_ptr_type &alpha_d, const device_ptr_type &rho_d, const device_ptr_type &sv_or_w_d, const device_ptr_type &predict_points_d) const -> device_ptr_type {
     const std::size_t num_classes = alpha_d.shape().x;
     const std::size_t num_predict_points = predict_points_d.shape().x;  // = device_specific_num_rows
     const std::size_t num_features = predict_points_d.shape().y;
+    const std::size_t num_sv = sv_or_w_d.shape().x;
     const queue_type &device = devices_[device_id];
 
     device_ptr_type out_d{ shape{ num_predict_points, num_classes }, shape{ PADDING_SIZE, PADDING_SIZE }, device };
 
-    // define block sizes
-    const std::size_t max_work_group_size = this->get_max_work_group_size(device_id);
-    if (max_work_group_size < std::size_t{ THREAD_BLOCK_SIZE } * std::size_t{ THREAD_BLOCK_SIZE }) {
-        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}! Try reducing THREAD_BLOCK_SIZE.", THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE) };
-    }
-    const ::sycl::range<2> block{ THREAD_BLOCK_SIZE, THREAD_BLOCK_SIZE };
+    // convert execution range block to SYCL's native range<3>
+    const ::sycl::range native_block = detail::dim_type_to_native<2>(exec.block);
 
-    if (params.kernel_type == kernel_function_type::linear) {
-        const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_classes) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                     static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-        const ::sycl::nd_range<2> execution_range{ grid, block };
+    for (const auto &grid : exec.grids) {
+        // capturing structured bindings is a C++20 extension
+        ::plssvm::detail::dim_type partial_grid{};
+        ::plssvm::detail::dim_type offsets{};
+        std::tie(partial_grid, offsets) = grid;
+        // convert execution range grid[i] to SYCL's native range<3>
+        const ::sycl::range native_partial_grid = detail::dim_type_to_native<2>(partial_grid) * native_block;
 
-        device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
-            cgh.parallel_for(execution_range, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features });
-        });
-    } else {
-        const std::size_t num_sv = sv_or_w_d.shape().x;
-
-        const ::sycl::range<2> grid{ static_cast<std::size_t>(std::ceil(static_cast<double>(num_sv) / static_cast<double>(block[0] * INTERNAL_BLOCK_SIZE))) * block[0],
-                                     static_cast<std::size_t>(std::ceil(static_cast<double>(num_predict_points) / static_cast<double>(block[1] * INTERNAL_BLOCK_SIZE))) * block[1] };
-        const ::sycl::nd_range<2> execution_range{ grid, block };
+        const ::sycl::nd_range native_exec{ native_partial_grid, native_block };
 
         switch (params.kernel_type) {
             case kernel_function_type::linear:
-                // already handled
+                device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
+                    cgh.parallel_for(native_exec, sycl::detail::device_kernel_predict_linear{ cgh, out_d.get(), sv_or_w_d.get(), rho_d.get(), predict_points_d.get(), num_classes, num_predict_points, num_features, offsets.x, offsets.y });
+                });
                 break;
             case kernel_function_type::polynomial:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::polynomial, decltype(params.degree), real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, params.degree, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, params.degree, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::rbf:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::rbf, real_type>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::sigmoid:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::sigmoid, real_type, decltype(params.coef0)>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma), params.coef0 });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma), params.coef0 });
                 });
                 break;
             case kernel_function_type::laplacian:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::laplacian, real_type>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
                 });
                 break;
             case kernel_function_type::chi_squared:
                 device.impl->sycl_queue.submit([&](::sycl::handler &cgh) {
                     using functor_type = sycl::detail::device_kernel_predict<kernel_function_type::chi_squared, real_type>;
-                    cgh.parallel_for(execution_range, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, std::get<real_type>(params.gamma) });
+                    cgh.parallel_for(native_exec, functor_type{ cgh, out_d.get(), alpha_d.get(), rho_d.get(), sv_or_w_d.get(), predict_points_d.get(), num_classes, num_sv, num_predict_points, num_features, offsets.x, offsets.y, std::get<real_type>(params.gamma) });
                 });
                 break;
         }

--- a/src/plssvm/backends/execution_range.cpp
+++ b/src/plssvm/backends/execution_range.cpp
@@ -56,7 +56,7 @@ execution_range::execution_range(const dim_type block_p, const unsigned long lon
     if (remaining_x > 0ull) {
         const unsigned long long num_grid_y = grid.y / max_allowed_grid_size.y;
         for (unsigned long long y = 0; y < num_grid_y; ++y) {
-            grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), std::min(grid.y, max_allowed_grid_size.y) }, dim_type{ num_grid_x * max_allowed_grid_size.x, y * max_allowed_grid_size.y });
+            grids.emplace_back(dim_type{ remaining_x, std::min(grid.y, max_allowed_grid_size.y) }, dim_type{ num_grid_x * max_allowed_grid_size.x, y * max_allowed_grid_size.y });
         }
         const unsigned long long remaining_y = grid.y % max_allowed_grid_size.y;
         if (remaining_y > 0ull) {

--- a/src/plssvm/backends/execution_range.cpp
+++ b/src/plssvm/backends/execution_range.cpp
@@ -1,0 +1,88 @@
+/**
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ */
+
+#include "plssvm/backends/execution_range.hpp"
+
+#include "plssvm/exceptions/exceptions.hpp"  // plssvm::kernel_launch_resources
+
+#include "fmt/core.h"    // fmt::format
+#include "fmt/format.h"  // fmt::join
+
+#include <algorithm>  // std::min, std::swap
+#include <cmath>      // std::ceil
+#include <ostream>    // std::ostream
+#include <vector>     // std::vector
+
+namespace plssvm::detail {
+
+//*************************************************************************************************************************************//
+//                                                              dim_type                                                               //
+//*************************************************************************************************************************************//
+
+std::ostream &operator<<(std::ostream &out, const dim_type dim) {
+    return out << fmt::format("[{}, {}, {}]", dim.x, dim.y, dim.z);
+}
+
+//*************************************************************************************************************************************//
+//                                                           execution_range                                                           //
+//*************************************************************************************************************************************//
+
+execution_range::execution_range(const dim_type block_p, const unsigned long long max_allowed_block_size, const dim_type grid, const dim_type max_allowed_grid_size) :
+    block{ block_p } {
+    // check whether the provided block size is valid
+    if (max_allowed_block_size < block.x * block.y * block.z) {
+        throw kernel_launch_resources{ fmt::format("Not enough work-items allowed for a work-groups of size {}x{}x{} (#threads: {}; max allowed: {})! Try reducing THREAD_BLOCK_SIZE.", block.x, block.y, block.z, block.x * block.y * block.z, max_allowed_block_size) };
+    }
+
+    // TODO: implement better?! -> z axis?
+    // split the large grid into sub-grids
+    const unsigned long long num_grid_x = grid.x / max_allowed_grid_size.x;
+    for (unsigned long long x = 0; x < num_grid_x; ++x) {
+        const unsigned long long num_grid_y = grid.y / max_allowed_grid_size.y;
+        for (unsigned long long y = 0; y < num_grid_y; ++y) {
+            grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), std::min(grid.y, max_allowed_grid_size.y) }, dim_type{ x * max_allowed_grid_size.x, y * max_allowed_grid_size.y });
+        }
+        const unsigned long long remaining_y = grid.y % max_allowed_grid_size.y;
+        if (remaining_y > 0ull) {
+            grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), remaining_y }, dim_type{ x * max_allowed_grid_size.x, num_grid_y * max_allowed_grid_size.y });
+        }
+    }
+    const unsigned long long remaining_x = grid.x % max_allowed_grid_size.x;
+    if (remaining_x > 0ull) {
+        const unsigned long long num_grid_y = grid.y / max_allowed_grid_size.y;
+        for (unsigned long long y = 0; y < num_grid_y; ++y) {
+            grids.emplace_back(dim_type{ std::min(grid.x, max_allowed_grid_size.x), std::min(grid.y, max_allowed_grid_size.y) }, dim_type{ num_grid_x * max_allowed_grid_size.x, y * max_allowed_grid_size.y });
+        }
+        const unsigned long long remaining_y = grid.y % max_allowed_grid_size.y;
+        if (remaining_y > 0ull) {
+            grids.emplace_back(dim_type{ remaining_x, remaining_y }, dim_type{ num_grid_x * max_allowed_grid_size.x, num_grid_y * max_allowed_grid_size.y });
+        }
+    }
+}
+
+void execution_range::swap(execution_range &other) noexcept {
+    using std::swap;
+    swap(block, other.block);
+    swap(grids, other.grids);
+}
+
+void swap(execution_range &lhs, execution_range &rhs) noexcept {
+    lhs.swap(rhs);
+}
+
+std::ostream &operator<<(std::ostream &out, const execution_range &exec) {
+    if (exec.grids.size() == 1) {
+        return out << fmt::format("grid: {}; block: {}", exec.grids.front().first, exec.block);
+    } else {
+        std::vector<dim_type> transformed_vec(exec.grids.size());
+        std::transform(exec.grids.cbegin(), exec.grids.cend(), transformed_vec.begin(), [](const execution_range::grid_type &grid) { return grid.first; });
+        return out << fmt::format("grids: [{}]; block: {}", fmt::join(transformed_vec, ", "), exec.block);
+    }
+}
+
+}  // namespace plssvm::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -112,6 +112,9 @@ set(PLSSVM_BASE_TEST_NAME Base_tests)
 
 # list all necessary sources
 set(PLSSVM_BASE_TEST_SOURCES
+    ## it is unnecessary to test the execution range for each backend
+    ${CMAKE_CURRENT_LIST_DIR}/backends/execution_range.cpp
+    
     ## since the SYCL implementation_type and kernel_invocation_type enumerations are used even if no SYCL backend
     ## is available these are also tested in the base library
     ${CMAKE_CURRENT_LIST_DIR}/backends/SYCL/implementation_types.cpp

--- a/tests/backends/CUDA/cuda_csvm.cpp
+++ b/tests/backends/CUDA/cuda_csvm.cpp
@@ -109,14 +109,15 @@ TEST_F(CUDACSVM, construct_target_and_named_args) {
                       "Invalid target platform 'gpu_intel' for the CUDA backend!");
 }
 
+template <bool mock_grid_size>
 struct cuda_csvm_test_type {
-    using mock_csvm_type = mock_cuda_csvm;
+    using mock_csvm_type = mock_cuda_csvm<mock_grid_size>;
     using csvm_type = plssvm::cuda::csvm;
     using device_ptr_type = typename csvm_type::device_ptr_type;
     inline constexpr static auto additional_arguments = std::make_tuple();
 };
 
-using cuda_csvm_test_tuple = std::tuple<cuda_csvm_test_type>;
+using cuda_csvm_test_tuple = std::tuple<cuda_csvm_test_type<false>>;
 using cuda_csvm_test_label_type_list = util::cartesian_type_product_t<cuda_csvm_test_tuple, plssvm::detail::supported_label_types>;
 using cuda_csvm_test_type_list = util::cartesian_type_product_t<cuda_csvm_test_tuple>;
 
@@ -143,9 +144,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVMDeathTest, GenericCSVMSolverDeathTest, cu
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVMDeathTest, GenericCSVMKernelFunctionDeathTest, cuda_kernel_function_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVMDeathTest, GenericCSVMSolverKernelFunctionDeathTest, cuda_solver_and_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM tests
+// generic GPU CSVM tests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVM, GenericGPUCSVM, cuda_csvm_test_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVM, GenericGPUCSVMKernelFunction, cuda_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM DeathTests
+// generic GPU CSVM DeathTests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVMDeathTest, GenericGPUCSVMDeathTest, cuda_csvm_test_type_gtest, naming::test_parameter_to_name);
+
+using cuda_mock_csvm_test_tuple = std::tuple<cuda_csvm_test_type<true>>;
+using cuda_mock_csvm_test_type_list = util::cartesian_type_product_t<cuda_mock_csvm_test_tuple>;
+
+using cuda_mock_csvm_test_type_gtest = util::combine_test_parameters_gtest_t<cuda_mock_csvm_test_type_list>;
+using cuda_mock_kernel_function_type_gtest = util::combine_test_parameters_gtest_t<cuda_mock_csvm_test_type_list, util::kernel_function_type_list>;
+
+// generic GPU CSVM tests - mocked grid sizes
+INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVMFakedGridSize, GenericGPUCSVM, cuda_mock_csvm_test_type_gtest, naming::test_parameter_to_name);
+INSTANTIATE_TYPED_TEST_SUITE_P(CUDACSVMFakedGridSize, GenericGPUCSVMKernelFunction, cuda_mock_kernel_function_type_gtest, naming::test_parameter_to_name);

--- a/tests/backends/CUDA/detail/utility.cu
+++ b/tests/backends/CUDA/detail/utility.cu
@@ -11,6 +11,7 @@
 #include "plssvm/backends/CUDA/detail/utility.cuh"
 
 #include "plssvm/backends/CUDA/exceptions.hpp"  // plssvm::cuda::backend_exception
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
 
 #include "tests/custom_test_macros.hpp"  // EXPECT_THROW_WHAT, EXPECT_THROW_WHAT_MATCHER
 
@@ -28,6 +29,19 @@ TEST(CUDAUtility, error_check) {
     EXPECT_THROW_WHAT_MATCHER(PLSSVM_CUDA_ERROR_CHECK(cudaErrorInvalidValue),
                               plssvm::cuda::backend_exception,
                               ::testing::StartsWith("CUDA assert 'cudaErrorInvalidValue' (1):"));
+}
+
+TEST(CUDAUtility, dim_type_to_native) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a CUDA dim3
+    const dim3 native_dim = plssvm::cuda::detail::dim_type_to_native(dim);
+
+    // check values for correctness
+    EXPECT_EQ(native_dim.x, dim.x);
+    EXPECT_EQ(native_dim.y, dim.y);
+    EXPECT_EQ(native_dim.z, dim.z);
 }
 
 TEST(CUDAUtility, get_device_count) {

--- a/tests/backends/CUDA/mock_cuda_csvm.hpp
+++ b/tests/backends/CUDA/mock_cuda_csvm.hpp
@@ -34,6 +34,7 @@ class mock_cuda_csvm final : public plssvm::cuda::csvm {
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
+    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 

--- a/tests/backends/HIP/detail/utility.hip
+++ b/tests/backends/HIP/detail/utility.hip
@@ -8,8 +8,10 @@
  * @brief Tests for the custom utility functions related to the HIP backend.
  */
 
-#include "plssvm/backends/HIP/detail/utility.hip.hpp"  // PLSSVM_HIP_ERROR_CHECK, plssvm::hip::detail::{gpu_assert, get_device_count, set_device, device_synchronize}
-#include "plssvm/backends/HIP/exceptions.hpp"          // plssvm::hip::backend_exception
+#include "plssvm/backends/HIP/detail/utility.hip.hpp"
+
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+#include "plssvm/backends/HIP/exceptions.hpp"   // plssvm::hip::backend_exception
 
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
@@ -30,6 +32,19 @@ TEST(HIPUtility, error_check) {
     EXPECT_THROW_WHAT_MATCHER(PLSSVM_HIP_ERROR_CHECK(hipErrorInvalidValue),
                               plssvm::hip::backend_exception,
                               ::testing::StartsWith("HIP assert 'hipErrorInvalidValue' (1):"));
+}
+
+TEST(HIPUtility, dim_type_to_native) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a HIP dim3
+    const dim3 native_dim = plssvm::hip::detail::dim_type_to_native(dim);
+
+    // check values for correctness
+    EXPECT_EQ(native_dim.x, dim.x);
+    EXPECT_EQ(native_dim.y, dim.y);
+    EXPECT_EQ(native_dim.z, dim.z);
 }
 
 TEST(HIPUtility, get_device_count) {

--- a/tests/backends/HIP/hip_csvm.hip
+++ b/tests/backends/HIP/hip_csvm.hip
@@ -98,14 +98,15 @@ TEST_F(HIPCSVM, construct_target_and_named_args) {
                       "Invalid target platform 'gpu_intel' for the HIP backend!");
 }
 
+template <bool mock_grid_size>
 struct hip_csvm_test_type {
-    using mock_csvm_type = mock_hip_csvm;
+    using mock_csvm_type = mock_hip_csvm<mock_grid_size>;
     using csvm_type = plssvm::hip::csvm;
     using device_ptr_type = typename csvm_type::device_ptr_type;
     inline constexpr static auto additional_arguments = std::make_tuple();
 };
 
-using hip_csvm_test_tuple = std::tuple<hip_csvm_test_type>;
+using hip_csvm_test_tuple = std::tuple<hip_csvm_test_type<false>>;
 using hip_csvm_test_label_type_list = util::cartesian_type_product_t<hip_csvm_test_tuple, plssvm::detail::supported_label_types>;
 using hip_csvm_test_type_list = util::cartesian_type_product_t<hip_csvm_test_tuple>;
 
@@ -132,9 +133,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVMDeathTest, GenericCSVMSolverDeathTest, hip
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVMDeathTest, GenericCSVMKernelFunctionDeathTest, hip_kernel_function_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVMDeathTest, GenericCSVMSolverKernelFunctionDeathTest, hip_solver_and_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM tests
+// generic GPU CSVM tests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVM, GenericGPUCSVM, hip_csvm_test_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVM, GenericGPUCSVMKernelFunction, hip_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM DeathTests
+// generic GPU CSVM DeathTests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVMDeathTest, GenericGPUCSVMDeathTest, hip_csvm_test_type_gtest, naming::test_parameter_to_name);
+
+using hip_mock_csvm_test_tuple = std::tuple<hip_csvm_test_type<true>>;
+using hip_mock_csvm_test_type_list = util::cartesian_type_product_t<hip_mock_csvm_test_tuple>;
+
+using hip_mock_csvm_test_type_gtest = util::combine_test_parameters_gtest_t<hip_mock_csvm_test_type_list>;
+using hip_mock_kernel_function_type_gtest = util::combine_test_parameters_gtest_t<hip_mock_csvm_test_type_list, util::kernel_function_type_list>;
+
+// generic GPU CSVM tests - mocked grid sizes
+INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVMFakedGridSize, GenericGPUCSVM, hip_mock_csvm_test_type_gtest, naming::test_parameter_to_name);
+INSTANTIATE_TYPED_TEST_SUITE_P(HIPCSVMFakedGridSize, GenericGPUCSVMKernelFunction, hip_mock_kernel_function_type_gtest, naming::test_parameter_to_name);

--- a/tests/backends/HIP/mock_hip_csvm.hpp
+++ b/tests/backends/HIP/mock_hip_csvm.hpp
@@ -13,11 +13,19 @@
 #define PLSSVM_TESTS_BACKENDS_CUDA_MOCK_HIP_CSVM_HPP_
 #pragma once
 
-#include "plssvm/backends/HIP/csvm.hpp"  // plssvm::hip::csvm
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+#include "plssvm/backends/HIP/csvm.hpp"         // plssvm::hip::csvm
+
+#include "gmock/gmock.h"  // MOCK_METHOD, ON_CALL, ::testing::Return
+
+#include <cstddef>  // std::size_t
+#include <utility>  // std::forward
 
 /**
- * @brief GTest mock class for the HPI CSVM.
+ * @brief GTest mock class for the HIP CSVM.
+ * @tparam mock_grid_size `true` if the `plssvm::hip::csvm::get_max_grid_size()` function should be mocked, otherwise `false`
  */
+template <bool mock_grid_size>
 class mock_hip_csvm final : public plssvm::hip::csvm {
     using base_type = plssvm::hip::csvm;
 
@@ -26,13 +34,16 @@ class mock_hip_csvm final : public plssvm::hip::csvm {
 
     template <typename... Args>
     explicit mock_hip_csvm(Args &&...args) :
-        base_type{ std::forward<Args>(args)... } { }
+        base_type{ std::forward<Args>(args)... } {
+        this->fake_functions();
+    }
+
+    MOCK_METHOD((plssvm::detail::dim_type), get_max_grid_size, (const std::size_t), (const, override));
 
     // make protected member functions public
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
-    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 
@@ -55,6 +66,20 @@ class mock_hip_csvm final : public plssvm::hip::csvm {
 
     using base_type::data_distribution_;
     using base_type::devices_;
+
+  private:
+    /*
+     * @brief Fake the plssvm::hip::csvm::get_max_grid_size() function if requested.
+     */
+    void fake_functions() const {
+        if constexpr (mock_grid_size) {
+            // mock the function using hardcoded maximum grid sizes
+            ON_CALL(*this, get_max_grid_size).WillByDefault(::testing::Return(plssvm::detail::dim_type{ std::size_t{ 4 }, std::size_t{ 4 }, std::size_t{ 4 } }));
+        } else {
+            // use the actual real implementation otherwise
+            ON_CALL(*this, get_max_grid_size).WillByDefault([this](const std::size_t device_id) { return base_type::get_max_grid_size(device_id); });
+        }
+    }
 };
 
 #endif  // PLSSVM_TESTS_BACKENDS_CUDA_MOCK_HIP_CSVM_HPP_

--- a/tests/backends/HIP/mock_hip_csvm.hpp
+++ b/tests/backends/HIP/mock_hip_csvm.hpp
@@ -32,6 +32,7 @@ class mock_hip_csvm final : public plssvm::hip::csvm {
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
+    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 

--- a/tests/backends/OpenCL/detail/utility.cpp
+++ b/tests/backends/OpenCL/detail/utility.cpp
@@ -8,8 +8,9 @@
  * @brief Tests for the custom utility functions related to the OpenCL backend.
  */
 
-#include "plssvm/backends/OpenCL/detail/utility.hpp"  // PLSSVM_OPENCL_ERROR_CHECK, plssvm::opencl::detail::{device_assert, get_contexts, get_device_name}
+#include "plssvm/backends/OpenCL/detail/utility.hpp"
 
+#include "plssvm/backends/execution_range.hpp"              // plssvm::detail::dim_type
 #include "plssvm/backends/OpenCL/detail/command_queue.hpp"  // plssvm::opencl::detail::command_queue
 #include "plssvm/backends/OpenCL/detail/context.hpp"        // plssvm::opencl::detail::context
 #include "plssvm/backends/OpenCL/exceptions.hpp"            // plssvm::opencl::backend_exception
@@ -20,9 +21,10 @@
 
 #include "gtest/gtest.h"  // TEST, EXPECT_EQ, EXPECT_NE, EXPECT_NO_THROW, EXPECT_FALSE
 
-#include <regex>   // std::regex, std::regex::extended, std::regex_match
-#include <string>  // std::string
-#include <vector>  // std::vector
+#include <cstddef>  // std::size_t
+#include <regex>    // std::regex, std::regex::extended, std::regex_match
+#include <string>   // std::string
+#include <vector>   // std::vector
 
 TEST(OpenCLUtility, error_check) {
     // CL_SUCCESS must not throw
@@ -32,6 +34,45 @@ TEST(OpenCLUtility, error_check) {
     EXPECT_THROW_WHAT(PLSSVM_OPENCL_ERROR_CHECK(CL_DEVICE_NOT_FOUND, "error"),
                       plssvm::opencl::backend_exception,
                       "OpenCL assert 'CL_DEVICE_NOT_FOUND' (-1): error!");
+}
+
+TEST(OpenCLUtility, dim_type_to_native_1) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a OpenCL std::vector<std::size_t>
+    const std::vector<std::size_t> native_dim = plssvm::opencl::detail::dim_type_to_native<1>(dim);
+
+    // check values for correctness
+    ASSERT_EQ(native_dim.size(), 1);
+    EXPECT_EQ(native_dim[0], dim.x);
+}
+
+TEST(OpenCLUtility, dim_type_to_native_2) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a OpenCL std::vector<std::size_t>
+    const std::vector<std::size_t> native_dim = plssvm::opencl::detail::dim_type_to_native<2>(dim);
+
+    // check values for correctness
+    ASSERT_EQ(native_dim.size(), 2);
+    EXPECT_EQ(native_dim[0], dim.x);
+    EXPECT_EQ(native_dim[1], dim.y);
+}
+
+TEST(OpenCLUtility, dim_type_to_native_3) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a OpenCL std::vector<std::size_t>
+    const std::vector<std::size_t> native_dim = plssvm::opencl::detail::dim_type_to_native<3>(dim);
+
+    // check values for correctness
+    ASSERT_EQ(native_dim.size(), 3);
+    EXPECT_EQ(native_dim[0], dim.x);
+    EXPECT_EQ(native_dim[1], dim.y);
+    EXPECT_EQ(native_dim[2], dim.z);
 }
 
 TEST(OpenCLUtility, get_contexts) {

--- a/tests/backends/OpenCL/mock_opencl_csvm.hpp
+++ b/tests/backends/OpenCL/mock_opencl_csvm.hpp
@@ -32,6 +32,7 @@ class mock_opencl_csvm : public plssvm::opencl::csvm {
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
+    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 

--- a/tests/backends/OpenCL/opencl_csvm.cpp
+++ b/tests/backends/OpenCL/opencl_csvm.cpp
@@ -107,14 +107,15 @@ TEST_F(OpenCLCSVM, construct_target_and_named_args) {
 #endif
 }
 
+template <bool mock_grid_size>
 struct opencl_csvm_test_type {
-    using mock_csvm_type = mock_opencl_csvm;
+    using mock_csvm_type = mock_opencl_csvm<mock_grid_size>;
     using csvm_type = plssvm::opencl::csvm;
     using device_ptr_type = typename csvm_type::device_ptr_type;
     inline constexpr static auto additional_arguments = std::make_tuple();
 };
 
-using opencl_csvm_test_tuple = std::tuple<opencl_csvm_test_type>;
+using opencl_csvm_test_tuple = std::tuple<opencl_csvm_test_type<false>>;
 using opencl_csvm_test_label_type_list = util::cartesian_type_product_t<opencl_csvm_test_tuple, plssvm::detail::supported_label_types>;
 using opencl_csvm_test_type_list = util::cartesian_type_product_t<opencl_csvm_test_tuple>;
 
@@ -141,9 +142,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVMDeathTest, GenericCSVMSolverDeathTest, 
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVMDeathTest, GenericCSVMKernelFunctionDeathTest, opencl_kernel_function_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVMDeathTest, GenericCSVMSolverKernelFunctionDeathTest, opencl_solver_and_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM tests
+// generic GPU CSVM tests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVM, GenericGPUCSVM, opencl_csvm_test_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVM, GenericGPUCSVMKernelFunction, opencl_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM DeathTests
+// generic GPU CSVM DeathTests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVMDeathTest, GenericGPUCSVMDeathTest, opencl_csvm_test_type_gtest, naming::test_parameter_to_name);
+
+using opencl_mock_csvm_test_tuple = std::tuple<opencl_csvm_test_type<true>>;
+using opencl_mock_csvm_test_type_list = util::cartesian_type_product_t<opencl_mock_csvm_test_tuple>;
+
+using opencl_mock_csvm_test_type_gtest = util::combine_test_parameters_gtest_t<opencl_mock_csvm_test_type_list>;
+using opencl_mock_kernel_function_type_gtest = util::combine_test_parameters_gtest_t<opencl_mock_csvm_test_type_list, util::kernel_function_type_list>;
+
+// generic GPU CSVM tests - mocked grid sizes
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVMFakedGridSize, GenericGPUCSVM, opencl_mock_csvm_test_type_gtest, naming::test_parameter_to_name);
+INSTANTIATE_TYPED_TEST_SUITE_P(OpenCLCSVMFakedGridSize, GenericGPUCSVMKernelFunction, opencl_mock_kernel_function_type_gtest, naming::test_parameter_to_name);

--- a/tests/backends/SYCL/AdaptiveCpp/adaptivecpp_csvm.cpp
+++ b/tests/backends/SYCL/AdaptiveCpp/adaptivecpp_csvm.cpp
@@ -137,14 +137,15 @@ TEST_F(AdaptiveCppCSVM, get_kernel_invocation_type) {
     EXPECT_NE(svm.get_kernel_invocation_type(), plssvm::sycl::kernel_invocation_type::automatic);
 }
 
+template <bool mock_grid_size>
 struct adaptivecpp_csvm_test_type {
-    using mock_csvm_type = mock_adaptivecpp_csvm;
+    using mock_csvm_type = mock_adaptivecpp_csvm<mock_grid_size>;
     using csvm_type = plssvm::adaptivecpp::csvm;
     using device_ptr_type = typename csvm_type::device_ptr_type;
     inline constexpr static auto additional_arguments = std::make_tuple();
 };
 
-using adaptivecpp_csvm_test_tuple = std::tuple<adaptivecpp_csvm_test_type>;
+using adaptivecpp_csvm_test_tuple = std::tuple<adaptivecpp_csvm_test_type<false>>;
 using adaptivecpp_csvm_test_label_type_list = util::cartesian_type_product_t<adaptivecpp_csvm_test_tuple, plssvm::detail::supported_label_types>;
 using adaptivecpp_csvm_test_type_list = util::cartesian_type_product_t<adaptivecpp_csvm_test_tuple>;
 
@@ -171,9 +172,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVMDeathTest, GenericCSVMSolverDeathT
 INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVMDeathTest, GenericCSVMKernelFunctionDeathTest, adaptivecpp_kernel_function_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVMDeathTest, GenericCSVMSolverKernelFunctionDeathTest, adaptivecpp_solver_and_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM tests
+// generic GPU CSVM tests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVM, GenericGPUCSVM, adaptivecpp_csvm_test_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVM, GenericGPUCSVMKernelFunction, adaptivecpp_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM DeathTests
+// generic GPU CSVM DeathTests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVMDeathTest, GenericGPUCSVMDeathTest, adaptivecpp_csvm_test_type_gtest, naming::test_parameter_to_name);
+
+using adaptivecpp_mock_csvm_test_tuple = std::tuple<adaptivecpp_csvm_test_type<true>>;
+using adaptivecpp_mock_csvm_test_type_list = util::cartesian_type_product_t<adaptivecpp_mock_csvm_test_tuple>;
+
+using adaptivecpp_mock_csvm_test_type_gtest = util::combine_test_parameters_gtest_t<adaptivecpp_mock_csvm_test_type_list>;
+using adaptivecpp_mock_kernel_function_type_gtest = util::combine_test_parameters_gtest_t<adaptivecpp_mock_csvm_test_type_list, util::kernel_function_type_list>;
+
+// generic GPU CSVM tests - mocked grid sizes
+INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVMFakedGridSize, GenericGPUCSVM, adaptivecpp_mock_csvm_test_type_gtest, naming::test_parameter_to_name);
+INSTANTIATE_TYPED_TEST_SUITE_P(AdaptiveCppCSVMFakedGridSize, GenericGPUCSVMKernelFunction, adaptivecpp_mock_kernel_function_type_gtest, naming::test_parameter_to_name);

--- a/tests/backends/SYCL/AdaptiveCpp/detail/utility.cpp
+++ b/tests/backends/SYCL/AdaptiveCpp/detail/utility.cpp
@@ -8,14 +8,57 @@
  * @brief Tests for the custom utility functions related to the SYCL backends with AdaptiveCpp as SYCL implementation.
  */
 
-#include "plssvm/backends/SYCL/AdaptiveCpp/detail/utility.hpp"  // plssvm::adaptivecpp::detail::get_device_list
+#include "plssvm/backends/SYCL/AdaptiveCpp/detail/utility.hpp"
 
-#include "plssvm/target_platforms.hpp"  // plssvm::target_platform
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+#include "plssvm/target_platforms.hpp"          // plssvm::target_platform
+
+#include "sycl/sycl.hpp"  // sycl::range
 
 #include "gtest/gtest.h"  // TEST, EXPECT_NE, EXPECT_FALSE
 
-#include <regex>   // std::regex, std::regex::extended, std::regex_match
-#include <string>  // std::string
+#include <regex>        // std::regex, std::regex::extended, std::regex_match
+#include <string>       // std::string
+#include <type_traits>  // std::remove_const_t
+
+TEST(AdaptiveCppUtility, dim_type_to_native_1) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a SYCL sycl::range
+    const ::sycl::range native_dim = plssvm::adaptivecpp::detail::dim_type_to_native<1>(dim);
+
+    // check values for correctness
+    ::testing::StaticAssertTypeEq<std::remove_const_t<decltype(native_dim)>, ::sycl::range<1>>();
+    EXPECT_EQ(native_dim[0], dim.x);
+}
+
+TEST(AdaptiveCppUtility, dim_type_to_native_2) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a SYCL sycl::range
+    const ::sycl::range native_dim = plssvm::adaptivecpp::detail::dim_type_to_native<2>(dim);
+
+    // check values for correctness -> account for inversed iteration range in SYCL!
+    ::testing::StaticAssertTypeEq<std::remove_const_t<decltype(native_dim)>, ::sycl::range<2>>();
+    EXPECT_EQ(native_dim[0], dim.y);
+    EXPECT_EQ(native_dim[1], dim.x);
+}
+
+TEST(AdaptiveCppUtility, dim_type_to_native_3) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a SYCL sycl::range
+    const ::sycl::range native_dim = plssvm::adaptivecpp::detail::dim_type_to_native<3>(dim);
+
+    // check values for correctness -> account for inversed iteration range in SYCL!
+    ::testing::StaticAssertTypeEq<std::remove_const_t<decltype(native_dim)>, ::sycl::range<3>>();
+    EXPECT_EQ(native_dim[0], dim.z);
+    EXPECT_EQ(native_dim[1], dim.y);
+    EXPECT_EQ(native_dim[2], dim.x);
+}
 
 TEST(AdaptiveCppUtility, get_device_list) {
     const auto &[queues, actual_target] = plssvm::adaptivecpp::detail::get_device_list(plssvm::target_platform::automatic);

--- a/tests/backends/SYCL/AdaptiveCpp/mock_adaptivecpp_csvm.hpp
+++ b/tests/backends/SYCL/AdaptiveCpp/mock_adaptivecpp_csvm.hpp
@@ -32,6 +32,7 @@ class mock_adaptivecpp_csvm final : public plssvm::adaptivecpp::csvm {
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
+    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 

--- a/tests/backends/SYCL/AdaptiveCpp/mock_adaptivecpp_csvm.hpp
+++ b/tests/backends/SYCL/AdaptiveCpp/mock_adaptivecpp_csvm.hpp
@@ -13,11 +13,19 @@
 #define PLSSVM_TESTS_BACKENDS_SYCL_ADAPTIVECPP_MOCK_ADAPTIVECPP_CSVM_HPP_
 #pragma once
 
+#include "plssvm/backends/execution_range.hpp"        // plssvm::detail::dim_type
 #include "plssvm/backends/SYCL/AdaptiveCpp/csvm.hpp"  // plssvm::adaptivecpp::csvm
+
+#include "gmock/gmock.h"  // MOCK_METHOD, ON_CALL, ::testing::Return
+
+#include <cstddef>  // std::size_t
+#include <utility>  // std::forward
 
 /**
  * @brief GTest mock class for the SYCL CSVM using AdaptiveCpp as SYCL implementation.
+ * @tparam mock_grid_size `true` if the `plssvm::adaptivecpp::csvm::get_max_grid_size()` function should be mocked, otherwise `false`
  */
+template <bool mock_grid_size>
 class mock_adaptivecpp_csvm final : public plssvm::adaptivecpp::csvm {
     using base_type = plssvm::adaptivecpp::csvm;
 
@@ -26,13 +34,16 @@ class mock_adaptivecpp_csvm final : public plssvm::adaptivecpp::csvm {
 
     template <typename... Args>
     explicit mock_adaptivecpp_csvm(Args &&...args) :
-        base_type{ std::forward<Args>(args)... } { }
+        base_type{ std::forward<Args>(args)... } {
+        this->fake_functions();
+    }
+
+    MOCK_METHOD((plssvm::detail::dim_type), get_max_grid_size, (const std::size_t), (const, override));
 
     // make protected member functions public
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
-    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 
@@ -55,6 +66,20 @@ class mock_adaptivecpp_csvm final : public plssvm::adaptivecpp::csvm {
 
     using base_type::data_distribution_;
     using base_type::devices_;
+
+  private:
+    /*
+     * @brief Fake the plssvm::adaptivecpp::csvm::get_max_grid_size() function if requested.
+     */
+    void fake_functions() const {
+        if constexpr (mock_grid_size) {
+            // mock the function using hardcoded maximum grid sizes
+            ON_CALL(*this, get_max_grid_size).WillByDefault(::testing::Return(plssvm::detail::dim_type{ std::size_t{ 4 }, std::size_t{ 4 }, std::size_t{ 4 } }));
+        } else {
+            // use the actual real implementation otherwise
+            ON_CALL(*this, get_max_grid_size).WillByDefault([this](const std::size_t device_id) { return base_type::get_max_grid_size(device_id); });
+        }
+    }
 };
 
 #endif  // PLSSVM_TESTS_BACKENDS_SYCL_ADAPTIVECPP_MOCK_ADAPTIVECPP_CSVM_HPP_

--- a/tests/backends/SYCL/DPCPP/detail/utility.cpp
+++ b/tests/backends/SYCL/DPCPP/detail/utility.cpp
@@ -8,14 +8,56 @@
  * @brief Tests for the custom utility functions related to the SYCL backends with DPC++ as SYCL implementation.
  */
 
-#include "plssvm/backends/SYCL/DPCPP/detail/utility.hpp"  // plssvm::dpcpp::detail::get_device_list
+#include "plssvm/backends/SYCL/DPCPP/detail/utility.hpp"
 
-#include "plssvm/target_platforms.hpp"  // plssvm::target_platform
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+#include "plssvm/target_platforms.hpp"          // plssvm::target_platform
+
+#include "sycl/sycl.hpp"  // sycl::range
 
 #include "gtest/gtest.h"  // TEST, EXPECT_NE, EXPECT_FALSE
 
 #include <regex>   // std::regex, std::regex::extended, std::regex_match
 #include <string>  // std::string
+
+TEST(DPCPPUtility, dim_type_to_native_1) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a SYCL sycl::range
+    const ::sycl::range native_dim = plssvm::dpcpp::detail::dim_type_to_native<1>(dim);
+
+    // check values for correctness
+    ::testing::StaticAssertTypeEq<std::remove_const_t<decltype(native_dim)>, ::sycl::range<1>>();
+    EXPECT_EQ(native_dim[0], dim.x);
+}
+
+TEST(DPCPPUtility, dim_type_to_native_2) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a SYCL sycl::range
+    const ::sycl::range native_dim = plssvm::dpcpp::detail::dim_type_to_native<2>(dim);
+
+    // check values for correctness -> account for inversed iteration range in SYCL!
+    ::testing::StaticAssertTypeEq<std::remove_const_t<decltype(native_dim)>, ::sycl::range<2>>();
+    EXPECT_EQ(native_dim[0], dim.y);
+    EXPECT_EQ(native_dim[1], dim.x);
+}
+
+TEST(DPCPPUtility, dim_type_to_native_3) {
+    // create a dim_type
+    constexpr plssvm::detail::dim_type dim{ 128ull, 64ull, 32ull };
+
+    // convert it to a SYCL sycl::range
+    const ::sycl::range native_dim = plssvm::dpcpp::detail::dim_type_to_native<3>(dim);
+
+    // check values for correctness -> account for inversed iteration range in SYCL!
+    ::testing::StaticAssertTypeEq<std::remove_const_t<decltype(native_dim)>, ::sycl::range<3>>();
+    EXPECT_EQ(native_dim[0], dim.z);
+    EXPECT_EQ(native_dim[1], dim.y);
+    EXPECT_EQ(native_dim[2], dim.x);
+}
 
 TEST(DPCPPUtility, get_device_list) {
     const auto &[queues, actual_target] = plssvm::dpcpp::detail::get_device_list(plssvm::target_platform::automatic);

--- a/tests/backends/SYCL/DPCPP/dpcpp_csvm.cpp
+++ b/tests/backends/SYCL/DPCPP/dpcpp_csvm.cpp
@@ -137,14 +137,15 @@ TEST_F(DPCPPCSVM, get_kernel_invocation_type) {
     EXPECT_NE(svm.get_kernel_invocation_type(), plssvm::sycl::kernel_invocation_type::automatic);
 }
 
+template <bool mock_grid_size>
 struct dpcpp_csvm_test_type {
-    using mock_csvm_type = mock_dpcpp_csvm;
+    using mock_csvm_type = mock_dpcpp_csvm<mock_grid_size>;
     using csvm_type = plssvm::dpcpp::csvm;
     using device_ptr_type = typename csvm_type::device_ptr_type;
     inline static auto additional_arguments = std::make_tuple();
 };
 
-using dpcpp_csvm_test_tuple = std::tuple<dpcpp_csvm_test_type>;
+using dpcpp_csvm_test_tuple = std::tuple<dpcpp_csvm_test_type<false>>;
 using dpcpp_csvm_test_label_type_list = util::cartesian_type_product_t<dpcpp_csvm_test_tuple, plssvm::detail::supported_label_types>;
 using dpcpp_csvm_test_type_list = util::cartesian_type_product_t<dpcpp_csvm_test_tuple>;
 
@@ -171,9 +172,19 @@ INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVMDeathTest, GenericCSVMSolverDeathTest, d
 INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVMDeathTest, GenericCSVMKernelFunctionDeathTest, dpcpp_kernel_function_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVMDeathTest, GenericCSVMSolverKernelFunctionDeathTest, dpcpp_solver_and_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM tests
+// generic GPU CSVM tests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVM, GenericGPUCSVM, dpcpp_csvm_test_type_gtest, naming::test_parameter_to_name);
 INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVM, GenericGPUCSVMKernelFunction, dpcpp_kernel_function_type_gtest, naming::test_parameter_to_name);
 
-// generic GPU CSVM DeathTests
+// generic GPU CSVM DeathTests - correct grid sizes
 INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVMDeathTest, GenericGPUCSVMDeathTest, dpcpp_csvm_test_type_gtest, naming::test_parameter_to_name);
+
+using dpcpp_mock_csvm_test_tuple = std::tuple<dpcpp_csvm_test_type<true>>;
+using dpcpp_mock_csvm_test_type_list = util::cartesian_type_product_t<dpcpp_mock_csvm_test_tuple>;
+
+using dpcpp_mock_csvm_test_type_gtest = util::combine_test_parameters_gtest_t<dpcpp_mock_csvm_test_type_list>;
+using dpcpp_mock_kernel_function_type_gtest = util::combine_test_parameters_gtest_t<dpcpp_mock_csvm_test_type_list, util::kernel_function_type_list>;
+
+// generic GPU CSVM tests - mocked grid sizes
+INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVMFakedGridSize, GenericGPUCSVM, dpcpp_mock_csvm_test_type_gtest, naming::test_parameter_to_name);
+INSTANTIATE_TYPED_TEST_SUITE_P(DPCPPCSVMFakedGridSize, GenericGPUCSVMKernelFunction, dpcpp_mock_kernel_function_type_gtest, naming::test_parameter_to_name);

--- a/tests/backends/SYCL/DPCPP/mock_dpcpp_csvm.hpp
+++ b/tests/backends/SYCL/DPCPP/mock_dpcpp_csvm.hpp
@@ -32,6 +32,7 @@ class mock_dpcpp_csvm final : public plssvm::dpcpp::csvm {
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
+    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 

--- a/tests/backends/SYCL/DPCPP/mock_dpcpp_csvm.hpp
+++ b/tests/backends/SYCL/DPCPP/mock_dpcpp_csvm.hpp
@@ -14,10 +14,19 @@
 #pragma once
 
 #include "plssvm/backends/SYCL/DPCPP/csvm.hpp"  // plssvm::dpcpp::csvm
+#include "plssvm/backends/execution_range.hpp"  // plssvm::detail::dim_type
+
+#include "gmock/gmock.h"  // MOCK_METHOD, ON_CALL, ::testing::Return
+
+#include <cstddef>  // std::size_t
+#include <utility>  // std::forward
+
 
 /**
  * @brief GTest mock class for the SYCL CSVM using DPC++ as SYCL implementation.
+ * @tparam mock_grid_size `true` if the `plssvm::dpcpp::csvm::get_max_grid_size()` function should be mocked, otherwise `false`
  */
+template <bool mock_grid_size>
 class mock_dpcpp_csvm final : public plssvm::dpcpp::csvm {
     using base_type = plssvm::dpcpp::csvm;
 
@@ -26,13 +35,16 @@ class mock_dpcpp_csvm final : public plssvm::dpcpp::csvm {
 
     template <typename... Args>
     explicit mock_dpcpp_csvm(Args &&...args) :
-        base_type{ std::forward<Args>(args)... } { }
+        base_type{ std::forward<Args>(args)... } {
+        this->fake_functions();
+    }
+
+    MOCK_METHOD((plssvm::detail::dim_type), get_max_grid_size, (const std::size_t), (const, override));
 
     // make protected member functions public
     using base_type::assemble_kernel_matrix;
     using base_type::blas_level_3;
     using base_type::get_device_memory;
-    using base_type::get_max_grid_size;
     using base_type::get_max_work_group_size;
     using base_type::num_available_devices;
 
@@ -55,6 +67,20 @@ class mock_dpcpp_csvm final : public plssvm::dpcpp::csvm {
 
     using base_type::data_distribution_;
     using base_type::devices_;
+
+  private:
+    /*
+     * @brief Fake the plssvm::dpcpp::csvm::get_max_grid_size() function if requested.
+     */
+    void fake_functions() const {
+        if constexpr (mock_grid_size) {
+            // mock the function using hardcoded maximum grid sizes
+            ON_CALL(*this, get_max_grid_size).WillByDefault(::testing::Return(plssvm::detail::dim_type{ std::size_t{ 4 }, std::size_t{ 4 }, std::size_t{ 4 } }));
+        } else {
+            // use the actual real implementation otherwise
+            ON_CALL(*this, get_max_grid_size).WillByDefault([this](const std::size_t device_id) { return base_type::get_max_grid_size(device_id); });
+        }
+    }
 };
 
 #endif  // PLSSVM_TESTS_BACKENDS_SYCL_DPCPP_MOCK_DPCPP_CSVM_HPP_

--- a/tests/backends/execution_range.cpp
+++ b/tests/backends/execution_range.cpp
@@ -156,74 +156,85 @@ TEST(DimType, to_string) {
 
 TEST(ExecutionRange, construct_single_grid) {
     // create execution range
-    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 16ull, 16ull, 2ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } };
 
     // check the block size
-    EXPECT_EQ(exec.block, (plssvm::detail::dim_type{ 16ull, 16ull }));
+    EXPECT_EQ(exec.block, (plssvm::detail::dim_type{ 16ull, 16ull, 2ull }));
 
     // check the grids
     EXPECT_EQ(exec.grids.size(), 1);
-    EXPECT_EQ(exec.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull }));
-    EXPECT_EQ(exec.grids.front().second, (plssvm::detail::dim_type{ 0ull, 0ull }));
+    EXPECT_EQ(exec.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
+    EXPECT_EQ(exec.grids.front().second, (plssvm::detail::dim_type{ 0ull, 0ull, 0ull }));
 }
 
 TEST(ExecutionRange, construct_multiple_grids) {
     // create execution range
-    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 16ull, 16ull, 4ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 127ull, 126ull }, plssvm::detail::dim_type{ 64ull, 64ull, 64ull } };
 
     // check the block size
-    EXPECT_EQ(exec.block, (plssvm::detail::dim_type{ 32ull, 32ull }));
+    EXPECT_EQ(exec.block, (plssvm::detail::dim_type{ 16ull, 16ull, 4ull }));
 
     // check the grids
-    EXPECT_EQ(exec.grids.size(), 4);
-    EXPECT_EQ(exec.grids[0].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
-    EXPECT_EQ(exec.grids[0].second, (plssvm::detail::dim_type{ 0ull, 0ull }));
-    EXPECT_EQ(exec.grids[1].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
-    EXPECT_EQ(exec.grids[1].second, (plssvm::detail::dim_type{ 0ull, 64ull }));
-    EXPECT_EQ(exec.grids[2].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
-    EXPECT_EQ(exec.grids[2].second, (plssvm::detail::dim_type{ 64ull, 0ull }));
-    EXPECT_EQ(exec.grids[3].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
-    EXPECT_EQ(exec.grids[3].second, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec.grids.size(), 8);
+    EXPECT_EQ(exec.grids[0].first, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
+    EXPECT_EQ(exec.grids[0].second, (plssvm::detail::dim_type{ 0ull, 0ull, 0ull }));
+    EXPECT_EQ(exec.grids[1].first, (plssvm::detail::dim_type{ 64ull, 64ull, 62ull }));
+    EXPECT_EQ(exec.grids[1].second, (plssvm::detail::dim_type{ 0ull, 0ull, 64ull }));
+
+    EXPECT_EQ(exec.grids[2].first, (plssvm::detail::dim_type{ 64ull, 63ull, 64ull }));
+    EXPECT_EQ(exec.grids[2].second, (plssvm::detail::dim_type{ 0ull, 64ull, 0ull }));
+    EXPECT_EQ(exec.grids[3].first, (plssvm::detail::dim_type{ 64ull, 63ull, 62ull }));
+    EXPECT_EQ(exec.grids[3].second, (plssvm::detail::dim_type{ 0ull, 64ull, 64ull }));
+
+    EXPECT_EQ(exec.grids[4].first, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
+    EXPECT_EQ(exec.grids[4].second, (plssvm::detail::dim_type{ 64ull, 0ull, 0ull }));
+    EXPECT_EQ(exec.grids[5].first, (plssvm::detail::dim_type{ 64ull, 64ull, 62ull }));
+    EXPECT_EQ(exec.grids[5].second, (plssvm::detail::dim_type{ 64ull, 0ull, 64ull }));
+
+    EXPECT_EQ(exec.grids[6].first, (plssvm::detail::dim_type{ 64ull, 63ull, 64ull }));
+    EXPECT_EQ(exec.grids[6].second, (plssvm::detail::dim_type{ 64ull, 64ull, 0ull }));
+    EXPECT_EQ(exec.grids[7].first, (plssvm::detail::dim_type{ 64ull, 63ull, 62ull }));
+    EXPECT_EQ(exec.grids[7].second, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
 }
 
 TEST(ExecutionRange, construct_invalid_block) {
     // the product of the block dimensions may not exceed to total number of threads allowed in a block
-    EXPECT_THROW_WHAT((plssvm::detail::execution_range{ plssvm::detail::dim_type{ 16ull, 16ull }, 16ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } }),
+    EXPECT_THROW_WHAT((plssvm::detail::execution_range{ plssvm::detail::dim_type{ 16ull, 16ull, 4ull }, 16ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } }),
                       plssvm::kernel_launch_resources,
-                      "Not enough work-items allowed for a work-groups of size 16x16x1 (#threads: 256; max allowed: 16)! Try reducing THREAD_BLOCK_SIZE.");
+                      "Not enough work-items allowed for a work-groups of size 16x16x4 (#threads: 1024; max allowed: 16)! Try reducing THREAD_BLOCK_SIZE.");
 }
 
 TEST(ExecutionRange, swap_member_function) {
-    plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
-    plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull, 4ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } };
+    plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 4ull, 4ull, 4ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull, 64ull } };
 
     // swap the contents
     exec1.swap(exec2);
 
     // check the contents
-    EXPECT_EQ(exec1.block, (plssvm::detail::dim_type{ 32ull, 32ull }));
-    EXPECT_EQ(exec1.grids.size(), 4);
+    EXPECT_EQ(exec1.block, (plssvm::detail::dim_type{ 4ull, 4ull, 4ull }));
+    EXPECT_EQ(exec1.grids.size(), 8);
 
-    EXPECT_EQ(exec2.block, (plssvm::detail::dim_type{ 16ull, 16ull }));
+    EXPECT_EQ(exec2.block, (plssvm::detail::dim_type{ 16ull, 16ull, 4ull }));
     EXPECT_EQ(exec2.grids.size(), 1);
-    EXPECT_EQ(exec2.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec2.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
 }
 
 TEST(ExecutionRange, swap_free_function) {
-    plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
-    plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull, 4ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } };
+    plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 4ull, 4ull, 4ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull, 64ull } };
 
     // swap the contents
     using plssvm::detail::swap;
     swap(exec1, exec2);
 
     // check the contents
-    EXPECT_EQ(exec1.block, (plssvm::detail::dim_type{ 32ull, 32ull }));
-    EXPECT_EQ(exec1.grids.size(), 4);
+    EXPECT_EQ(exec1.block, (plssvm::detail::dim_type{ 4ull, 4ull, 4ull }));
+    EXPECT_EQ(exec1.grids.size(), 8);
 
-    EXPECT_EQ(exec2.block, (plssvm::detail::dim_type{ 16ull, 16ull }));
+    EXPECT_EQ(exec2.block, (plssvm::detail::dim_type{ 16ull, 16ull, 4ull }));
     EXPECT_EQ(exec2.grids.size(), 1);
-    EXPECT_EQ(exec2.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec2.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
 }
 
 TEST(ExecutionRange, equality) {

--- a/tests/backends/execution_range.cpp
+++ b/tests/backends/execution_range.cpp
@@ -197,7 +197,21 @@ TEST(ExecutionRange, construct_multiple_grids) {
     EXPECT_EQ(exec.grids[7].second, (plssvm::detail::dim_type{ 64ull, 64ull, 64ull }));
 }
 
-TEST(ExecutionRange, construct_invalid_block) {
+TEST(ExecutionRange, construct_block_zero_threads) {
+    // at least one thread must be present!
+    EXPECT_THROW_WHAT((plssvm::detail::execution_range{ plssvm::detail::dim_type{ 0ull, 0ull, 0ull }, 16ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } }),
+                      plssvm::kernel_launch_resources,
+                      "At least one thread must be given per block! Maybe one dimension is zero?");
+}
+
+TEST(ExecutionRange, construct_block_zero_threads_in_single_dimension) {
+    // EACH dimension must at least consist of a single thread!
+    EXPECT_THROW_WHAT((plssvm::detail::execution_range{ plssvm::detail::dim_type{ 4ull, 4ull, 0ull }, 16ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } }),
+                      plssvm::kernel_launch_resources,
+                      "At least one thread must be given per block! Maybe one dimension is zero?");
+}
+
+TEST(ExecutionRange, construct_block_too_many_threads) {
     // the product of the block dimensions may not exceed to total number of threads allowed in a block
     EXPECT_THROW_WHAT((plssvm::detail::execution_range{ plssvm::detail::dim_type{ 16ull, 16ull, 4ull }, 16ull, plssvm::detail::dim_type{ 64ull, 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull, 1024ull } }),
                       plssvm::kernel_launch_resources,

--- a/tests/backends/execution_range.cpp
+++ b/tests/backends/execution_range.cpp
@@ -1,0 +1,279 @@
+/**
+ * @author Alexander Van Craen
+ * @author Marcel Breyer
+ * @copyright 2018-today The PLSSVM project - All Rights Reserved
+ * @license This file is part of the PLSSVM project which is released under the MIT license.
+ *          See the LICENSE.md file in the project root for full license information.
+ *
+ * @brief Tests for the execution range related functions and classes.
+ */
+
+#include "plssvm/backends/execution_range.hpp"
+
+#include "plssvm/exceptions/exceptions.hpp"  // plssvm::kernel_launch_resources
+
+#include "tests/custom_test_macros.hpp"  // EXPECT_THROW_WHAT
+
+#include "fmt/core.h"     // fmt::format
+#include "gtest/gtest.h"  // TEST, EXPECT_EQ, EXPECT_TRUE, EXPECT_FALSE
+
+#include <string>  // std::string
+
+//*************************************************************************************************************************************//
+//                                                              dim_type                                                               //
+//*************************************************************************************************************************************//
+
+TEST(DimType, default_construct) {
+    // a default constructed dim_type should be all ones
+    constexpr plssvm::detail::dim_type dim{};
+
+    EXPECT_EQ(dim.x, 1ull);
+    EXPECT_EQ(dim.y, 1ull);
+    EXPECT_EQ(dim.z, 1ull);
+}
+
+TEST(DimType, one_argument) {
+    // a default constructed dim_type should be all ones
+    constexpr plssvm::detail::dim_type dim{ 64ull };
+
+    EXPECT_EQ(dim.x, 64ull);
+    EXPECT_EQ(dim.y, 1ull);
+    EXPECT_EQ(dim.z, 1ull);
+}
+
+TEST(DimType, two_arguments) {
+    // a default constructed dim_type should be all ones
+    constexpr plssvm::detail::dim_type dim{ 64ull, 32ull };
+
+    EXPECT_EQ(dim.x, 64ull);
+    EXPECT_EQ(dim.y, 32ull);
+    EXPECT_EQ(dim.z, 1ull);
+}
+
+TEST(DimType, three_arguments) {
+    // a default constructed dim_type should be all ones
+    constexpr plssvm::detail::dim_type dim{ 64ull, 32ull, 16ull };
+
+    EXPECT_EQ(dim.x, 64ull);
+    EXPECT_EQ(dim.y, 32ull);
+    EXPECT_EQ(dim.z, 16ull);
+}
+
+TEST(DimType, swap_member_function) {
+    plssvm::detail::dim_type dim1{ 64ull };
+    plssvm::detail::dim_type dim2{ 32ull, 16ull };
+
+    // swap the contents
+    dim1.swap(dim2);
+
+    // check the contents
+    EXPECT_EQ(dim1.x, 32ull);
+    EXPECT_EQ(dim1.y, 16ull);
+    EXPECT_EQ(dim1.z, 1ull);
+
+    EXPECT_EQ(dim2.x, 64ull);
+    EXPECT_EQ(dim2.y, 1ull);
+    EXPECT_EQ(dim2.z, 1ull);
+}
+
+TEST(DimType, swap_free_function) {
+    plssvm::detail::dim_type dim1{ 64ull };
+    plssvm::detail::dim_type dim2{ 32ull, 16ull };
+
+    // swap the contents
+    using plssvm::detail::swap;
+    swap(dim1, dim2);
+
+    // check the contents
+    EXPECT_EQ(dim1.x, 32ull);
+    EXPECT_EQ(dim1.y, 16ull);
+    EXPECT_EQ(dim1.z, 1ull);
+
+    EXPECT_EQ(dim2.x, 64ull);
+    EXPECT_EQ(dim2.y, 1ull);
+    EXPECT_EQ(dim2.z, 1ull);
+}
+
+TEST(DimType, equality) {
+    // create dim types
+    constexpr plssvm::detail::dim_type dim1{};
+    constexpr plssvm::detail::dim_type dim2{ 64ull };
+    constexpr plssvm::detail::dim_type dim3{ 64ull, 32ull };
+    constexpr plssvm::detail::dim_type dim4{ 64ull, 32ull, 16ull };
+    constexpr plssvm::detail::dim_type dim5{ 32ull };
+    constexpr plssvm::detail::dim_type dim6{ 32ull, 16ull };
+    constexpr plssvm::detail::dim_type dim7{ 32ull, 16ull, 8ull };
+
+    // check for equality
+    EXPECT_TRUE(dim1 == dim1);
+    EXPECT_TRUE(dim2 == dim2);
+    EXPECT_TRUE(dim3 == dim3);
+    EXPECT_TRUE(dim4 == dim4);
+    EXPECT_FALSE(dim2 == dim3);
+    EXPECT_FALSE(dim2 == dim4);
+    EXPECT_FALSE(dim3 == dim4);
+    EXPECT_FALSE(dim2 == dim5);
+    EXPECT_FALSE(dim3 == dim6);
+    EXPECT_FALSE(dim4 == dim7);
+}
+
+TEST(DimType, inequality) {
+    // create dim types
+    constexpr plssvm::detail::dim_type dim1{};
+    constexpr plssvm::detail::dim_type dim2{ 64ull };
+    constexpr plssvm::detail::dim_type dim3{ 64ull, 32ull };
+    constexpr plssvm::detail::dim_type dim4{ 64ull, 32ull, 16ull };
+    constexpr plssvm::detail::dim_type dim5{ 32ull };
+    constexpr plssvm::detail::dim_type dim6{ 32ull, 16ull };
+    constexpr plssvm::detail::dim_type dim7{ 32ull, 16ull, 8ull };
+
+    // check for inequality
+    EXPECT_FALSE(dim1 != dim1);
+    EXPECT_FALSE(dim2 != dim2);
+    EXPECT_FALSE(dim3 != dim3);
+    EXPECT_FALSE(dim4 != dim4);
+    EXPECT_TRUE(dim2 != dim3);
+    EXPECT_TRUE(dim2 != dim4);
+    EXPECT_TRUE(dim3 != dim4);
+    EXPECT_TRUE(dim2 != dim5);
+    EXPECT_TRUE(dim3 != dim6);
+    EXPECT_TRUE(dim4 != dim7);
+}
+
+TEST(DimType, to_string) {
+    constexpr plssvm::detail::dim_type dim{ 64ull, 32ull, 16ull };
+
+    // convert it to a string
+    const std::string str = fmt::format("{}", dim);
+
+    // check the string for correctness
+    EXPECT_EQ(str, std::string{ "[64, 32, 16]" });
+}
+
+//*************************************************************************************************************************************//
+//                                                           execution_range                                                           //
+//*************************************************************************************************************************************//
+
+TEST(ExecutionRange, construct_single_grid) {
+    // create execution range
+    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+
+    // check the block size
+    EXPECT_EQ(exec.block, (plssvm::detail::dim_type{ 16ull, 16ull }));
+
+    // check the grids
+    EXPECT_EQ(exec.grids.size(), 1);
+    EXPECT_EQ(exec.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec.grids.front().second, (plssvm::detail::dim_type{ 0ull, 0ull }));
+}
+
+TEST(ExecutionRange, construct_multiple_grids) {
+    // create execution range
+    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+
+    // check the block size
+    EXPECT_EQ(exec.block, (plssvm::detail::dim_type{ 32ull, 32ull }));
+
+    // check the grids
+    EXPECT_EQ(exec.grids.size(), 4);
+    EXPECT_EQ(exec.grids[0].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec.grids[0].second, (plssvm::detail::dim_type{ 0ull, 0ull }));
+    EXPECT_EQ(exec.grids[1].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec.grids[1].second, (plssvm::detail::dim_type{ 0ull, 64ull }));
+    EXPECT_EQ(exec.grids[2].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec.grids[2].second, (plssvm::detail::dim_type{ 64ull, 0ull }));
+    EXPECT_EQ(exec.grids[3].first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+    EXPECT_EQ(exec.grids[3].second, (plssvm::detail::dim_type{ 64ull, 64ull }));
+}
+
+TEST(ExecutionRange, construct_invalid_block) {
+    // the product of the block dimensions may not exceed to total number of threads allowed in a block
+    EXPECT_THROW_WHAT((plssvm::detail::execution_range{ plssvm::detail::dim_type{ 16ull, 16ull }, 16ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } }),
+                      plssvm::kernel_launch_resources,
+                      "Not enough work-items allowed for a work-groups of size 16x16x1 (#threads: 256; max allowed: 16)! Try reducing THREAD_BLOCK_SIZE.");
+}
+
+TEST(ExecutionRange, swap_member_function) {
+    plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+    plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+
+    // swap the contents
+    exec1.swap(exec2);
+
+    // check the contents
+    EXPECT_EQ(exec1.block, (plssvm::detail::dim_type{ 32ull, 32ull }));
+    EXPECT_EQ(exec1.grids.size(), 4);
+
+    EXPECT_EQ(exec2.block, (plssvm::detail::dim_type{ 16ull, 16ull }));
+    EXPECT_EQ(exec2.grids.size(), 1);
+    EXPECT_EQ(exec2.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+}
+
+TEST(ExecutionRange, swap_free_function) {
+    plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+    plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+
+    // swap the contents
+    using plssvm::detail::swap;
+    swap(exec1, exec2);
+
+    // check the contents
+    EXPECT_EQ(exec1.block, (plssvm::detail::dim_type{ 32ull, 32ull }));
+    EXPECT_EQ(exec1.grids.size(), 4);
+
+    EXPECT_EQ(exec2.block, (plssvm::detail::dim_type{ 16ull, 16ull }));
+    EXPECT_EQ(exec2.grids.size(), 1);
+    EXPECT_EQ(exec2.grids.front().first, (plssvm::detail::dim_type{ 64ull, 64ull }));
+}
+
+TEST(ExecutionRange, equality) {
+    // create execution ranges
+    const plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+    const plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    const plssvm::detail::execution_range exec3{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    const plssvm::detail::execution_range exec4{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+
+    // check for equality
+    EXPECT_TRUE(exec1 == exec1);
+    EXPECT_TRUE(exec1 == exec2);
+    EXPECT_FALSE(exec1 == exec3);
+    EXPECT_FALSE(exec1 == exec4);
+    EXPECT_FALSE(exec3 == exec4);
+    EXPECT_TRUE(exec4 == exec4);
+}
+
+TEST(ExecutionRange, inequality) {
+    // create execution ranges
+    const plssvm::detail::execution_range exec1{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+    const plssvm::detail::execution_range exec2{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    const plssvm::detail::execution_range exec3{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+    const plssvm::detail::execution_range exec4{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+
+    // check for inequality
+    EXPECT_FALSE(exec1 != exec1);
+    EXPECT_FALSE(exec1 != exec2);
+    EXPECT_TRUE(exec1 != exec3);
+    EXPECT_TRUE(exec1 != exec4);
+    EXPECT_TRUE(exec3 != exec4);
+    EXPECT_FALSE(exec4 != exec4);
+}
+
+TEST(ExecutionRange, to_string_single_grid) {
+    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 16ull, 16ull }, 1024ull, plssvm::detail::dim_type{ 64ull, 64ull }, plssvm::detail::dim_type{ 1024ull, 1024ull } };
+
+    // convert it to a string
+    const std::string str = fmt::format("{}", exec);
+
+    // check the string for correctness
+    EXPECT_EQ(str, std::string{ "grid: [64, 64, 1]; block: [16, 16, 1]" });
+}
+
+TEST(ExecutionRange, to_string_multiple_grids) {
+    const plssvm::detail::execution_range exec{ plssvm::detail::dim_type{ 32ull, 32ull }, 1024ull, plssvm::detail::dim_type{ 128ull, 128ull }, plssvm::detail::dim_type{ 64ull, 64ull } };
+
+    // convert it to a string
+    const std::string str = fmt::format("{}", exec);
+
+    // check the string for correctness
+    EXPECT_EQ(str, std::string{ "grids: [[64, 64, 1], [64, 64, 1], [64, 64, 1], [64, 64, 1]]; block: [32, 32, 1]" });
+}


### PR DESCRIPTION
NVIDIA GPUs (as well as AMD GPUs) support 3-dimensional execution grids. 
While 2^31 - 1 thread blocks may be spawned in the first dimension, in the second and third dimensions only 65535 can be used. 
Previously this limited the potential data set size that could be used with PLSSVM. This commit removes this restriction by dividing the full execution grid into as many subgrids as needed to satisfy the hardware/runtime imposed constraints.